### PR TITLE
Open manuf file read-only

### DIFF
--- a/manuf.py
+++ b/manuf.py
@@ -67,7 +67,7 @@ class MacParser(object):
         """
         if not manuf_name:
             manuf_name = self._manuf_name
-        with open(manuf_name, 'r+') as f:
+        with open(manuf_name, 'r') as f:
             manuf_file = StringIO(f.read())
         self._masks = {}
 


### PR DESCRIPTION
The code never writes to the manuf file, so there's no reason to open it for writing. Without this change, the code fails if the user only has read permission and not write permission.
