### PR TITLE
Forced UTF-8 encoding on reading

### DIFF
--- a/manuf/manuf.py
+++ b/manuf/manuf.py
@@ -141,7 +141,7 @@ class MacParser(object):
 
         # Parse the response
         if response.code is 200:
-            with open(manuf_name, "wb", encoding="utf-8") as write_file:
+            with open(manuf_name, "wb") as write_file:
                 write_file.write(response.read())
             if refresh:
                 self.refresh(manuf_name)

--- a/manuf/manuf.py
+++ b/manuf/manuf.py
@@ -22,6 +22,7 @@ from collections import namedtuple
 import argparse
 import re
 import sys
+import io
 
 try:
     from urllib2 import urlopen
@@ -81,7 +82,7 @@ class MacParser(object):
         """
         if not manuf_name:
             manuf_name = self._manuf_name
-        with open(manuf_name, "r", encoding="utf-8") as read_file:
+        with io.open(manuf_name, "r", encoding="utf-8") as read_file:
             manuf_file = StringIO(read_file.read())
         self._masks = {}
 

--- a/manuf/manuf.py
+++ b/manuf/manuf.py
@@ -81,7 +81,7 @@ class MacParser(object):
         """
         if not manuf_name:
             manuf_name = self._manuf_name
-        with open(manuf_name, "r") as read_file:
+        with open(manuf_name, "r", encoding="utf-8") as read_file:
             manuf_file = StringIO(read_file.read())
         self._masks = {}
 
@@ -141,7 +141,7 @@ class MacParser(object):
 
         # Parse the response
         if response.code is 200:
-            with open(manuf_name, "wb") as write_file:
+            with open(manuf_name, "wb", encoding="utf-8") as write_file:
                 write_file.write(response.read())
             if refresh:
                 self.refresh(manuf_name)

--- a/manuf/manuf.py
+++ b/manuf/manuf.py
@@ -32,12 +32,9 @@ except ImportError:
     from urllib.error import URLError
 
 try:
-    from cStringIO import StringIO
+    from StringIO import StringIO
 except ImportError:
-    try:
-        from StringIO import StringIO
-    except ImportError:
-        from io import StringIO
+    from io import StringIO
 
 # Vendor tuple
 Vendor = namedtuple('Vendor', ['manuf', 'comment'])


### PR DESCRIPTION
Encoding was determined automatically basing on system encoding. This was causing a error on Windows since its native encoding is CP-1251 but manuf file (official) encoding is UTF-8.