### PR TITLE
Feature/improve cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,19 +31,30 @@ As a library:
     >>> p.get_comment('BC:EE:7B:00:00:00')
     'ASUSTek COMPUTER INC.'
 
-On the command line. Make sure manuf is in the same directory:
+On the command line:
 
-    $ python manuf.py BC:EE:7B:00:00:00
+    $ python -m manuf BC:EE:7B:00:00:00
+    Vendor(manuf='AsustekC', comment='ASUSTek COMPUTER INC.')
+   
+Alternatively, if the library has been installed i.e. using pip 
+
+    $ manuf BC:EE:7B:00:00:00
     Vendor(manuf='AsustekC', comment='ASUSTek COMPUTER INC.')
     
 Use a manuf file in a custom location:
 
-    $ python manuf.py --manuf ~/manuf BC:EE:7B:00:00:00
+    $ manuf --manuf ~/manuf BC:EE:7B:00:00:00
     Vendor(manuf='AsustekC', comment='ASUSTek COMPUTER INC.')
 
 Automatically update the manuf file from Wireshark's git:
 
-    $ python manuf.py --update --manuf ~/manuf BC:EE:7B:00:00:00
+    $ manuf --update BC:EE:7B:00:00:00
+    Vendor(manuf='AsustekC', comment='ASUSTek COMPUTER INC.')
+
+Note, that this command will update the manuf file bundled with this package. If you do not wish to 
+modify this, or do not have permissions to do so, you must specify a custom manuf file to perform an update.
+
+    $ manuf --update --manuf ~/manuf BC:EE:7B:00:00:00
     Vendor(manuf='AsustekC', comment='ASUSTek COMPUTER INC.')
 
 Advantages

--- a/manuf/__init__.py
+++ b/manuf/__init__.py
@@ -1,1 +1,2 @@
 from . import manuf
+from .manuf import MacParser

--- a/manuf/__init__.py
+++ b/manuf/__init__.py
@@ -1,0 +1,1 @@
+from . import manuf

--- a/manuf/__main__.py
+++ b/manuf/__main__.py
@@ -1,0 +1,2 @@
+from .manuf import main
+main()

--- a/manuf/manuf.py
+++ b/manuf/manuf.py
@@ -287,7 +287,7 @@ class MacParser(object):
     def _bits_left(mac_str):
         return 48 - 4 * len(mac_str)
 
-def main():
+def main(*input_args):
     """Simple command line wrapping for MacParser."""
     argparser = argparse.ArgumentParser(description="Parser utility for Wireshark's OUI database.")
     argparser.add_argument('-m', "--manuf",
@@ -298,7 +298,8 @@ def main():
                            action="store_true")
     argparser.add_argument("mac_address", nargs='?', help="MAC address to check")
 
-    args = argparser.parse_args()
+    input_args = input_args or None  # if main is called with explicit args parse these - else use sysargs
+    args = argparser.parse_args(args=input_args)
     if args.manuf:
         parser = MacParser(manuf_name=args.manuf, update=args.update)
     else:

--- a/manuf/test/test_manuf.py
+++ b/manuf/test/test_manuf.py
@@ -6,12 +6,12 @@ class ManufTestCase(unittest.TestCase):
     MANUF_URL = "https://code.wireshark.org/review/gitweb?p=wireshark.git;a=blob_plain;f=manuf"
 
     def setUp(self):
-        self.manuf = manuf.MacParser(manuf_name="test/manuf")
+        self.manuf = manuf.MacParser(manuf_name="manuf")
     #
     def test_update_update(self):
-        self.manuf.update(manuf_url=self.MANUF_URL, manuf_name="test/manuf_update")
-        assert os.path.exists("test/manuf_update")
-        os.remove("test/manuf_update")
+        self.manuf.update(manuf_url=self.MANUF_URL, manuf_name="manuf_update")
+        assert os.path.exists("manuf_update")
+        os.remove("manuf_update")
 
     def test_getAll_whenMacValid_getVendor(self):
         v = self.manuf.get_all("00:00:00:00:00:00")

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,13 @@ setup(
     url = 'https://github.com/coolbho3k/manuf/',
     license = 'Apache License 2.0 or GPLv3',
     keywords = ['manuf', 'mac address', 'networking'],
+    entry_points = {
+        'console_scripts': [
+            'manuf=manuf.manuf:main'
+        ],
+    },
+    package_data = {
+        'manuf': ['manuf']
+    },
 )
 


### PR DESCRIPTION
Dear maintainer, please accept this PR that adds common cli functionality:

- Bundle `manuf` file with the library and use as default regardless of working directory.
- add console entrypoint to allow `manuf BC:EE:7B:00:00:00`
- allow usage as module with `python -m manuf` syntax

I have tried to update documentation where necessary.

Beware that this PR changes manuf file defaults which may cause small issues for existing users. I am thinking that default manuf file logic could be changed to first look for an existing manuf file in cwd, and then falling back to bundled file if none exists.