### PR TITLE
Call the script as a program

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
-  - "3.5-dev"
+  - "3.6"
   - "nightly"
   - "pypy"
 script: python -m unittest test.test_manuf

--- a/manuf/manuf
+++ b/manuf/manuf
@@ -10,19 +10,7 @@
 # By Gerald Combs <gerald [AT] wireshark.org>
 # Copyright 1998 Gerald Combs
 #
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # The data below has been assembled from the following sources:
 #
@@ -243,13 +231,13 @@
 00:00:BA	Siig	Siig, Inc.
 00:00:BB	Tri-Data	TRI-DATA Systems Inc.	# Netway products, 3274 emulators
 00:00:BC	Rockwell	Rockwell Automation
-00:00:BD	Mitsubis	Mitsubishi Cable Company
+00:00:BD	Mitsubis	Mitsubishi Cable Industries, Ltd. / Ryosei Systems
 00:00:BE	NtiGroup	The Nti Group
 00:00:BF	Symmetri	Symmetric Computer Systems
 00:00:C0	WesternD	Western Digital now SMC (Std. Microsystems Corp.)
 00:00:C1	Madge	Madge Ltd.
 00:00:C2	Informat	Information Presentation Tech.
-00:00:C3	HarrisCo	Harris Corp Computer Sys Div
+00:00:C3	Harris	Harris Corporation
 00:00:C4	WatersDi	Waters Div. Of Millipore
 00:00:C5	ArrisGro	ARRIS Group, Inc.
 00:00:C6	HpIntell	HP Intelligent Networks Operation (formerly Eon Systems)
@@ -312,8 +300,8 @@
 00:00:FF	CamtecEl	Camtec Electronics (UK) Ltd.
 00:01:00	EquipTra	EQUIP'TRANS
 00:01:01	Private
-00:01:02	3com	3COM CORPORATION
-00:01:03	3com	3COM CORPORATION
+00:01:02	3com
+00:01:03	3com
 00:01:04	Dvico	DVICO Co., Ltd.
 00:01:05	Beckhoff	Beckhoff Automation GmbH
 00:01:06	TewsDate	Tews Datentechnik GmbH
@@ -343,7 +331,7 @@
 00:01:1E	Precidia	Precidia Technologies, Inc.
 00:01:1F	RcNetwor	RC Networks, Inc.
 00:01:20	Oscilloq	Oscilloquartz S.A.
-00:01:21	Watchgua	Watchguard Technologies, Inc.
+00:01:21	Watchgua	WatchGuard Technologies, Inc.
 00:01:22	TrendCom	Trend Communications, Ltd.
 00:01:23	Schneide	Schneider Electric Japan Holdings Ltd.
 00:01:24	Acer	Acer Incorporated
@@ -383,7 +371,7 @@
 00:01:46	TescoCon	Tesco Controls, Inc.
 00:01:47	ZhoneTec	Zhone Technologies
 00:01:48	X-Traweb	X-traWeb Inc.
-00:01:49	TDTTrans	T.D.T. Transfer Data Test GmbH
+00:01:49	Tdt	Tdt Ag
 00:01:4A	Sony	Sony Corporation
 00:01:4B	Ennovate	Ennovate Networks, Inc.
 00:01:4C	Berkeley	Berkeley Process Control
@@ -495,7 +483,7 @@
 00:01:B6	SaejinT&	SAEJIN T&M Co., Ltd.
 00:01:B7	Centos	Centos, Inc.
 00:01:B8	Netsensi	Netsensity, Inc.
-00:01:B9	SkfCondi	SKF Condition Monitoring
+00:01:B9	SkfUK	SKF (U.K.) Limited
 00:01:BA	Ic-Net	IC-Net, Inc.
 00:01:BB	Frequent	Frequentis
 00:01:BC	Brains	Brains Corporation
@@ -629,7 +617,7 @@
 00:02:3C	Creative	Creative Technology, Ltd.
 00:02:3D	Cisco	Cisco Systems, Inc
 00:02:3E	SeltaTel	Selta Telematica S.p.a
-00:02:3F	CompalEl	Compal Electronics, Inc.
+00:02:3F	CompalEl	Compal Electronics INC.
 00:02:40	Seedek	Seedek Co., Ltd.
 00:02:41	AmerCom	Amer.com
 00:02:42	Videofra	Videoframe Systems
@@ -698,7 +686,7 @@
 00:02:81	Madge	Madge Ltd.
 00:02:82	Viaclix	ViaClix, Inc.
 00:02:83	Spectrum	Spectrum Controls, Inc.
-00:02:84	ArevaT&D	AREVA T&D
+00:02:84	UkGridSo	UK Grid Solutions Limited
 00:02:85	Riversto	Riverstone Networks
 00:02:86	OccamNet	Occam Networks
 00:02:87	Adapcom
@@ -973,7 +961,7 @@
 00:03:94	ConnectO	Connect One
 00:03:95	Californ	California Amplifier
 00:03:96	EzCast	EZ Cast Co., Ltd.
-00:03:97	Watchfro	Watchfront Limited
+00:03:97	Firebric	FireBrick Limited
 00:03:98	Wisi
 00:03:99	DongjuIn	Dongju Informations & Communications Co., Ltd.
 00:03:9A	Siconnec	SiConnect
@@ -1089,7 +1077,7 @@
 00:04:08	SankoEle	Sanko Electronics Co., Ltd.
 00:04:09	CratosNe	Cratos Networks
 00:04:0A	Sage	Sage Systems
-00:04:0B	3comEuro	3COM EUROPE LTD.
+00:04:0B	3comEuro	3COM EUROPE LTD
 00:04:0C	KannoWor	Kanno Works, Ltd.
 00:04:0D	Avaya	Avaya Inc
 00:04:0E	Avm	AVM GmbH
@@ -1097,7 +1085,7 @@
 00:04:10	Spinnake	Spinnaker Networks, Inc.
 00:04:11	InkraNet	Inkra Networks, Inc.
 00:04:12	Wavesmit	WaveSmith Networks, Inc.
-00:04:13	SnomTech	SNOM Technology AG
+00:04:13	SnomTech	snom technology GmbH
 00:04:14	UmezawaM	Umezawa Musen Denki Co., Ltd.
 00:04:15	Rasteme	Rasteme Systems Co., Ltd.
 00:04:16	ParksCom	Parks S/A Comunicacoes Digitais
@@ -1195,8 +1183,8 @@
 00:04:72	Telelynx	Telelynx, Inc.
 00:04:73	Photonex	Photonex Corporation
 00:04:74	Legrand
-00:04:75	3Com	3 Com Corporation
-00:04:76	3Com	3 Com Corporation
+00:04:75	3com
+00:04:76	3com
 00:04:77	Scalant	Scalant Systems, Inc.
 00:04:78	GStarTec	G. Star Technology Corporation
 00:04:79	Radius	Radius Co., Ltd.
@@ -1330,7 +1318,7 @@
 00:04:F9	XteraCom	Xtera Communications, Inc.
 00:04:FA	NbsTechn	NBS Technologies Inc.
 00:04:FB	Commtech	Commtech, Inc.
-00:04:FC	StratusC	Stratus Computer (DE), Inc.
+00:04:FC	StratusT	Stratus Technologies
 00:04:FD	JapanCon	Japan Control Engineering Co., Ltd.
 00:04:FE	PelagoNe	Pelago Networks
 00:04:FF	Acronet	Acronet Co., Ltd.
@@ -1360,7 +1348,7 @@
 00:05:17	Shellcom	Shellcomm, Inc.
 00:05:18	Jupiters	Jupiters Technology
 00:05:19	SiemensB	Siemens Building Technologies AG,
-00:05:1A	3comEuro	3COM EUROPE LTD.
+00:05:1A	3comEuro	3COM EUROPE LTD
 00:05:1B	MagicCon	Magic Control Technology Corporation
 00:05:1C	XnetTech	Xnet Technology Corp.
 00:05:1D	Airocon	Airocon, Inc.
@@ -1658,7 +1646,7 @@
 00:06:41	Itcn
 00:06:42	Genetel	Genetel Systems Inc.
 00:06:43	SonoComp	SONO Computer Co., Ltd.
-00:06:44	Neix	neix,Inc
+00:06:44	NextgenB	NextGen Business Solutions, Inc
 00:06:45	MeiseiEl	Meisei Electric Co. Ltd.
 00:06:46	Shenzhen	ShenZhen XunBao Network Technology Co Ltd
 00:06:47	EtraliSA	Etrali S.A.
@@ -1730,7 +1718,7 @@
 00:06:89	YlezTech	yLez Technologies Pte Ltd
 00:06:8A	Neuronne	NeuronNet Co. Ltd. R&D Center
 00:06:8B	Airrunne	AirRunner Technologies, Inc.
-00:06:8C	3com	3COM CORPORATION
+00:06:8C	3com
 00:06:8D	Sepaton	SEPATON, Inc.
 00:06:8E	Hid	HID Corporation
 00:06:8F	Telemoni	Telemonitor, Inc.
@@ -1904,7 +1892,7 @@
 00:07:37	Soriya	Soriya Co. Ltd.
 00:07:38	YoungTec	Young Technology Co., Ltd.
 00:07:39	ScottyGr	Scotty Group Austria Gmbh
-00:07:3A	Inventel	Inventel Systemes
+00:07:3A	Inventel
 00:07:3B	Tenovis	Tenovis GmbH & Co KG
 00:07:3C	TelecomD	Telecom Design
 00:07:3D	NanjingP	Nanjing Postel Telecommunications Co., Ltd.
@@ -2014,7 +2002,7 @@
 00:07:A5	YDK	Y.D.K Co. Ltd.
 00:07:A6	LevitonM	Leviton Manufacturing Co., Inc.
 00:07:A7	A-Z	A-Z Inc.
-00:07:A8	HaierGro	Haier Group Technologies Ltd.
+00:07:A8	HaierGro	Haier Group Technologies Ltd
 00:07:A9	Novasoni	Novasonics
 00:07:AA	QuantumD	Quantum Data Inc.
 00:07:AB	SamsungE	Samsung Electronics Co.,Ltd
@@ -2554,7 +2542,7 @@
 00:09:DC	GalaxisT	Galaxis Technology AG
 00:09:DD	MavinTec	Mavin Technology Inc.
 00:09:DE	SamjinIn	Samjin Information & Communications Co., Ltd.
-00:09:DF	VestelKo	Vestel Komunikasyon Sanayi ve Ticaret A.S.
+00:09:DF	VestelEl	Vestel Elektronik San ve Tic. A.Ş.
 00:09:E0	XemicsSA	Xemics S.A.
 00:09:E1	GemtekTe	Gemtek Technology Co., Ltd.
 00:09:E2	SinbonEl	Sinbon Electronics Co., Ltd.
@@ -2680,7 +2668,7 @@
 00:0A:5B	Power-On	Power-One as
 00:0A:5C	CarelSPA	Carel s.p.a.
 00:0A:5D	Fingerte	FingerTec Worldwide Sdn Bhd
-00:0A:5E	3com	3COM Corporation
+00:0A:5E	3com
 00:0A:5F	Almedio	almedio inc.
 00:0A:60	Autostar	Autostar Technology Pte Ltd
 00:0A:61	Cellinx	Cellinx Systems Inc.
@@ -2803,9 +2791,9 @@
 00:0A:D6	Beamreac	BeamReach Networks
 00:0A:D7	OriginEl	Origin ELECTRIC CO.,LTD.
 00:0A:D8	IpcservT	IPCserv Technology Corp.
-00:0A:D9	SonyMobi	Sony Mobile Communications AB
+00:0A:D9	SonyMobi	Sony Mobile Communications Inc
 00:0A:DA	Vindicat	Vindicator Technologies
-00:0A:DB	Skypilot	SkyPilot Network, Inc
+00:0A:DB	Trillian	Trilliant
 00:0A:DC	Ruggedco	RuggedCom Inc.
 00:0A:DD	Allworx	Allworx Corp.
 00:0A:DE	HappyCom	Happy Communication Co., Ltd.
@@ -2877,7 +2865,7 @@
 00:0B:20	Hirata	Hirata corporation
 00:0B:21	G-StarCo	G-Star Communications Inc.
 00:0B:22	Environm	Environmental Systems and Services
-00:0B:23	SiemensS	Siemens Subscriber Networks
+00:0B:23	SiemensH	Siemens Home & Office Comm. Devices
 00:0B:24	Airlogic
 00:0B:25	Aeluros
 00:0B:26	Wetek	Wetek Corporation
@@ -3005,7 +2993,7 @@
 00:0B:A0	T&LInfor	T&L Information Inc.
 00:0B:A1	Fujikura	Fujikura Solutions Ltd.
 00:0B:A2	Sumitomo	Sumitomo Electric Industries,Ltd
-00:0B:A3	SiemensI	Siemens AG, I&S
+00:0B:A3	Siemens	Siemens AG
 00:0B:A4	ShironSa	Shiron Satellite Communications Ltd. (1996)
 00:0B:A5	QuasarCi	Quasar Cipta Mandiri, PT
 00:0B:A6	Miyakawa	Miyakawa Electric Works Ltd.
@@ -3484,7 +3472,7 @@
 00:0D:7F	MidasCom	MIDAS  COMMUNICATION TECHNOLOGIES PTE LTD ( Foreign Branch)
 00:0D:80	OnlineDe	Online Development Inc
 00:0D:81	Pepperl+	Pepperl+Fuchs GmbH
-00:0D:82	PhsSrl	PHS srl
+00:0D:82	PhsnetSr	Phsnet Srls
 00:0D:83	Sanmina-	Sanmina-SCI Hungary  Ltd.
 00:0D:84	Makus	Makus Inc.
 00:0D:85	Tapwave	Tapwave, Inc.
@@ -3617,7 +3605,7 @@
 00:0E:04	Cma/Micr	CMA/Microdialysis AB
 00:0E:05	Wireless	Wireless Matrix Corp.
 00:0E:06	TeamSimo	Team Simoco Ltd
-00:0E:07	SonyMobi	Sony Mobile Communications AB
+00:0E:07	SonyMobi	Sony Mobile Communications Inc
 00:0E:08	Cisco-Li	Cisco-Linksys, LLC
 00:0E:09	Shenzhen	Shenzhen Coship Software Co.,LTD.
 00:0E:0A	SakumaDe	Sakuma Design Office
@@ -3753,7 +3741,7 @@
 00:0E:8C	SiemensA	Siemens AG A&D ET
 00:0E:8D	InProgre	Systems in Progress Holding GmbH
 00:0E:8E	Sparklan	SparkLAN Communications, Inc.
-00:0E:8F	Sercomm	Sercomm Corp.
+00:0E:8F	Sercomm	Sercomm Corporation.
 00:0E:90	Ponico	Ponico Corp.
 00:0E:91	NavicoAu	Navico Auckland Ltd
 00:0E:92	OpenTele	Open Telecom
@@ -3887,7 +3875,7 @@
 00:0F:12	Panasoni	Panasonic Europe Ltd.
 00:0F:13	Nisca	Nisca corporation
 00:0F:14	Mindray	Mindray Co., Ltd.
-00:0F:15	Kjaerulf	Kjaerulff1 A/S
+00:0F:15	Icotera	Icotera A/S
 00:0F:16	JayHowTe	Jay How Technology Co.,
 00:0F:17	InstaEle	Insta Elektro GmbH
 00:0F:18	Industri	Industrial Control Systems
@@ -4042,7 +4030,7 @@
 00:0F:AD	FmnCommu	FMN communications GmbH
 00:0F:AE	E2oCommu	E2O Communications
 00:0F:AF	Dialog	Dialog Inc.
-00:0F:B0	CompalEl	Compal Electronics, Inc.
+00:0F:B0	CompalEl	Compal Electronics INC.
 00:0F:B1	Cognio	Cognio Inc.
 00:0F:B2	Broadban	Broadband Pacenet (India) Pvt. Ltd.
 00:0F:B3	Actionte	Actiontec Electronics, Inc
@@ -4088,7 +4076,7 @@
 00:0F:DB	WestellT	Westell Technologies Inc.
 00:0F:DC	UedaJapa	Ueda Japan  Radio Co., Ltd.
 00:0F:DD	Sordin	Sordin Ab
-00:0F:DE	SonyMobi	Sony Mobile Communications AB
+00:0F:DE	SonyMobi	Sony Mobile Communications Inc
 00:0F:DF	SolomonT	SOLOMON Technology Corp.
 00:0F:E0	Ncomputi	NComputing Co.,Ltd.
 00:0F:E1	IdDigita	Id Digital Corporation
@@ -4408,7 +4396,7 @@
 00:11:1B	TargaDiv	Targa Systems Div L-3 Communications
 00:11:1C	PleoraTe	Pleora Technologies Inc.
 00:11:1D	Hectrix	Hectrix Limited
-00:11:1E	EpsgEthe	EPSG (Ethernet Powerlink Standardization Group)
+00:11:1E	Ethernet	ETHERNET Powerlink Standarization Group (EPSG)
 00:11:1F	DoremiLa	Doremi Labs, Inc.
 00:11:20	Cisco	Cisco Systems, Inc
 00:11:21	Cisco	Cisco Systems, Inc
@@ -4429,7 +4417,7 @@
 00:11:30	AlliedTe	Allied Telesis (Hong Kong) Ltd.
 00:11:31	Unatech	Unatech. Co.,Ltd
 00:11:32	Synology	Synology Incorporated
-00:11:33	SiemensA	Siemens Austria SIMEA
+00:11:33	SiemensA	Siemens AG Austria
 00:11:34	Mediacel	MediaCell, Inc.
 00:11:35	Grandeye	Grandeye Ltd
 00:11:36	Goodrich	Goodrich Sensor Systems
@@ -4713,7 +4701,7 @@
 00:12:4C	Bbwm	BBWM Corporation
 00:12:4D	InduconB	Inducon BV
 00:12:4E	XacAutom	Xac Automation Corp.
-00:12:4F	PentairT	Pentair Thermal Management
+00:12:4F	Nvent
 00:12:50	TokyoAir	Tokyo Aircaft Instrument Co., Ltd.
 00:12:51	Silink
 00:12:52	Citronix	Citronix, LLC
@@ -4799,7 +4787,7 @@
 00:12:A2	Vita
 00:12:A3	TrustInt	Trust International B.V.
 00:12:A4	Thingmag	ThingMagic, LLC
-00:12:A5	Stargen	Stargen, Inc.
+00:12:A5	DolphinI	Dolphin Interconnect Solutions AS
 00:12:A6	DolbyAus	Dolby Australia
 00:12:A7	IsrTechn	ISR TECHNOLOGIES Inc
 00:12:A8	Intec	intec GmbH
@@ -4872,7 +4860,7 @@
 00:12:EB	PdhSolut	PDH Solutions, LLC
 00:12:EC	Movacolo	Movacolor b.v.
 00:12:ED	AvgAdvan	AVG Advanced Technologies
-00:12:EE	SonyMobi	Sony Mobile Communications AB
+00:12:EE	SonyMobi	Sony Mobile Communications Inc
 00:12:EF	Oneacces	OneAccess SA
 00:12:F0	IntelCor	Intel Corporate
 00:12:F1	Ifotec
@@ -4969,7 +4957,7 @@
 00:13:4C	YdtTechn	YDT Technology International
 00:13:4D	IneproBv	Inepro BV
 00:13:4E	Valox	Valox Systems, Inc.
-00:13:4F	TranzeoW	Tranzeo Wireless Technologies Inc.
+00:13:4F	RapidusW	Rapidus Wireless Networks Inc.
 00:13:50	SilverSp	Silver Spring Networks, Inc
 00:13:51	NilesAud	Niles Audio Corporation
 00:13:52	Naztec	Naztec, Inc.
@@ -5024,11 +5012,11 @@
 00:13:83	Applicat	Application Technologies and Engineering Research Laboratory
 00:13:84	Advanced	Advanced Motion Controls
 00:13:85	Add-OnTe	Add-On Technology Co., LTD.
-00:13:86	Abb/Tota	ABB Inc./Totalflow
+00:13:86	AbbInc/T	ABB Inc/Totalflow
 00:13:87	27mTechn	27M Technologies AB
 00:13:88	WimediaA	WiMedia Alliance
 00:13:89	RedesDeT	Redes de Telefonía Móvil S.A.
-00:13:8A	QingdaoG	Qingdao Goertek Electronics Co.,Ltd.
+00:13:8A	QingdaoG	Qingdao GoerTek Technology Co., Ltd.
 00:13:8B	PhantomT	Phantom Technologies LLC
 00:13:8C	Kumyoung	Kumyoung.Co.Ltd
 00:13:8D	Kinghold
@@ -5053,7 +5041,7 @@
 00:13:A0	Algosyst	ALGOSYSTEM Co., Ltd.
 00:13:A1	CrowElec	Crow Electronic Engeneering
 00:13:A2	Maxstrea	MaxStream, Inc
-00:13:A3	SiemensC	Siemens Com CPE Devices
+00:13:A3	SiemensH	Siemens Home & Office Comm. Devices
 00:13:A4	KeyeyeCo	KeyEye Communications
 00:13:A5	GeneralS	General Solutions, LTD.
 00:13:A6	Extricom	Extricom Ltd
@@ -5175,7 +5163,7 @@
 00:14:1A	Deicy	Deicy Corporation
 00:14:1B	Cisco	Cisco Systems, Inc
 00:14:1C	Cisco	Cisco Systems, Inc
-00:14:1D	LtiDrive	LTi DRIVES GmbH
+00:14:1D	Lti-Moti	LTI-Motion GmbH
 00:14:1E	PASemi	P.A. Semi, Inc.
 00:14:1F	Sunkwang	SunKwang Electronics Co., Ltd
 00:14:20	G-LinksN	G-Links networking company
@@ -5260,12 +5248,12 @@
 00:14:6F	Kohler	Kohler Co
 00:14:70	ProkomSo	Prokom Software SA
 00:14:71	EasternA	Eastern Asia Technology Limited
-00:14:72	ChinaBro	China Broadband Wireless IP Standard Group
+00:14:72	ChinaBro	China Broadband Wireless IP Standard group(ChinaBWIPS)
 00:14:73	Bookham	Bookham Inc
 00:14:74	K40Elect	K40 Electronics
 00:14:75	WilineNe	Wiline Networks, Inc.
 00:14:76	Multicom	MultiCom Industries Limited
-00:14:77	Nertec	Nertec  Inc.
+00:14:77	Trillian	Trilliant
 00:14:78	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 00:14:79	NecMagnu	NEC Magnus Communications,Ltd.
 00:14:7A	Eubus	Eubus GmbH
@@ -5432,7 +5420,7 @@
 00:15:1B	Isilon	Isilon Systems Inc.
 00:15:1C	Leneco
 00:15:1D	M2i	M2I CORPORATION
-00:15:1E	Ethernet	Ethernet Powerlink Standardization Group (EPSG)
+00:15:1E	Ethernet	ETHERNET Powerlink Standarization Group (EPSG)
 00:15:1F	Multivis	Multivision Intelligent Surveillance (Hong Kong) Ltd
 00:15:20	Radiocra	Radiocrafts AS
 00:15:21	Horoquar	Horoquartz
@@ -5690,7 +5678,7 @@
 00:16:1D	Innovati	Innovative Wireless Technologies, Inc.
 00:16:1E	Woojinne	Woojinnet
 00:16:1F	Sunwavet	SUNWAVETEC Co., Ltd.
-00:16:20	SonyMobi	Sony Mobile Communications AB
+00:16:20	SonyMobi	Sony Mobile Communications Inc
 00:16:21	Colorado	Colorado Vnet
 00:16:22	Bbh	Bbh Systems Gmbh
 00:16:23	Interval	Interval Media
@@ -5750,7 +5738,7 @@
 00:16:59	ZMPRadwa	Z.M.P. Radwag
 00:16:5A	HarmanSp	Harman Specialty Group
 00:16:5B	GripAudi	Grip Audio
-00:16:5C	Trackflo	Trackflow Ltd
+00:16:5C	Trackflo	Trackflow Ltd.
 00:16:5D	Airdefen	AirDefense, Inc.
 00:16:5E	Precisio	Precision I/O
 00:16:5F	Fairmoun	Fairmount Automation
@@ -5842,7 +5830,7 @@
 00:16:B5	ArrisGro	ARRIS Group, Inc.
 00:16:B6	Cisco-Li	Cisco-Linksys, LLC
 00:16:B7	SeoulCom	Seoul Commtech
-00:16:B8	SonyMobi	Sony Mobile Communications AB
+00:16:B8	SonyMobi	Sony Mobile Communications Inc
 00:16:B9	Procurve	ProCurve Networking by HP
 00:16:BA	Weathern	Weathernews Inc.
 00:16:BB	Law-Chai	Law-Chain Computer Technology Co Ltd
@@ -6096,7 +6084,7 @@
 00:17:B3	AftekInf	Aftek Infosys Limited
 00:17:B4	RemoteSe	Remote Security Systems, LLC
 00:17:B5	Peerless	Peerless Systems Corporation
-00:17:B6	Aquantia
+00:17:B6	Aquantia	Aquantia Corporation
 00:17:B7	TonzeTec	Tonze Technology Co.
 00:17:B8	Novatron	Novatron Co., Ltd.
 00:17:B9	GambroLu	Gambro Lundia AB
@@ -6157,7 +6145,7 @@
 00:17:F0	SzcomBro	SZCOM Broadband Network Technology Co.,Ltd
 00:17:F1	RenuElec	Renu Electronics Pvt Ltd
 00:17:F2	Apple	Apple, Inc.
-00:17:F3	HarrisCo	Harris Corparation
+00:17:F3	Harris	Harris Corporation
 00:17:F4	ZeronAll	Zeron Alliance
 00:17:F5	LigNeopt	Lig Neoptek
 00:17:F6	PyramidM	Pyramid Meriden Inc.
@@ -6189,7 +6177,7 @@
 00:18:10	IptradeS	IPTrade S.A.
 00:18:11	NeurosTe	Neuros Technology International, LLC.
 00:18:12	BeijingX	Beijing Xinwei Telecom Technology Co., Ltd.
-00:18:13	SonyMobi	Sony Mobile Communications AB
+00:18:13	SonyMobi	Sony Mobile Communications Inc
 00:18:14	Mitutoyo	Mitutoyo Corporation
 00:18:15	GzTechno	GZ Technologies, Inc.
 00:18:16	Ubixon	Ubixon Co., Ltd.
@@ -6243,7 +6231,7 @@
 00:18:46	CryptoSA	Crypto S.A.
 00:18:47	AcenetTe	AceNet Technology Inc.
 00:18:48	VecimaNe	Vecima Networks Inc.
-00:18:49	PigeonPo	Pigeon Point Systems LLC
+00:18:49	NventSch	nVent, Schroff GmbH
 00:18:4A	Catcher	Catcher, Inc.
 00:18:4B	LasVegas	Las Vegas Gaming, Inc.
 00:18:4C	BogenCom	Bogen Communications
@@ -6388,7 +6376,7 @@
 00:18:D7	JavadGns	JAVAD GNSS, Inc.
 00:18:D8	ArchMete	ARCH METER Corporation
 00:18:D9	Santosha	Santosha Internatonal, Inc
-00:18:DA	AmberWir	AMBER wireless GmbH
+00:18:DA	WürthEle	Würth Elektronik eiSos GmbH & Co. KG
 00:18:DB	EplTechn	EPL Technology Ltd
 00:18:DC	Prostar	Prostar Co., Ltd.
 00:18:DD	Silicond	Silicondust Engineering Ltd
@@ -6525,7 +6513,7 @@
 00:19:60	Docomo	DoCoMo Systems, Inc.
 00:19:61	Blaupunk	Blaupunkt  Embedded Systems GmbH
 00:19:62	Commerci	Commerciant, LP
-00:19:63	SonyMobi	Sony Mobile Communications AB
+00:19:63	SonyMobi	Sony Mobile Communications Inc
 00:19:64	Doorking	Doorking Inc.
 00:19:65	YuhuaTel	YuHua TelTech (ShangHai) Co., Ltd.
 00:19:66	Asiarock	Asiarock Technology Limited
@@ -6731,7 +6719,7 @@
 00:1A:2E	ZiovaCop	Ziova Coporation
 00:1A:2F	Cisco	Cisco Systems, Inc
 00:1A:30	Cisco	Cisco Systems, Inc
-00:1A:31	ScanCoin	SCAN COIN Industries AB
+00:1A:31	ScanCoin	Scan Coin Ab
 00:1A:32	ActivaMu	Activa Multimedia
 00:1A:33	AsiCommu	ASI Communications, Inc.
 00:1A:34	KonkaGro	Konka Group Co., Ltd.
@@ -6799,7 +6787,7 @@
 00:1A:72	MosartSe	Mosart Semiconductor Corp.
 00:1A:73	GemtekTe	Gemtek Technology Co., Ltd.
 00:1A:74	ProcareI	Procare International Co
-00:1A:75	SonyMobi	Sony Mobile Communications AB
+00:1A:75	SonyMobi	Sony Mobile Communications Inc
 00:1A:76	SdtInfor	SDT information Technology Co.,LTD.
 00:1A:77	ArrisGro	ARRIS Group, Inc.
 00:1A:78	Ubtos
@@ -6879,7 +6867,7 @@
 00:1A:C2	Yec	YEC Co.,Ltd.
 00:1A:C3	Scientif	Scientific-Atlanta, Inc
 00:1A:C4	2wire	2Wire Inc
-00:1A:C5	Breaking	BreakingPoint Systems, Inc.
+00:1A:C5	Keysight	Keysight Technologies, Inc.
 00:1A:C6	MicroCon	Micro Control Designs
 00:1A:C7	Unipoint
 00:1A:C8	IslInstr	ISL (Instrumentation Scientifique de Laboratoire)
@@ -7027,7 +7015,7 @@
 00:1B:56	TehutiNe	Tehuti Networks Ltd.
 00:1B:57	Semindia	Semindia Systems Private Limited
 00:1B:58	AceCadEn	ACE CAD Enterprise Co., Ltd.
-00:1B:59	SonyMobi	Sony Mobile Communications AB
+00:1B:59	SonyMobi	Sony Mobile Communications Inc
 00:1B:5A	ApolloIm	Apollo Imaging Technologies, Inc.
 00:1B:5B	2wire	2Wire Inc
 00:1B:5C	Azuretec	Azuretec Co., Ltd.
@@ -7048,7 +7036,7 @@
 00:1B:6B	SwyxSolu	Swyx Solutions AG
 00:1B:6C	LookxDig	LookX Digital Media BV
 00:1B:6D	Midtroni	Midtronics, Inc.
-00:1B:6E	Anue	Anue Systems, Inc.
+00:1B:6E	Keysight	Keysight Technologies, Inc.
 00:1B:6F	Teletrak	Teletrak Ltd
 00:1B:70	IriUbite	IRI Ubiteq, INC.
 00:1B:71	Telular	Telular Corp.
@@ -7356,7 +7344,7 @@
 00:1B:D6	KelvinHu	Kelvin Hughes Ltd
 00:1B:D7	CiscoSpv	Cisco SPVTG
 00:1B:D8	Flir	FLIR Systems Inc
-00:1B:D9	Edgewate	Edgewater Computer Systems
+00:1B:D9	Edgewate	Edgewater Wireless Systems Inc
 00:1B:DA	Utstarco	UTStarcom Inc
 00:1B:DB	ValeoVec	Valeo VECS
 00:1B:DC	Vencer	Vencer Co., Ltd.
@@ -7559,7 +7547,7 @@
 00:1C:A1	AkamaiTe	Akamai Technologies, Inc.
 00:1C:A2	AdbBroad	ADB Broadband Italia
 00:1C:A3	Terra
-00:1C:A4	SonyMobi	Sony Mobile Communications AB
+00:1C:A4	SonyMobi	Sony Mobile Communications Inc
 00:1C:A5	Zygo	Zygo Corporation
 00:1C:A6	Win4net
 00:1C:A7	Internat	International Quartz Limited
@@ -7691,7 +7679,7 @@
 00:1D:25	SamsungE	Samsung Electronics Co.,Ltd
 00:1D:26	Rockridg	Rockridgesound Technology Co.
 00:1D:27	Nac-Inte	NAC-INTERCOM
-00:1D:28	SonyMobi	Sony Mobile Communications AB
+00:1D:28	SonyMobi	Sony Mobile Communications Inc
 00:1D:29	Doro	Doro AB
 00:1D:2A	Shenzhen	SHENZHEN BUL-TECH CO.,LTD.
 00:1D:2B	WuhanPon	Wuhan Pont Technology CO. , LTD
@@ -7958,7 +7946,7 @@
 00:1E:30	Shireen	Shireen Inc
 00:1E:31	Infomark	Infomark Co.,Ltd.
 00:1E:32	Zensys
-00:1E:33	Inventec	INVENTEC Corporation
+00:1E:33	Inventec	Inventec Corporation
 00:1E:34	Cryptome	CryptoMetrics
 00:1E:35	Nintendo	Nintendo Co., Ltd.
 00:1E:36	Ipte
@@ -7976,7 +7964,7 @@
 00:1E:42	Teltonik	Teltonika
 00:1E:43	AisinAw	Aisin Aw Co.,Ltd.
 00:1E:44	Santec
-00:1E:45	SonyMobi	Sony Mobile Communications AB
+00:1E:45	SonyMobi	Sony Mobile Communications Inc
 00:1E:46	ArrisGro	ARRIS Group, Inc.
 00:1E:47	PtHariff	PT. Hariff Daya Tunggal Engineering
 00:1E:48	Wi-Links
@@ -8035,7 +8023,7 @@
 00:1E:7D	SamsungE	Samsung Electronics Co.,Ltd
 00:1E:7E	NortelNe	Nortel Networks
 00:1E:7F	CbmOfAme	CBM of America
-00:1E:80	LastMile	Last Mile Ltd.
+00:1E:80	Icotera	Icotera A/S
 00:1E:81	CnbTechn	CNB Technology Inc.
 00:1E:82	Sandisk	SanDisk Corporation
 00:1E:83	Lan/ManS	LAN/MAN Standards Association (LMSC)
@@ -8127,7 +8115,7 @@
 00:1E:D9	Mitsubis	Mitsubishi Precision Co.,LTd.
 00:1E:DA	Wesemann	Wesemann Elektrotechniek B.V.
 00:1E:DB	GikenTra	Giken Trastem Co., Ltd.
-00:1E:DC	SonyMobi	Sony Mobile Communications AB
+00:1E:DC	SonyMobi	Sony Mobile Communications Inc
 00:1E:DD	WaskoSA	Wasko S.A.
 00:1E:DE	Byd	Byd Company Limited
 00:1E:DF	MasterIn	Master Industrialization Center Kista
@@ -8391,7 +8379,7 @@
 00:1F:E1	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 00:1F:E2	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 00:1F:E3	LgElectr	LG Electronics (Mobile Communications)
-00:1F:E4	SonyMobi	Sony Mobile Communications AB
+00:1F:E4	SonyMobi	Sony Mobile Communications Inc
 00:1F:E5	In-Circu	In-Circuit GmbH
 00:1F:E6	Alphion	Alphion Corporation
 00:1F:E7	Simet
@@ -8433,7 +8421,7 @@
 00:20:0B	Octagon	Octagon Systems Corp.
 00:20:0C	Adastra		Adastra Systems Corp
 00:20:0D	CarlZeis	Carl Zeiss
-00:20:0E	Satellit	Satellite Technology Mgmt, Inc
+00:20:0E	Nsslglob	NSSLGlobal Technologies AS
 00:20:0F	Ebrains	EBRAINS Inc
 00:20:10	JeolSyst	Jeol System Technology Co. Ltd
 00:20:11	Canopus		Canopus Co Ltd
@@ -8480,7 +8468,7 @@
 00:20:3A	DigitalB	DIGITAL BI0METRICS INC.
 00:20:3B	Wisdm	Wisdm Ltd.
 00:20:3C	Eurotime	Eurotime Ab
-00:20:3D	Honeywel	Honeywell ECC
+00:20:3D	Honeywel	Honeywell Environmental & Combustion Controls
 00:20:3E	LogicanT	LogiCan Technologies, Inc.
 00:20:3F	Juki	Juki Corporation
 00:20:40	ArrisGro	ARRIS Group, Inc.
@@ -8833,7 +8821,7 @@
 00:21:9B	Dell	Dell Inc.
 00:21:9C	Honeywld	Honeywld Technology Corp.
 00:21:9D	AdesysBv	Adesys BV
-00:21:9E	SonyMobi	Sony Mobile Communications AB
+00:21:9E	SonyMobi	Sony Mobile Communications Inc
 00:21:9F	SatelOy	Satel Oy
 00:21:A0	Cisco	Cisco Systems, Inc
 00:21:A1	Cisco	Cisco Systems, Inc
@@ -8955,7 +8943,7 @@
 00:22:15	AsustekC	ASUSTek COMPUTER INC.
 00:22:16	Shibaura	Shibaura Vending Machine Corporation
 00:22:17	NeatElec	Neat Electronics
-00:22:18	Verivue	Verivue Inc.
+00:22:18	AkamaiTe	Akamai Technologies Inc
 00:22:19	Dell	Dell Inc.
 00:22:1A	AudioPre	Audio Precision
 00:22:1B	Morega	Morega Systems
@@ -9083,7 +9071,7 @@
 00:22:95	SgmTechn	SGM Technology for lighting spa
 00:22:96	Linowave	LinoWave Corporation
 00:22:97	XmosSemi	XMOS Semiconductor
-00:22:98	SonyMobi	Sony Mobile Communications AB
+00:22:98	SonyMobi	Sony Mobile Communications Inc
 00:22:99	Seamicro	SeaMicro Inc.
 00:22:9A	Lastar	Lastar, Inc.
 00:22:9B	Averlogi	AverLogic Technologies, Inc.
@@ -9248,7 +9236,7 @@
 00:23:3A	SamsungE	Samsung Electronics Co.,Ltd
 00:23:3B	C-Matic	C-Matic Systems Ltd
 00:23:3C	Alflex
-00:23:3D	NoveroBV	Novero holding B.V.
+00:23:3D	LairdTec	Laird Technologies
 00:23:3E	Alcatel-	Alcatel-Lucent IPD
 00:23:3F	Purechoi	Purechoice Inc
 00:23:40	Mixtelem	MiXTelematics
@@ -9256,7 +9244,7 @@
 00:23:42	CoffeeEq	Coffee Equipment Company
 00:23:43	Tem	Tem Ag
 00:23:44	Objectiv	Objective Interface Systems, Inc.
-00:23:45	SonyMobi	Sony Mobile Communications AB
+00:23:45	SonyMobi	Sony Mobile Communications Inc
 00:23:46	Vestac
 00:23:47	Procurve	ProCurve Networking by HP
 00:23:48	Sagemcom	Sagemcom Broadband SAS
@@ -9267,7 +9255,7 @@
 00:23:4D	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 00:23:4E	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 00:23:4F	Luminous	Luminous Power Technologies Pvt. Ltd.
-00:23:50	Lyntec
+00:23:50	RdcDbaLy	RDC, Inc. dba LynTec
 00:23:51	2wire	2Wire Inc
 00:23:52	Datasens	DATASENSOR S.p.A.
 00:23:53	FETElett	F E T Elettronica snc
@@ -9428,7 +9416,7 @@
 00:23:EE	ArrisGro	ARRIS Group, Inc.
 00:23:EF	ZuendSys	Zuend Systemtechnik AG
 00:23:F0	Shanghai	Shanghai Jinghan Weighing Apparatus Co. Ltd.
-00:23:F1	SonyMobi	Sony Mobile Communications AB
+00:23:F1	SonyMobi	Sony Mobile Communications Inc
 00:23:F2	Tvlogic
 00:23:F3	Glocom	Glocom, Inc.
 00:23:F4	Masterna	Masternaut
@@ -9614,7 +9602,7 @@
 00:24:AB	A7Engine	A7 Engineering, Inc.
 00:24:AC	Hangzhou	Hangzhou DPtech Technologies Co., Ltd.
 00:24:AD	AdolfThi	Adolf Thies Gmbh & Co. KG
-00:24:AE	Morpho
+00:24:AE	Idemia
 00:24:AF	DishTech	Dish Technologies Corp
 00:24:B0	Esab	Esab Ab
 00:24:B1	CoulombT	Coulomb Technologies
@@ -9679,7 +9667,7 @@
 00:24:EC	UnitedIn	United Information Technology Co.,Ltd.
 00:24:ED	YtElec	YT Elec. Co,.Ltd.
 00:24:EE	Wynmax	Wynmax Inc.
-00:24:EF	SonyMobi	Sony Mobile Communications AB
+00:24:EF	SonyMobi	Sony Mobile Communications Inc
 00:24:F0	Seanodes
 00:24:F1	Shenzhen	Shenzhen Fanhai Sanjiang Electronics Co., Ltd.
 00:24:F2	Uniphone	Uniphone Telecommunication Co., Ltd.
@@ -9708,7 +9696,7 @@
 00:25:09	Sharetro	SHARETRONIC Group LTD
 00:25:0A	Security	Security Expert Co. Ltd
 00:25:0B	Centrofa	Centrofactor Inc
-00:25:0C	Enertrac
+00:25:0C	Senet	Senet Inc
 00:25:0D	GztTelko	GZT Telkom-Telmor sp. z o.o.
 00:25:0E	GtGerman	gt german telematics gmbh
 00:25:0F	On-RampW	On-Ramp Wireless, Inc.
@@ -9925,7 +9913,7 @@
 00:25:E4	Omni-Wif	OMNI-WiFi, LLC
 00:25:E5	LgElectr	LG Electronics (Mobile Communications)
 00:25:E6	BelgianM	Belgian Monitoring Systems bvba
-00:25:E7	SonyMobi	Sony Mobile Communications AB
+00:25:E7	SonyMobi	Sony Mobile Communications Inc
 00:25:E8	IdahoTec	Idaho Technology
 00:25:E9	I-MateDe	i-mate Development, Inc.
 00:25:EA	IphionBv	Iphion BV
@@ -10031,7 +10019,7 @@
 00:26:51	Cisco	Cisco Systems, Inc
 00:26:52	Cisco	Cisco Systems, Inc
 00:26:53	Dayseque	DaySequerra Corporation
-00:26:54	3com	3Com Corporation
+00:26:54	3com
 00:26:55	HewlettP	Hewlett Packard
 00:26:56	Sansonic	Sansonic Electronics USA
 00:26:57	OooNppEk	Ooo Npp Ekra
@@ -10055,7 +10043,7 @@
 00:26:69	NokiaDan	Nokia Danmark A/S
 00:26:6A	Essensiu	Essensium Nv
 00:26:6B	ShineUni	Shine Union Enterprise Limited
-00:26:6C	Inventec	INVENTEC Corporation
+00:26:6C	Inventec	Inventec Corporation
 00:26:6D	Mobileac	MobileAccess Networks
 00:26:6E	Nissho-D	Nissho-denki Co.,LTD.
 00:26:6F	Coordiwi	Coordiwise Technology Corp.
@@ -10136,7 +10124,7 @@
 00:26:BA	ArrisGro	ARRIS Group, Inc.
 00:26:BB	Apple	Apple, Inc.
 00:26:BC	GeneralJ	General Jack Technology Ltd.
-00:26:BD	JtecCard	JTEC Card & Communication Co., Ltd.
+00:26:BD	JtecCard	JTEC Card &amp; Communication Co., Ltd
 00:26:BE	Schoonde	Schoonderbeek Elektronica Systemen B.V.
 00:26:BF	Shenzhen	ShenZhen Temobi Science&Tech Development Co.,Ltd
 00:26:C0	Energyhu	EnergyHub
@@ -10250,6 +10238,7 @@
 00:2C:C8	Cisco	Cisco Systems, Inc
 00:2D:76	Titech	TITECH GmbH
 00:2E:C7	HuaweiTe	Huawei Technologies Co.,Ltd
+00:2F:D9	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 00:30:00	AllwellT	Allwell Technology Corp.
 00:30:01	Smp
 00:30:02	ExpandNe	Expand Networks
@@ -10280,7 +10269,7 @@
 00:30:1B	Shuttle	Shuttle, Inc.
 00:30:1C	Altvater	Altvater Airdata Systems
 00:30:1D	Skystrea	Skystream, Inc.
-00:30:1E	3comEuro	3COM EUROPE LTD.
+00:30:1E	3comEuro	3COM EUROPE LTD
 00:30:1F	OpticalN	Optical Networks, Inc.
 00:30:20	Tsi	TSI, Inc..
 00:30:21	HsingTec	Hsing Tech. Enterprise Co.,Ltd
@@ -10529,8 +10518,10 @@
 00:3A:9C	Cisco	Cisco Systems, Inc
 00:3A:9D	NecPlatf	NEC Platforms, Ltd.
 00:3A:AF	Bluebit	BlueBit Ltd.
+00:3C:10	Cisco	Cisco Systems, Inc
 00:3C:C5	WonwooEn	WONWOO Engineering Co., Ltd
 00:3D:41	Hattelan	Hatteland Computer AS
+00:3D:E8	LgElectr	LG Electronics (Mobile Communications)
 00:3E:E1	Apple	Apple, Inc.
 00:40:00	PciCompo	Pci Componentes Da Amzonia Ltd
 00:40:01	ZeroOneT	Zero One Technology Co Ltd (ZyXEL?)
@@ -10664,7 +10655,7 @@
 00:40:81	Mannesma	Mannesmann Scangraphic Gmbh
 00:40:82	Laborato	Laboratory Equipment Corp
 00:40:83	TdaIndus	Tda Industria De Produtos
-00:40:84	Honeywel	Honeywell Acs
+00:40:84	Honeywel	Honeywell International HPS
 00:40:85	SaabInst	SAAB Instruments AB
 00:40:86	MichelsK	Michels & Kleberhoff Computer
 00:40:87	Ubitrex		Ubitrex Corporation
@@ -10793,8 +10784,10 @@
 00:42:52	RlxTechn	RLX Technologies
 00:42:5A	Cisco	Cisco Systems, Inc
 00:42:68	Cisco	Cisco Systems, Inc
+00:42:79	SunitecE	Sunitec Enterprise Co.,Ltd
 00:43:FF	KetronSR	Ketron S.R.L.
 00:45:01	VersusTe	Versus Technology, Inc.
+00:45:1D	Cisco	Cisco Systems, Inc
 00:46:4B	HuaweiTe	Huawei Technologies Co.,Ltd
 00:48:54	DigitalS	Digital SemiConductor	# 21143/2 based 10/100
 00:4A:77	Zte	zte corporation
@@ -10944,7 +10937,7 @@
 00:50:96	SalixTec	Salix Technologies, Inc.
 00:50:97	Mmc-Embe	MMC-EMBEDDED COMPUTERTECHNIK GmbH
 00:50:98	Globaloo	Globaloop, Ltd.
-00:50:99	3comEuro	3COM EUROPE, LTD.
+00:50:99	3comEuro	3COM EUROPE LTD
 00:50:9A	TagElect	Tag Electronic Systems
 00:50:9B	Switchco	Switchcore Ab
 00:50:9C	BetaRese	Beta Research
@@ -11115,7 +11108,7 @@
 00:50:C2:08:00:00/36	Aim
 00:50:C2:08:10:00/36	Matusche	Matuschek Messtechnik GmbH
 00:50:C2:08:20:00/36	GfiChron	GFI Chrono Time
-00:50:C2:08:30:00/36	ArdSa	Ard Sa
+00:50:C2:08:30:00/36	ArdSa	ard sa
 00:50:C2:08:40:00/36	Dialog4S	DIALOG4 System Engineering GmbH
 00:50:C2:08:50:00/36	Crosspor	Crossport Systems
 00:50:C2:08:60:00/36	Validyne	Validyne Engineering Corp.
@@ -11456,7 +11449,7 @@
 00:50:C2:1D:50:00/36	Redpoint	Redpoint Controls
 00:50:C2:1D:60:00/36	Shanghai	shanghai trend intelligent systems CO.,LTD
 00:50:C2:1D:70:00/36	PleoraTe	Pleora Technologies Inc.
-00:50:C2:1D:80:00/36	Guardian	Guardian Controls International
+00:50:C2:1D:80:00/36	Guardian	Guardian Controls International Ltd
 00:50:C2:1D:90:00/36	Edc
 00:50:C2:1D:A0:00/36	GfiChron	GFI Chrono Time
 00:50:C2:1D:B0:00/36	AppliedE	Applied Systems Engineering, Inc.
@@ -11533,7 +11526,7 @@
 00:50:C2:22:20:00/36	Imo-Elek	imo-elektronik GmbH
 00:50:C2:22:30:00/36	Visicont	visicontrol GmbH
 00:50:C2:22:40:00/36	Pannocom	PANNOCOM Ltd.
-00:50:C2:22:50:00/36	PigeonPo	Pigeon Point Systems LLC
+00:50:C2:22:50:00/36	NventSch	nVent, Schroff GmbH
 00:50:C2:22:60:00/36	RossVide	Ross Video Limited
 00:50:C2:22:70:00/36	Intellig	Intelligent Photonics Control
 00:50:C2:22:80:00/36	Intellig	Intelligent Media Technologies, Inc.
@@ -11722,7 +11715,7 @@
 00:50:C2:2D:F0:00/36	Micrel-N	MICREL-NKE
 00:50:C2:2E:00:00/36	BaxterIn	Baxter International Inc
 00:50:C2:2E:10:00/36	AccessIs	Access IS
-00:50:C2:2E:20:00/36	BallardT	Ballard Technology, Inc.
+00:50:C2:2E:20:00/36	BallardT	Ballard Technology, Inc,
 00:50:C2:2E:30:00/36	MgIndust	MG Industrieelektronik GmbH
 00:50:C2:2E:40:00/36	Iamba	iamba LTD.
 00:50:C2:2E:50:00/36	Transtec	Transtech DSP
@@ -11875,7 +11868,7 @@
 00:50:C2:37:80:00/36	Daintree	Daintree Networks Pty
 00:50:C2:37:90:00/36	ControlL	Control LAN S.A.
 00:50:C2:37:A0:00/36	Ida	IDA Corporation
-00:50:C2:37:B0:00/36	Freescal	freescale semiconductor
+00:50:C2:37:B0:00/36	Freescal	Freescale Semiconductor
 00:50:C2:37:C0:00/36	Modia	MODIA SYSTEMS Co., Ltd
 00:50:C2:37:D0:00/36	Verotrak	VeroTrak Inc.
 00:50:C2:37:E0:00/36	NiSRL	Ni.Co. S.r.l.
@@ -11907,7 +11900,7 @@
 00:50:C2:39:80:00/36	InhandEl	Inhand Electronics, Inc.
 00:50:C2:39:90:00/36	Advanced	Advanced Micro Controls Inc.
 00:50:C2:39:A0:00/36	OpticalA	Optical Air Data Systems
-00:50:C2:39:B0:00/36	YuyamaMf	Yuyama Mfg. Co., Ltd.
+00:50:C2:39:B0:00/36	YuyamaMf	YUYAMA MFG Co.,Ltd
 00:50:C2:39:C0:00/36	TiyodaMf	Tiyoda Mfg Co.,Ltd.
 00:50:C2:39:D0:00/36	Digitald	DigitalDeck, Inc.
 00:50:C2:39:E0:00/36	ARGElect	A.R.G ElectroDesign Ltd
@@ -11929,7 +11922,7 @@
 00:50:C2:3A:E0:00/36	HankukTa	Hankuk Tapi Computer Co., Ltd
 00:50:C2:3A:F0:00/36	NorbitOd	Norbit ODM AS
 00:50:C2:3B:00:00/36	Microtar	Microtarget Tecnologia Digital Ltda.
-00:50:C2:3B:10:00/36	RdcSpecs	RDC Specstroy-Svyaz Ltd
+00:50:C2:3B:10:00/36	Specstro	Specstroy-Svyaz Ltd
 00:50:C2:3B:20:00/36	Tennesse	Tennessee Valley Authority
 00:50:C2:3B:30:00/36	MediaLab	Media Lab., Inc.
 00:50:C2:3B:40:00/36	Contrôle	Contrôle Analytique inc.
@@ -11974,7 +11967,7 @@
 00:50:C2:3D:B0:00/36	Osmetech	Osmetech Inc.
 00:50:C2:3D:C0:00/36	3dPercep	3D perception
 00:50:C2:3D:D0:00/36	Elmic	ELMIC GmbH
-00:50:C2:3D:E0:00/36	AbbPower	ABB Power Technologies S.p.A. Unità  Operativa SACE (PTMV)
+00:50:C2:3D:E0:00/36	AbbPower	ABB Power Technologies S.p.A.  Unità  Operativa SACE (PTMV)
 00:50:C2:3D:F0:00/36	Biode	BiODE Inc.
 00:50:C2:3E:00:00/36	OyStingh	Oy Stinghorn Ltd
 00:50:C2:3E:10:00/36	Neulion	NeuLion Incorporated
@@ -11995,7 +11988,7 @@
 00:50:C2:3F:00:00/36	MegatecE	megatec electronic GmbH
 00:50:C2:3F:10:00/36	SallandE	Salland Electronics Holding BV
 00:50:C2:3F:20:00/36	Stl	STL GmbH
-00:50:C2:3F:30:00/36	HytecGer	Hytec Geraetebau GmbH
+00:50:C2:3F:30:00/36	Abb-Powe	ABB AG - Power Grids - Grid Automation
 00:50:C2:3F:40:00/36	McTechno	MC TECHNOLOGY GmbH
 00:50:C2:3F:50:00/36	Phaedrus	Phaedrus Limited
 00:50:C2:3F:60:00/36	Daftdata	dAFTdATA Limited
@@ -12003,7 +11996,7 @@
 00:50:C2:3F:80:00/36	Superna	Superna Ltd
 00:50:C2:3F:90:00/36	Sintium	Sintium Ltd
 00:50:C2:3F:A0:00/36	Tumsan
-00:50:C2:3F:B0:00/36	PigeonPo	Pigeon Point Systems LLC
+00:50:C2:3F:B0:00/36	NventSch	nVent, Schroff GmbH
 00:50:C2:3F:C0:00/36	Weinberg	Weinberger Deutschland GmbH
 00:50:C2:3F:D0:00/36	Hartmann	HARTMANN software GbR
 00:50:C2:3F:E0:00/36	Haivisio	HaiVision Systems Inc
@@ -12090,8 +12083,8 @@
 00:50:C2:44:F0:00/36	Kippdata	kippdata GmbH
 00:50:C2:45:00:00/36	Enconair	Enconair Ecological Chambers Inc.
 00:50:C2:45:10:00/36	Hameg	HAMEG GmbH
-00:50:C2:45:20:00/36	ScameSis	SCAME SISTEMI s.r.l.
-00:50:C2:45:30:00/36	Erhardt+	Erhardt + Leimer GmbH
+00:50:C2:45:20:00/36	ScameSis	Scame Sistemi srl
+00:50:C2:45:30:00/36	Erhardt+	Erhardt+Leimer GmbH
 00:50:C2:45:40:00/36	BrivoLlc	Brivo Systems, LLC
 00:50:C2:45:50:00/36	GogoBa	Gogo BA
 00:50:C2:45:60:00/36	DrdcValc	DRDC Valcartier
@@ -12169,7 +12162,7 @@
 00:50:C2:49:E0:00/36	Armorlin	Armorlink Co .Ltd
 00:50:C2:49:F0:00/36	Gcs	GCS, Inc
 00:50:C2:4A:00:00/36	Advanced	Advanced technologies & Engineering (pty) Ltd
-00:50:C2:4A:10:00/36	PigeonPo	Pigeon Point Systems LLC
+00:50:C2:4A:10:00/36	NventSch	nVent, Schroff GmbH
 00:50:C2:4A:20:00/36	Specs	SPECS GmbH
 00:50:C2:4A:30:00/36	ProtiumT	Protium Technologies, Inc.
 00:50:C2:4A:40:00/36	IeeeP160	IEEE P1609 WG
@@ -12326,7 +12319,7 @@
 00:50:C2:53:B0:00/36	Teleks	Teleks Co. Ltd.
 00:50:C2:53:C0:00/36	Marposs	Marposs SPA
 00:50:C2:53:D0:00/36	DigitalC	Digital communications Technologies
-00:50:C2:53:E0:00/36	Honeywel	Honeywell GNO
+00:50:C2:53:E0:00/36	Honeywel	Honeywell
 00:50:C2:53:F0:00/36	EllipsBV	Ellips B.V.
 00:50:C2:54:00:00/36	MesureCo	Mesure Controle Commande
 00:50:C2:54:10:00/36	WavesSys	Waves System
@@ -12386,7 +12379,7 @@
 00:50:C2:57:70:00/36	Advanced	Advanced Software Technologies
 00:50:C2:57:80:00/36	DelphiDi	Delphi Display Systems, Inc.
 00:50:C2:57:90:00/36	Gastager	Gastager Systemtechnik GmbH
-00:50:C2:57:A0:00/36	PigeonPo	Pigeon Point Systems LLC
+00:50:C2:57:A0:00/36	NventSch	nVent, Schroff GmbH
 00:50:C2:57:B0:00/36	Ptswitch
 00:50:C2:57:C0:00/36	Éolane
 00:50:C2:57:D0:00/36	SierraVi	Sierra Video Systems
@@ -12395,7 +12388,7 @@
 00:50:C2:58:00:00/36	BuyangEl	Buyang Electronics Industrial co.,Ltd.
 00:50:C2:58:10:00/36	Devitech	Devitech ApS
 00:50:C2:58:20:00/36	Allsun	AllSun A/S
-00:50:C2:58:30:00/36	JüngerAu	Jünger Audio-Studiotechnik GmbH
+00:50:C2:58:30:00/36	JungerAu	Junger Audio-Studiotechnik GmbH
 00:50:C2:58:40:00/36	ToyotaMo	Toyota Motorsport GmbH
 00:50:C2:58:50:00/36	Wireless	Wireless Cables Inc.
 00:50:C2:58:60:00/36	Genetix	Genetix Ltd
@@ -12446,7 +12439,7 @@
 00:50:C2:5B:30:00/36	HitecomS	HITECOM System
 00:50:C2:5B:40:00/36	Terrasci	Terrascience Systems Ltd.
 00:50:C2:5B:50:00/36	Rafael
-00:50:C2:5B:60:00/36	KontronB	Kontron (Beijing) Technology Co.,Ltd.
+00:50:C2:5B:60:00/36	KontronB	Kontron (BeiJing) Technology Co.,Ltd
 00:50:C2:5B:70:00/36	Avermedi	AVerMedia Technologies, Inc.
 00:50:C2:5B:80:00/36	Westfali	WestfaliaSurge GmbH
 00:50:C2:5B:90:00/36	TaiwanVi	Taiwan Video & Monitor
@@ -12799,7 +12792,7 @@
 00:50:C2:71:40:00/36	TEAmSA	T.E.Am., S. A.
 00:50:C2:71:50:00/36	Riexinge	RIEXINGER Elektronik
 00:50:C2:71:60:00/36	MitrolSR	Mitrol S.R.L.
-00:50:C2:71:70:00/36	MbConnec	MB Connect Line GmbH
+00:50:C2:71:70:00/36	MbConnec	MB connect line GmbH Fernwartungssysteme
 00:50:C2:71:80:00/36	IllunisL	illunis LLC
 00:50:C2:71:90:00/36	Ennovati	ennovatis GmbH
 00:50:C2:71:A0:00/36	LogusBro	Logus Broadband Wireless Solutions Inc.
@@ -12876,7 +12869,7 @@
 00:50:C2:76:10:00/36	ElbitOfA	Elbit Systems of America - Fort Worth Operations
 00:50:C2:76:20:00/36	Assembly	Assembly Contracts Limited
 00:50:C2:76:30:00/36	Xtendwav	XtendWave
-00:50:C2:76:40:00/36	Argus-Sp	Argus-Spectrum
+00:50:C2:76:40:00/36	Argus-Sp	ARGUS-SPECTRUM
 00:50:C2:76:50:00/36	PhytecMe	Phytec Messtechnik GmbH
 00:50:C2:76:60:00/36	Guterman	Gutermann Technology GmbH
 00:50:C2:76:70:00/36	Eid
@@ -13281,7 +13274,7 @@
 00:50:C2:8F:60:00/36	K-Mac	K-MAC Corp.
 00:50:C2:8F:70:00/36	Tge	TGE Co., Ltd.
 00:50:C2:8F:80:00/36	Rmsd	Rmsd Ltd
-00:50:C2:8F:90:00/36	Honeywel	Honeywell International
+00:50:C2:8F:90:00/36	Honeywel	Honeywell
 00:50:C2:8F:A0:00/36	TeliumSC	TELIUM s.c.
 00:50:C2:8F:B0:00/36	AlfredKu	Alfred Kuhse GmbH
 00:50:C2:8F:C0:00/36	Symetric	Symetrics Industries
@@ -13307,7 +13300,7 @@
 00:50:C2:91:00:00/36	Autotank	Autotank AB
 00:50:C2:91:10:00/36	VaporRai	Vapor Rail
 00:50:C2:91:20:00/36	AssetInt	ASSET InterTech, Inc.
-00:50:C2:91:30:00/36	SelexEx	Selex Ex Ltd
+00:50:C2:91:30:00/36	Leonardo	Leonardo MW Ltd (Land & Naval Defence Electronic)
 00:50:C2:91:40:00/36	Io-Conne	IO-Connect
 00:50:C2:91:50:00/36	Verint	Verint Systems Ltd.
 00:50:C2:91:60:00/36	ChkGrids	CHK GridSense P/L
@@ -13326,7 +13319,7 @@
 00:50:C2:92:30:00/36	AmicusWi	Amicus Wireless
 00:50:C2:92:40:00/36	LinkElec	Link Electric & Safety Control Co.
 00:50:C2:92:50:00/36	PhbEletr	PHB Eletronica Ltda.
-00:50:C2:92:60:00/36	DitestFa	Ditest Fahrzeugdiagnose Gmbh
+00:50:C2:92:60:00/36	DitestFa	DiTEST Fahrzeugdiagnose GmbH
 00:50:C2:92:70:00/36	AtisGrou	ATIS group s.r.o.
 00:50:C2:92:80:00/36	Cinetix	Cinetix GmbH
 00:50:C2:92:90:00/36	FlightDe	Flight Deck Resources
@@ -13357,7 +13350,7 @@
 00:50:C2:94:20:00/36	KeithKoe	Keith & Koep GmbH
 00:50:C2:94:30:00/36	Quanzhou	QuanZhou TDX Electronics Co., Ltd.
 00:50:C2:94:40:00/36	Wireonai	Wireonair A/S
-00:50:C2:94:50:00/36	Ex-IFlow	Ex-i Flow Measurement Ltd.
+00:50:C2:94:50:00/36	ExiFlowM	Exi Flow Measurement Ltd
 00:50:C2:94:60:00/36	MegwareC	MEGWARE Computer GmbH
 00:50:C2:94:70:00/36	Imexhigh	IMEXHIGHWAY cvba
 00:50:C2:94:80:00/36	Electron	Electronia
@@ -13466,7 +13459,7 @@
 00:50:C2:9A:F0:00/36	Kress-Ne	KRESS-NET Krzysztof Rutecki
 00:50:C2:9B:00:00/36	Ebru	Ebru GmbH
 00:50:C2:9B:10:00/36	BonHora	Bon Hora GmbH
-00:50:C2:9B:20:00/36	Tempsys
+00:50:C2:9B:20:00/36	MesaLabs	Mesa Labs, Inc.
 00:50:C2:9B:30:00/36	KahlerAu	Kahler Automation
 00:50:C2:9B:40:00/36	EukreaEl	Eukrea Electromatique Sarl
 00:50:C2:9B:50:00/36	Telegamm	Telegamma srl
@@ -13590,7 +13583,7 @@
 00:50:C2:A2:B0:00/36	ApriliaR	Aprilia Racing S.R.L.
 00:50:C2:A2:C0:00/36	Kws-Elec	KWS-Electronic GmbH
 00:50:C2:A2:D0:00/36	Inventur	Inventure Inc.
-00:50:C2:A2:E0:00/36	YuyamaMf	Yuyama Mfg. Co., Ltd.
+00:50:C2:A2:E0:00/36	YuyamaMf	YUYAMA MFG Co.,Ltd
 00:50:C2:A2:F0:00/36	Dragonfl	DragonFly Scientific LLC
 00:50:C2:A3:00:00/36	D-Ta	D-TA Systems
 00:50:C2:A3:10:00/36	Coolit	Coolit Systems, Inc.
@@ -13672,7 +13665,7 @@
 00:50:C2:A7:D0:00/36	VitelNet	Vitel Net
 00:50:C2:A7:E0:00/36	Independ	Independent Project Engineering Ltd
 00:50:C2:A7:F0:00/36	PhytecMe	Phytec Messtechnik GmbH
-00:50:C2:A8:00:00/36	ArdSa	Ard Sa
+00:50:C2:A8:00:00/36	ArdSa	ard sa
 00:50:C2:A8:10:00/36	BpcCircu	BPC circuits Ltd
 00:50:C2:A8:20:00/36	Ct	CT Company
 00:50:C2:A8:30:00/36	TechnoSo	Techno Sobi Co. Ltd.
@@ -13831,7 +13824,7 @@
 00:50:C2:B1:C0:00/36	PhytecMe	Phytec Messtechnik GmbH
 00:50:C2:B1:D0:00/36	Telegeni	Telegenix
 00:50:C2:B1:E0:00/36	AbbottMe	Abbott Medical Optics
-00:50:C2:B1:F0:00/36	ScaSchuc	SCA Schucker GmbH & Co.
+00:50:C2:B1:F0:00/36	AtlasCop	Atlas Copco IAS GmbH
 00:50:C2:B2:00:00/36	Five9Net	FIVE9 NETWORK SYSTEMS LLC
 00:50:C2:B2:10:00/36	Phytron-	Phytron-Elektronik GmbH
 00:50:C2:B2:20:00/36	FarsiteC	FarSite Communications Limited
@@ -13884,7 +13877,7 @@
 00:50:C2:B5:10:00/36	Aeroflex	Aeroflex GmbH
 00:50:C2:B5:20:00/36	SmhTechn	SMH Technologies
 00:50:C2:B5:30:00/36	Prodco
-00:50:C2:B5:40:00/36	ApgCashD	Apg Cash Drawer
+00:50:C2:B5:40:00/36	ApgCashD	APG Cash Drawer, LLC
 00:50:C2:B5:50:00/36	SanyoEle	Sanyo Electronic Industries Co.,Ltd
 00:50:C2:B5:60:00/36	SinoviaS	Sinovia Sa
 00:50:C2:B5:70:00/36	PhytecMe	Phytec Messtechnik GmbH
@@ -14107,7 +14100,7 @@
 00:50:C2:C3:10:00/36	4dTechno	4D Technology Corporation
 00:50:C2:C3:20:00/36	ProconEl	Procon Electronics
 00:50:C2:C3:40:00/36	Kyuhen
-00:50:C2:C3:50:00/36	Insitu	Insitu, Inc.
+00:50:C2:C3:50:00/36	Insitu	Insitu, Inc
 00:50:C2:C3:60:00/36	Set	SET GmbH
 00:50:C2:C3:70:00/36	BEARSolu	B.E.A.R. Solutions (Australasia) Pty, Ltd
 00:50:C2:C3:80:00/36	Computer	Computer Automation Technology Inc
@@ -14318,7 +14311,7 @@
 00:50:C2:D0:60:00/36	NckResea	nCk Research LLC
 00:50:C2:D0:70:00/36	Iaf	IAF GmbH
 00:50:C2:D0:80:00/36	Reimesch	Reimesch Kommunikationssysteme GmbH
-00:50:C2:D0:90:00/36	Guardtec	Guardtec, Inc.
+00:50:C2:D0:90:00/36	Guardtec	Guardtec,Inc
 00:50:C2:D0:A0:00/36	Airpoint	Airpoint Co., Ltd.
 00:50:C2:D0:B0:00/36	CodacoEl	CODACO ELECTRONIC s.r.o.
 00:50:C2:D0:C0:00/36	JvlIndus	JVL Industri Elektronik
@@ -14372,7 +14365,7 @@
 00:50:C2:D3:C0:00/36	Assystem	ASSYSTEM France
 00:50:C2:D3:D0:00/36	TellabsO	Tellabs Operations Inc.
 00:50:C2:D3:E0:00/36	SynatecE	Synatec Electronic GmbH
-00:50:C2:D3:F0:00/36	CssLlc	Css, Llc
+00:50:C2:D3:F0:00/36	Communic	Communication Systems Solutions
 00:50:C2:D4:00:00/36	DemmelPr	demmel products
 00:50:C2:D4:10:00/36	AreaEner	Area Energy, Inc.
 00:50:C2:D4:20:00/36	HagenukK	Hagenuk KMT GmbH
@@ -14445,7 +14438,7 @@
 00:50:C2:D8:50:00/36	Vitec
 00:50:C2:D8:60:00/36	EcommEra	Ecomm Era
 00:50:C2:D8:70:00/36	Electrol	Electrolight Shivuk (1994) Ltd.
-00:50:C2:D8:80:00/36	T+AElekt	T+A elektroakustik GmbH & Co KG
+00:50:C2:D8:80:00/36	T+AElekt	T+A elektroakustik GmbH & Co.KG
 00:50:C2:D8:90:00/36	VisualTe	Visual Telecommunication Network, Inc
 00:50:C2:D8:A0:00/36	Optolink	OptoLink  Industria e Comercio Ltda
 00:50:C2:D8:B0:00/36	SiconSrl	Sicon srl
@@ -14525,7 +14518,7 @@
 00:50:C2:DD:50:00/36	FriendSp	Friend Spring Industrial Co., Ltd.
 00:50:C2:DD:60:00/36	TransasM	Transas Marine Limited
 00:50:C2:DD:70:00/36	TornadoM	Tornado Modular Systems
-00:50:C2:DD:80:00/36	SelexInt	Selex Systems Integration Inc
+00:50:C2:DD:80:00/36	Leonardo	Leonardo MW Ltd (Land & Naval Defence Electronic)
 00:50:C2:DD:90:00/36	Metrawar	Metraware
 00:50:C2:DD:A0:00/36	RbzRobot	rbz robot design s.l.
 00:50:C2:DD:B0:00/36	Luceo
@@ -14731,7 +14724,7 @@
 00:50:C2:EA:50:00/36	Aerodata	Aerodata AG
 00:50:C2:EA:60:00/36	Powersen	Powersense A/S
 00:50:C2:EA:70:00/36	Saia-Bur	Saia-Burgess Controls AG
-00:50:C2:EA:80:00/36	MbConnec	MB Connect Line GmbH
+00:50:C2:EA:80:00/36	MbConnec	MB connect line GmbH Fernwartungssysteme
 00:50:C2:EA:90:00/36	MettlerT	Mettler Toledo Hi Speed
 00:50:C2:EA:A0:00/36	Bae	BAE Systems
 00:50:C2:EA:B0:00/36	Warp9Tec	Warp9 Tech Design, Inc.
@@ -14799,7 +14792,7 @@
 00:50:C2:EE:90:00/36	QuantaSR	QUANTA S.r.l.
 00:50:C2:EE:A0:00/36	Position	Positioneering Limited
 00:50:C2:EE:B0:00/36	Fibriste	fibrisTerre GmbH
-00:50:C2:EE:C0:00/36	YuyamaMf	Yuyama Mfg. Co., Ltd.
+00:50:C2:EE:C0:00/36	YuyamaMf	YUYAMA MFG Co.,Ltd
 00:50:C2:EE:D0:00/36	FutureDe	Future Design Controls, Inc
 00:50:C2:EE:E0:00/36	AbbTrans	ABB Transmission and Distribution Automation Equipment (Xiamen) Co., Ltd.
 00:50:C2:EE:F0:00/36	Idtronic	IDTRONIC GmbH
@@ -14904,7 +14897,7 @@
 00:50:C2:F5:20:00/36	Rohde&Sc	Rohde&Schwarz Topex SA
 00:50:C2:F5:30:00/36	BaycomOp	BAYCOM OPTO-ELECTRONICS TECHNOLGY CO., LTD.
 00:50:C2:F5:40:00/36	HellaGut	Hella Gutmann Solutions GmbH
-00:50:C2:F5:50:00/36	Honeywel	Honeywell International Inc.
+00:50:C2:F5:50:00/36	Honeywel	Honeywell
 00:50:C2:F5:60:00/36	MonsoonS	Monsoon Solutions, Inc.
 00:50:C2:F5:70:00/36	ReachTec	Reach Technologies Inc.
 00:50:C2:F5:80:00/36	IeeeRegi	IEEE Registration Authority
@@ -15030,7 +15023,7 @@
 00:50:C2:FD:10:00/36	EnyxSa	Enyx SA
 00:50:C2:FD:20:00/36	Autonomi	Autonomic Controls. Inc
 00:50:C2:FD:30:00/36	AsterEle	Aster Electric Co.,Ltd.
-00:50:C2:FD:40:00/36	Insitu	Insitu, Inc.
+00:50:C2:FD:40:00/36	Insitu	Insitu, Inc
 00:50:C2:FD:50:00/36	American	American Microsystems, Ltd.
 00:50:C2:FD:60:00/36	CityComp	City Computing Ltd
 00:50:C2:FD:70:00/36	Deuta-We	Deuta-Werke GmbH
@@ -15051,7 +15044,7 @@
 00:50:C2:FE:60:00/36	Exibea	Exibea AB
 00:50:C2:FE:70:00/36	Erhardt+	Erhardt+Leimer GmbH
 00:50:C2:FE:80:00/36	MangoDsp	Mango DSP, Inc.
-00:50:C2:FE:90:00/36	MbConnec	MB Connect Line GmbH
+00:50:C2:FE:90:00/36	MbConnec	MB connect line GmbH Fernwartungssysteme
 00:50:C2:FE:A0:00/36	BrunelSe	Brunel GmbH Section Communications
 00:50:C2:FE:B0:00/36	AxibleTe	Axible Technologies
 00:50:C2:FE:C0:00/36	FirstSys	First System Technology Co., Ltd.
@@ -15059,7 +15052,7 @@
 00:50:C2:FE:E0:00/36	SparksIn	Sparks Instruments SA
 00:50:C2:FE:F0:00/36	TaskSist	Task Sistemas de Computacao
 00:50:C2:FF:00:00/36	GdMissio	GD Mission Systems
-00:50:C2:FF:10:00/36	DitestFa	DiTEST FAHRZEUGDIAGNOSE GMBH
+00:50:C2:FF:10:00/36	DitestFa	DiTEST Fahrzeugdiagnose GmbH
 00:50:C2:FF:20:00/36	Globalco	Globalcom Engineering Srl
 00:50:C2:FF:30:00/36	ControlS	CONTROL SYSTEMS Srl
 00:50:C2:FF:40:00/36	BurkTech	Burk Technology
@@ -15096,7 +15089,7 @@
 00:50:D7	Telstrat
 00:50:D8	UnicornC	Unicorn Computer Corp.
 00:50:D9	Engetron	ENGETRON-ENGENHARIA ELETRONICA IND. e COM. LTDA
-00:50:DA	3com	3COM CORPORATION
+00:50:DA	3com
 00:50:DB	Contempo	Contemporary Control
 00:50:DC	TasTelef	TAS TELEFONBAU A. SCHWABE GMBH & CO. KG
 00:50:DD	SerraSol	Serra Soldadura, S.A.
@@ -15130,6 +15123,7 @@
 00:50:FD	Visionco	Visioncomm Co., Ltd.
 00:50:FE	PctvnetA	PCTVnet ASA
 00:50:FF	HakkoEle	Hakko Electronics Co., Ltd.
+00:51:ED	LgInnote	LG Innotek
 00:52:18	WuxiKebo	Wuxi Keboda Electron Co.Ltd
 00:54:9F	Avaya	Avaya Inc
 00:54:AF	Continen	Continental Automotive Systems Inc.
@@ -15154,7 +15148,9 @@
 00:55:DA:F0:00:00/28	Private
 00:56:2B	Cisco	Cisco Systems, Inc
 00:56:CD	Apple	Apple, Inc.
+00:57:C1	LgElectr	LG Electronics (Mobile Communications)
 00:57:D2	Cisco	Cisco Systems, Inc
+00:58:3F	PcAquari	PC Aquarius
 00:59:07	Lenovoem	LenovoEMC Products USA, LLC
 00:59:79	Networke	Networked Energy Services
 00:59:AC	KpnBV	Kpn. B.V.
@@ -15439,9 +15435,12 @@
 00:6F:64	SamsungE	Samsung Electronics Co.,Ltd
 00:70:B0	M/A-ComC	M/A-COM INC. COMPANIES
 00:70:B3	DataReca	Data Recall Ltd.
+00:71:47	AmazonTe	Amazon Technologies Inc.
 00:71:C2	Pegatron	Pegatron Corporation
 00:71:CC	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
+00:72:04	SamsungE	Samsung Electronics Co., Ltd. ARTIK
 00:72:63	NetcoreT	Netcore Technology Inc.
+00:72:78	Cisco	Cisco Systems, Inc
 00:73:8D	Shenzhen	Shenzhen TINNO Mobile Technology Corp.
 00:73:E0	SamsungE	Samsung Electronics Co.,Ltd
 00:74:9C	RuijieNe	Ruijie Networks Co.,LTD
@@ -15453,8 +15452,10 @@
 00:78:9E	Sagemcom	Sagemcom Broadband SAS
 00:78:CD	Ignition	Ignition Design Labs
 00:7B:18	Sentry	SENTRY Co., LTD.
+00:7C:2D	SamsungE	Samsung Electronics Co.,Ltd
 00:7D:FA	Volkswag	Volkswagen Group of America
 00:7E:56	ChinaDra	China Dragon Technology Limited
+00:7E:95	Cisco	Cisco Systems, Inc
 00:7F:28	Actionte	Actiontec Electronics, Inc
 00:80:00	Multitec	Multitech Systems Inc
 00:80:01	Periphon	Periphonics Corporation
@@ -15725,7 +15726,7 @@
 00:8B:FC	Mixi	mixi,Inc.
 00:8C:10	BlackBox	Black Box Corp.
 00:8C:54	AdbBroad	ADB Broadband Italia
-00:8C:FA	Inventec	INVENTEC Corporation
+00:8C:FA	Inventec	Inventec Corporation
 00:8D:4E	CjscNiiS	Cjsc Nii Stt
 00:8D:DA	LinkOne	Link One Co., Ltd.
 00:8E:73	Cisco	Cisco Systems, Inc
@@ -15877,7 +15878,7 @@
 00:90:90	I-Bus
 00:90:91	Digitals	DigitalScape, Inc.
 00:90:92	Cisco
-00:90:93	Nanao	Nanao Corporation
+00:90:93	Eizo	EIZO Corporation
 00:90:94	OspreyTe	Osprey Technologies, Inc.
 00:90:95	Universa	Universal Avionics
 00:90:96	AskeyCom	Askey Computer Corp
@@ -15936,7 +15937,7 @@
 00:90:CB	Wireless	Wireless OnLine, Inc.
 00:90:CC	PlanexCo	Planex Communications Inc.
 00:90:CD	Ent-Empr	ENT-EMPRESA NACIONAL DE TELECOMMUNICACOES, S.A.
-00:90:CE	Tetra	TETRA GmbH
+00:90:CE	Avateram	avateramedical Mechatronics GmbH
 00:90:CF	Nortel
 00:90:D0	ThomsonT	Thomson Telecom Belgium
 00:90:D1	LeichuEn	Leichu Enterprise Co., Ltd.
@@ -15996,6 +15997,7 @@
 00:9A:CD	HuaweiTe	Huawei Technologies Co.,Ltd
 00:9A:D2	Cisco	Cisco Systems, Inc
 00:9C:02	HewlettP	Hewlett Packard
+00:9D:6B	MurataMa	Murata Manufacturing Co., Ltd.
 00:9D:8E	CardiacR	Cardiac Recorders, Inc.
 00:9E:1E	Cisco	Cisco Systems, Inc
 00:9E:C8	XiaomiCo	Xiaomi Communications Co Ltd
@@ -16032,7 +16034,7 @@
 00:A0:1E	Est	Est Corporation
 00:A0:1F	Tricord	Tricord Systems, Inc.
 00:A0:20	Citicorp	CITICORP/TTI
-00:A0:21	GeneralD	General Dynamics
+00:A0:21	GeneralD	General Dynamics Mission Systems
 00:A0:22	CentreFo	Centre For Development Of Advanced Computing
 00:A0:23	AppliedC	Applied Creative Technology, Inc.
 00:A0:24	3com
@@ -16212,7 +16214,7 @@
 00:A0:D2	AlliedTe	Allied Telesyn
 00:A0:D3	InstemCo	Instem Computer Systems, Ltd.
 00:A0:D4	Radiolan	Radiolan, Inc.
-00:A0:D5	SierraWi	Sierra Wireless Inc.
+00:A0:D5	SierraWi	Sierra Wireless Inc
 00:A0:D6	Sbe	SBE, Inc.
 00:A0:D7	KastenCh	Kasten Chase Applied Research
 00:A0:D8	Spectra-	SPECTRA - TEK
@@ -16264,6 +16266,7 @@
 00:A3:8E	Cisco	Cisco Systems, Inc
 00:A3:D1	Cisco	Cisco Systems, Inc
 00:A5:09	Wigwag	WigWag Inc.
+00:A5:BF	Cisco	Cisco Systems, Inc
 00:A6:CA	Cisco	Cisco Systems, Inc
 00:A7:42	Cisco	Cisco Systems, Inc
 00:A7:84	ItxSecur	ITX security
@@ -16271,8 +16274,10 @@
 00:AA:01	Intel	Intel Corporation
 00:AA:02	Intel	Intel Corporation
 00:AA:3C	Olivetti	OLIVETTI TELECOM SPA (OLTECO)
+00:AA:6E	Cisco	Cisco Systems, Inc
 00:AA:70	LgElectr	LG Electronics (Mobile Communications)
 00:AC:E0	ArrisGro	ARRIS Group, Inc.
+00:AD:24	D-LinkIn	D-Link International
 00:AE:CD	Pensando	Pensando Systems
 00:AE:FA	MurataMa	Murata Manufacturing Co., Ltd.
 00:AF:1F	Cisco	Cisco Systems, Inc
@@ -16313,26 +16318,38 @@
 00:B0:EE	Ajile	Ajile Systems, Inc.
 00:B0:F0	CalyNetw	Caly Networks
 00:B0:F5	Networth	NetWorth Technologies, Inc.
-00:B3:38	KontronD	Kontron Design Manufacturing Services (M) Sdn. Bhd
+00:B1:E3	Cisco	Cisco Systems, Inc
+00:B3:38	KontronA	Kontron Asia Pacific Design Sdn. Bhd
 00:B3:42	Macrosan	MacroSAN Technologies Co., Ltd.
 00:B3:62	Apple	Apple, Inc.
+00:B4:F5	Dongguan	DongGuan Siyoto Electronics Co., Ltd
 00:B5:6D	DavidEle	David Electronics Co., LTD.
+00:B5:D0	SamsungE	Samsung Electronics Co.,Ltd
 00:B5:D6	Omnibit	Omnibit Inc.
+00:B6:70	Cisco	Cisco Systems, Inc
 00:B6:9F	Latch
+00:B7:71	Cisco	Cisco Systems, Inc
 00:B7:8D	NanjingS	Nanjing Shining Electric Automation Co., Ltd
+00:B8:B3	Cisco	Cisco Systems, Inc
+00:B8:C2	HeightsT	Heights Telecom T ltd
 00:B9:F6	Shenzhen	Shenzhen Super Rich Electronics Co.,Ltd
 00:BA:C0	Biometri	Biometric Access Company
 00:BB:01	Octothor	Octothorpe Corp.
-00:BB:3A	Private
+00:BB:3A	AmazonTe	Amazon Technologies Inc.
+00:BB:60	IntelCor	Intel Corporate
 00:BB:8E	Hme	HME Co., Ltd.
 00:BB:C1	Canon	Canon Inc.
 00:BB:F0	Ungerman	UNGERMANN-BASS INC.
+00:BC:60	Cisco	Cisco Systems, Inc
 00:BD:27	Exar	Exar Corp.
 00:BD:3A	Nokia	Nokia Corporation
 00:BD:82	Shenzhen	Shenzhen YOUHUA Technology Co., Ltd
+00:BE:3B	HuaweiTe	Huawei Technologies Co.,Ltd
+00:BE:75	Cisco	Cisco Systems, Inc
 00:BE:9E	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 00:BF:15	Genetec	Genetec Inc.
 00:BF:61	SamsungE	Samsung Electronics Co.,Ltd
+00:BF:77	Cisco	Cisco Systems, Inc
 00:C0:00	Lanoptic	Lanoptics Ltd
 00:C0:01	DiatekPa	Diatek Patient Managment
 00:C0:02	Sercomm		Sercomm Corporation
@@ -16593,16 +16610,20 @@
 00:C1:64	Cisco	Cisco Systems, Inc
 00:C1:B1	Cisco	Cisco Systems, Inc
 00:C2:C6	IntelCor	Intel Corporate
+00:C3:F4	SamsungE	Samsung Electronics Co.,Ltd
 00:C5:DB	Datatech	Datatech Sistemas Digitales Avanzados SL
 00:C6:10	Apple	Apple, Inc.
 00:C8:8B	Cisco	Cisco Systems, Inc
 00:CA:E5	Cisco	Cisco Systems, Inc
 00:CB:00	Private
+00:CB:B4	Shenzhen	Shenzhen Ateko Photoelectricity Co.,Ltd
 00:CB:BD	Cambridg	Cambridge Broadband Networks Ltd.
+00:CC:3F	Universa	Universal Electronics, Inc.
 00:CC:FC	Cisco	Cisco Systems, Inc
 00:CD:90	MasElekt	MAS Elektronik AG
 00:CD:FE	Apple	Apple, Inc.
 00:CF:1C	Communic	Communication Machinery Corporation
+00:CF:C0	ChinaMob	China Mobile Group Device Co.,Ltd.
 00:D0:00	FerranSc	Ferran Scientific, Inc.
 00:D0:01	VstTechn	Vst Technologies, Inc.
 00:D0:02	Ditech	Ditech Corporation
@@ -16648,7 +16669,7 @@
 00:D0:2A	Voxent	Voxent Systems Ltd.
 00:D0:2B	Jetcell	Jetcell, Inc.
 00:D0:2C	Campbell	Campbell Scientific, Inc.
-00:D0:2D	Ademco
+00:D0:2D	Resideo
 00:D0:2E	Communic	Communication Automation Corp.
 00:D0:2F	VlsiTech	Vlsi Technology Inc.
 00:D0:30	Safetran	Safetran Systems Corp
@@ -16753,7 +16774,7 @@
 00:D0:93	Tq-Compo	TQ - COMPONENTS GMBH
 00:D0:94	SeeionCo	Seeion Control LLC
 00:D0:95	Alcatel-	Alcatel-Lucent Enterprise
-00:D0:96	3comEuro	3COM EUROPE LTD.
+00:D0:96	3comEuro	3COM EUROPE LTD
 00:D0:97	Cisco	Cisco Systems, Inc
 00:D0:98	PhotonDy	Photon Dynamics Canada Inc.
 00:D0:99	ElcardWi	Elcard Wireless Systems Oy
@@ -16809,7 +16830,7 @@
 00:D0:CB	Dasan	Dasan Co., Ltd.
 00:D0:CC	Technolo	Technologies Lyre Inc.
 00:D0:CD	AtanTech	Atan Technology Inc.
-00:D0:CE	AsystEle	Asyst Electronic
+00:D0:CE	IsystemL	iSystem Labs
 00:D0:CF	MoretonB	Moreton Bay
 00:D0:D0	Zhongxin	Zhongxing Telecom Ltd.
 00:D0:D1	Sycamore	Sycamore Networks
@@ -16819,7 +16840,7 @@
 00:D0:D5	Grundig	Grundig Ag
 00:D0:D6	AethraTe	Aethra Telecomunicazioni
 00:D0:D7	B2c2	B2C2, INC.
-00:D0:D8	3com	3Com Corporation
+00:D0:D8	3com
 00:D0:D9	Dedicate	Dedicated Microcomputers
 00:D0:DA	TaicomDa	Taicom Data Systems Co., Ltd.
 00:D0:DB	McquayIn	Mcquay International
@@ -16863,7 +16884,9 @@
 00:D3:18	SpgContr	SPG Controls
 00:D3:8D	HotelTec	Hotel Technology Next Generation
 00:D6:32	GeEnergy	GE Energy
+00:D6:FE	Cisco	Cisco Systems, Inc
 00:D7:8F	Cisco	Cisco Systems, Inc
+00:D8:61	Micro-St	Micro-Star INTL CO., LTD.
 00:D9:D1	SonyInte	Sony Interactive Entertainment Inc.
 00:DA:55	Cisco	Cisco Systems, Inc
 00:DB:1E	AlbedoTe	Albedo Telecom SL
@@ -16896,7 +16919,7 @@
 00:E0:06	SiliconI	Silicon Integrated Sys. Corp.
 00:E0:07	AvayaEcs	Avaya ECS Ltd
 00:E0:08	AmazingC	AMAZING CONTROLS! INC.
-00:E0:09	Marathon	Marathon Technologies Corp.
+00:E0:09	StratusT	Stratus Technologies
 00:E0:0A	Diba	Diba, Inc.
 00:E0:0B	RooftopC	Rooftop Communications Corp.
 00:E0:0C	Motorola
@@ -16979,7 +17002,7 @@
 00:E0:59	Controll	Controlled Environments, Ltd.
 00:E0:5A	GaleaNet	Galea Network Security
 00:E0:5B	WestEnd	West End Systems Corp.
-00:E0:5C	Panasoni	Panasonic Healthcare Co., Ltd.
+00:E0:5C	Phc	PHC Corporation
 00:E0:5D	Unitec	Unitec Co., Ltd.
 00:E0:5E	JapanAvi	Japan Aviation Electronics Industry, Ltd.
 00:E0:5F	E-Net	e-Net, Inc.
@@ -17152,7 +17175,8 @@
 00:E6:D3	NixdorfC	Nixdorf Computer Corp.
 00:E6:E8	NetzinTe	Netzin Technology Corporation,.Ltd.
 00:E8:AB	MeggittT	Meggitt Training Systems, Inc.
-00:EB:2D	SonyMobi	Sony Mobile Communications AB
+00:EA:BD	Cisco	Cisco Systems, Inc
+00:EB:2D	SonyMobi	Sony Mobile Communications Inc
 00:EB:D5	Cisco	Cisco Systems, Inc
 00:EC:0A	XiaomiCo	Xiaomi Communications Co Ltd
 00:EE:BD	Htc	HTC Corporation
@@ -17162,6 +17186,7 @@
 00:F3:DB	WooSport	WOO Sports
 00:F4:03	OrbisOy	Orbis Systems Oy
 00:F4:6F	SamsungE	Samsung Electronics Co.,Ltd
+00:F4:8D	LiteonTe	Liteon Technology Corporation
 00:F4:B9	Apple	Apple, Inc.
 00:F6:63	Cisco	Cisco Systems, Inc
 00:F7:6F	Apple	Apple, Inc.
@@ -17174,6 +17199,7 @@
 00:FC:70	Intrepid	Intrepid Control Systems, Inc.
 00:FC:8B	AmazonTe	Amazon Technologies Inc.
 00:FC:8D	HitronTe	Hitron Technologies. Inc
+00:FC:BA	Cisco	Cisco Systems, Inc
 00:FD:45	HewlettP	Hewlett Packard Enterprise
 00:FD:4C	Nevatec
 00:FE:C8	Cisco	Cisco Systems, Inc
@@ -17192,7 +17218,7 @@
 02:A0:C9	Intel
 02:AA:3C	Olivetti
 02:BB:01	Octothor	Octothorpe Corp.
-02:C0:8C	3com	3COM CORPORATION
+02:C0:8C	3com
 02:CF:1C	Communic	Communication Machinery Corporation
 02:CF:1F	CMC
 02:E0:3B	Prominet	Prominet Corporation	# Gigabit Ethernet Switch
@@ -17202,11 +17228,13 @@
 04:03:D6	Nintendo	Nintendo Co.,Ltd
 04:04:EA	ValensSe	Valens Semiconductor Ltd.
 04:09:73	HewlettP	Hewlett Packard Enterprise
+04:09:A5	Hfr	HFR, Inc.
 04:0A:83	Alcatel-	Alcatel-Lucent
 04:0A:E0	XmitComp	Xmit Ag Computer Networks
 04:0C:CE	Apple	Apple, Inc.
 04:0E:C2	Viewsoni	ViewSonic Mobile China Limited
 04:15:52	Apple	Apple, Inc.
+04:15:D9	Viwone
 04:18:0F	SamsungE	Samsung Electronics Co.,Ltd
 04:18:B6	Private
 04:18:D6	Ubiquiti	Ubiquiti Networks Inc.
@@ -17235,6 +17263,7 @@
 04:36:04	Gyeyoung	Gyeyoung I&T
 04:3A:0D	SmOptics	SM Optics S.r.l.
 04:3D:98	Chongqin	ChongQing QingJia Electronics CO.,LTD
+04:40:A9	NewH3cTe	New H3C Technologies Co., Ltd
 04:41:69	Gopro
 04:44:A1	TeleconG	Telecon Galicia,S.A.
 04:46:65	MurataMa	Murata Manufacturing Co., Ltd.
@@ -17245,6 +17274,7 @@
 04:4C:EF	FujianSa	Fujian Sanao Technology Co.,Ltd
 04:4E:06	Ericsson	Ericsson AB
 04:4E:5A	ArrisGro	ARRIS Group, Inc.
+04:4E:AF	LgInnote	LG Innotek
 04:4F:17	Humax	HUMAX Co., Ltd.
 04:4F:4C	HuaweiTe	Huawei Technologies Co.,Ltd
 04:4F:8B	Adapteva	Adapteva, Inc.
@@ -17271,6 +17301,8 @@
 04:65:65	Testop
 04:67:85	ScemtecH	scemtec Hard- und Software fuer Mess- und Steuerungstechnik GmbH
 04:69:F8	Apple	Apple, Inc.
+04:6B:1B	Sysdine	SYSDINE Co., Ltd.
+04:6B:25	SichuanT	Sichuan Tianyi Comheart Telecom Co.,Ltd
 04:6C:9D	Cisco	Cisco Systems, Inc
 04:6D:42	Bryston	Bryston Ltd.
 04:6E:02	Openrtls	OpenRTLS Group
@@ -17297,6 +17329,8 @@
 04:75:F5	Csst
 04:76:6E	AlpsElec	Alps Electric Co.,Ltd.
 04:78:63	Shanghai	Shanghai MXCHIP Information Technology Co., Ltd.
+04:79:70	HuaweiTe	Huawei Technologies Co.,Ltd
+04:79:B7	TexasIns	Texas Instruments
 04:7D:50	Shenzhen	Shenzhen Kang Ying Technology Co.Ltd.
 04:7D:7B	QuantaCo	Quanta Computer Inc.
 04:7E:4A	Moobox	moobox CO., Ltd.
@@ -17306,9 +17340,12 @@
 04:88:8C	Eifelwer	Eifelwerk Butler Systeme GmbH
 04:88:E2	BeatsEle	Beats Electronics LLC
 04:8A:15	Avaya	Avaya Inc
+04:8A:E1	Flextron	FLEXTRONICS MANUFACTURING(ZHUHAI)CO.,LTD.
 04:8B:42	Skspruce	Skspruce Technologies
 04:8C:03	ThinpadT	ThinPAD Technology (Shenzhen)CO.,LTD
 04:8D:38	NetcoreT	Netcore Technology Inc.
+04:91:62	Microchi	Microchip Technology Inc.
+04:92:26	AsustekC	ASUSTek COMPUTER INC.
 04:92:EE	Iway	iway AG
 04:94:6B	TecnoMob	Tecno Mobile Limited
 04:94:A1	CatchWin	Catch The Wind Inc
@@ -17327,6 +17364,7 @@
 04:A3:16	TexasIns	Texas Instruments
 04:A3:F3	Emicon
 04:A8:2A	Nokia	Nokia Corporation
+04:AB:18	Elecom	Elecom Co.,Ltd.
 04:AC:44	HoltekSe	Holtek Semiconductor Inc.
 04:B0:E7	HuaweiTe	Huawei Technologies Co.,Ltd
 04:B1:67	XiaomiCo	Xiaomi Communications Co Ltd
@@ -17335,6 +17373,7 @@
 04:B6:48	Zenner
 04:BA:36	LiSengTe	Li Seng Technology Ltd
 04:BB:F9	Pavilion	Pavilion Data Systems Inc
+04:BC:87	Shenzhen	Shenzhen JustLink Technology Co., LTD
 04:BD:70	HuaweiTe	Huawei Technologies Co.,Ltd
 04:BD:88	ArubaNet	Aruba Networks
 04:BF:6D	ZyxelCom	Zyxel Communications Corporation
@@ -17346,6 +17385,22 @@
 04:C1:B9	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 04:C2:3E	Htc	HTC Corporation
 04:C2:41	Nokia
+04:C3:E6	IeeeRegi	IEEE Registration Authority
+04:C3:E6:00:00:00/28	Dreamkas	Dreamkas Llc
+04:C3:E6:10:00:00/28	Guangdon	Guangdong New Pulse Electric Co., Ltd.
+04:C3:E6:20:00:00/28	SisTechn	SiS Technology
+04:C3:E6:30:00:00/28	ExtechEl	Extech Electronics Co., LTD.
+04:C3:E6:40:00:00/28	Innovusi	Innovusion Inc.
+04:C3:E6:50:00:00/28	Invasys
+04:C3:E6:60:00:00/28	Shenzhen	Shenzhen Shuotian Information Technology Co., LTD
+04:C3:E6:70:00:00/28	Advanced	Advanced Digital Technologies, s.r.o.
+04:C3:E6:80:00:00/28	Sloc	SLOC GmbH
+04:C3:E6:90:00:00/28	EkinTekn	Ekin Teknoloji San ve Tic A.S.
+04:C3:E6:A0:00:00/28	SealedUn	Sealed Unit Parts Co., Inc.
+04:C3:E6:B0:00:00/28	FlintecU	Flintec UK Ltd.
+04:C3:E6:C0:00:00/28	ShantouY	SHANTOU YINGSHENG IMPORT & EXPORT TRADING CO.,LTD.
+04:C3:E6:D0:00:00/28	Amiosec	Amiosec Ltd
+04:C3:E6:E0:00:00/28	Teleepoc	Teleepoch Ltd
 04:C5:A4	Cisco	Cisco Systems, Inc
 04:C8:80	Samtec	Samtec Inc
 04:C9:91	Phistek	Phistek INC.
@@ -17353,7 +17408,9 @@
 04:CB:1D	Traka	Traka plc
 04:CE:14	Wilocity	Wilocity LTD.
 04:CF:25	Manycolo	Manycolors, Inc.
+04:CF:8C	XiaomiEl	XIAOMI Electronics,CO.,LTD
 04:D1:3A	XiaomiCo	Xiaomi Communications Co Ltd
+04:D3:B0	IntelCor	Intel Corporate
 04:D3:CF	Apple	Apple, Inc.
 04:D4:37	Znv
 04:D6:AA	SamsungE	SAMSUNG ELECTRO-MECHANICS(THAILAND)
@@ -17368,13 +17425,16 @@
 04:E0:B0	Shenzhen	Shenzhen YOUHUA Technology Co., Ltd
 04:E0:C4	Triumph-	TRIUMPH-ADLER AG
 04:E1:C8	ImsSoluç	IMS Soluções em Energia Ltda.
+04:E2:29	QingdaoH	Qingdao Haier Technology Co.,Ltd
 04:E2:F8	AepTicke	AEP Ticketing solutions srl
 04:E4:51	TexasIns	Texas Instruments
 04:E5:36	Apple	Apple, Inc.
 04:E5:48	CohdaWir	Cohda Wireless Pty Ltd
+04:E5:98	XiaomiCo	Xiaomi Communications Co Ltd
 04:E6:62	Acroname	Acroname Inc.
 04:E6:76	AmpakTec	AMPAK Technology, Inc.
 04:E9:E5	PjrcComL	Pjrc.Com, Llc
+04:EB:40	Cisco	Cisco Systems, Inc
 04:EC:BB	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 04:EE:91	X-Fabric	x-fabric GmbH
 04:F0:21	CompexPt	Compex Systems Pte Ltd
@@ -17386,6 +17446,7 @@
 04:F8:C2	Flaircom	Flaircomm Microelectronics, Inc.
 04:F9:38	HuaweiTe	Huawei Technologies Co.,Ltd
 04:FA:3F	Opticore	Opticore Inc.
+04:FA:83	QingdaoH	Qingdao Haier Technology Co.,Ltd
 04:FE:31	SamsungE	Samsung Electronics Co.,Ltd
 04:FE:7F	Cisco	Cisco Systems, Inc
 04:FE:8D	HuaweiTe	Huawei Technologies Co.,Ltd
@@ -17438,7 +17499,7 @@
 08:00:2D	Lan-Tec	LAN-TEC INC.
 08:00:2E	Metaphor
 08:00:2F	PrimeCom	Prime Computer	# Prime 50-Series LHC300
-08:00:30	NetworkR	Network Research Corporation
+08:00:30	CERN		CERN
 08:00:31	LittleMa	Little Machines Inc.
 08:00:32	Tigan
 08:00:33	BauschLo	BAUSCH & LOMB
@@ -17468,7 +17529,7 @@
 08:00:4B	Planning	Planning Research Corp.
 08:00:4C	HydraCom	Hydra Computer Systems Inc.
 08:00:4D	Corvus	Corvus Systems Inc.
-08:00:4E	3comEuro	3COM EUROPE LTD.
+08:00:4E	3comEuro	3COM EUROPE LTD
 08:00:4F	Cygnet	Cygnet Systems
 08:00:50	Daisy	Daisy Systems Corp.
 08:00:51	Experdat	Experdata
@@ -17566,12 +17627,14 @@
 08:21:EF	SamsungE	Samsung Electronics Co.,Ltd
 08:23:B2	VivoMobi	vivo Mobile Communication Co., Ltd.
 08:25:22	Advansee
+08:25:25	XiaomiCo	Xiaomi Communications Co Ltd
 08:27:19	ApsSyste	APS systems/electronic AG
 08:27:CE	NaganoKe	Nagano Keiki Co., Ltd.
 08:2A:D0	SrdInnov	SRD Innovations Inc.
 08:2C:B0	NetworkI	Network Instruments
 08:2E:5F	HewlettP	Hewlett Packard
 08:30:6B	PaloAlto	Palo Alto Networks
+08:35:1B	Shenzhen	Shenzhen Jialihua Electronic Technology Co., Ltd
 08:35:71	Caswell	CASwell INC.
 08:35:B2	Coreedge	CoreEdge Networks Co., Ltd
 08:37:3D	SamsungE	Samsung Electronics Co.,Ltd
@@ -17589,6 +17652,7 @@
 08:40:27	Gridstor	Gridstore Inc.
 08:40:F3	TendaTec	Tenda Technology Co.,Ltd.Dongguan branch
 08:46:56	Veo-Labs
+08:47:D0	NokiaSha	Nokia Shanghai Bell Co. Ltd.）
 08:48:2C	RaycoreT	Raycore Taiwan Co., LTD.
 08:4A:CF	Guangdon	Guangdong Oppo Mobile Telecommunications Corp.,Ltd
 08:4E:1C	H2aLlc	H2A Systems, LLC
@@ -17635,10 +17699,12 @@
 08:8D:C8	RyowaEle	Ryowa Electronics Co.,Ltd
 08:8E:4F	SfSoftwa	SF Software Solutions
 08:8F:2C	HillsSou	Hills Sound Vision & Lighting
+08:90:BA	Danlaw	Danlaw Inc
 08:94:EF	WistronI	Wistron Infocomm (Zhongshan) Corporation
 08:95:2A	Technico	Technicolor CH USA Inc.
 08:96:AD	Cisco	Cisco Systems, Inc
 08:96:D7	Avm	AVM GmbH
+08:97:34	HewlettP	Hewlett Packard Enterprise
 08:97:58	Shenzhen	Shenzhen Strong Rising Electronics Co.,Ltd DongGuan Subsidiary
 08:9B:4B	IkuaiNet	iKuai Networks
 08:9E:01	QuantaCo	Quanta Computer Inc.
@@ -17657,6 +17723,7 @@
 08:B7:38	Lite-OnT	Lite-On Technogy Corp.
 08:B7:EC	Wireless	Wireless Seismic
 08:BA:22	Swaive	Swaive Corporation
+08:BA:5F	QingdaoH	Qingdao Hisense Electronics Co.,Ltd.
 08:BB:CC	Ak-NordE	AK-NORD EDV VERTRIEBSGES. mbH
 08:BC:20	Hangzhou	Hangzhou Royal Cloud Technology Co., Ltd
 08:BD:43	Netgear
@@ -17664,6 +17731,7 @@
 08:BE:77	GreenEle	Green Electronics
 08:BE:AC	EdimaxTe	Edimax Technology Co. Ltd.
 08:C0:21	HuaweiTe	Huawei Technologies Co.,Ltd
+08:C5:E1	SamsungE	SAMSUNG ELECTRO-MECHANICS(THAILAND)
 08:C6:B3	QtechLlc	Qtech Llc
 08:CA:45	ToyouFei	Toyou Feiji Electronics Co., Ltd.
 08:CC:68	Cisco	Cisco Systems, Inc
@@ -17675,9 +17743,12 @@
 08:D3:4B	TechmanE	Techman Electronics (Changshu) Co., Ltd.
 08:D4:0C	IntelCor	Intel Corporate
 08:D4:2B	SamsungE	Samsung Electronics Co.,Ltd
+08:D4:6A	LgElectr	LG Electronics (Mobile Communications)
+08:D5:9D	Sagemcom	Sagemcom Broadband SAS
 08:D5:C0	SeersTec	Seers Technology Co., Ltd
 08:D8:33	Shenzhen	Shenzhen RF Technology Co., Ltd
 08:DF:1F	Bose	Bose Corporation
+08:DF:CB	Systrome	Systrome Networks
 08:E5:DA	NanjingF	Nanjing Fujitsu Computer Products Co.,Ltd.
 08:E6:72	JebseeEl	Jebsee Electronics Co.,Ltd.
 08:E6:89	Apple	Apple, Inc.
@@ -17711,6 +17782,7 @@
 08:F1:B7	Towerstr	Towerstream Corpration
 08:F2:F4	NetOnePa	Net One Partners Co.,Ltd.
 08:F4:AB	Apple	Apple, Inc.
+08:F6:9C	Apple	Apple, Inc.
 08:F6:F8	GetEngin	GET Engineering
 08:F7:28	GloboMul	GLOBO Multimedia Sp. z o.o. Sp.k.
 08:FA:E0	FohhnAud	Fohhn Audio AG
@@ -17719,9 +17791,12 @@
 08:FD:0E	SamsungE	Samsung Electronics Co.,Ltd
 09:00:6A	AT&T
 0A:87:36	Ieee1901	IEEE 1901 Working Group
+0A:E4:71	Caterpil	Caterpillar Inc.
+0C:01:DB	InfinixM	Infinix mobility limited
 0C:02:27	Technico	Technicolor CH USA Inc.
 0C:04:00	JantarDO	Jantar d.o.o.
 0C:05:35	Juniper	Juniper Systems
+0C:08:B4	Humax	HUMAX Co., Ltd.
 0C:11:05	Ringslin	Ringslink (Xiamen) Network Communication Technologies Co., Ltd
 0C:11:67	Cisco	Cisco Systems, Inc
 0C:12:62	Zte	zte corporation
@@ -17732,16 +17807,21 @@
 0C:17:F1	Telecsys
 0C:19:1F	InformEl	Inform Electronik
 0C:1A:10	Acoustic	Acoustic Stream
+0C:1C:19	Longconn	LONGCONN ELECTRONICS(SHENZHEN) CO.,LTD
 0C:1C:20	Kakao	Kakao Corp
+0C:1C:57	TexasIns	Texas Instruments
 0C:1D:AF	XiaomiCo	Xiaomi Communications Co Ltd
 0C:1D:C2	SeahNetw	SeAH Networks
 0C:20:26	NoaxTech	noax Technologies AG
+0C:21:38	Hengstle	Hengstler GmbH
 0C:23:69	Honeywel	Honeywell SPS
 0C:25:76	Longchee	Longcheer Telecommunication Limited
 0C:27:24	Cisco	Cisco Systems, Inc
 0C:27:55	Valuable	Valuable Techologies Limited
 0C:2A:69	Electric	electric imp, incorporated
+0C:2A:86	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 0C:2A:E7	BeijingG	Beijing General Research Institute of Mining and Metallurgy
+0C:2C:54	HuaweiTe	Huawei Technologies Co.,Ltd
 0C:2D:89	QiiqComm	QiiQ Communications Inc.
 0C:30:21	Apple	Apple, Inc.
 0C:37:47	Zte	zte corporation
@@ -17751,6 +17831,7 @@
 0C:3C:65	DomeImag	Dome Imaging Inc
 0C:3C:CD	Universa	Universal Global Scientific Industrial Co., Ltd.
 0C:3E:9F	Apple	Apple, Inc.
+0C:41:01	RuichiAu	Ruichi Auto Technology (Guangzhou) Co., Ltd.
 0C:41:3E	Microsof	Microsoft Corporation
 0C:41:E9	HuaweiTe	Huawei Technologies Co.,Ltd
 0C:45:BA	HuaweiTe	Huawei Technologies Co.,Ltd
@@ -17766,6 +17847,7 @@
 0C:51:01	Apple	Apple, Inc.
 0C:51:F7	ChauvinA	Chauvin Arnoux
 0C:52:03	AgmGroup	Agm Group Limited
+0C:53:31	EthZuric	ETH Zurich
 0C:54:15	IntelCor	Intel Corporate
 0C:54:A5	Pegatron	Pegatron Corporation
 0C:54:B9	Nokia
@@ -17781,21 +17863,43 @@
 0C:61:11	AndaTech	Anda Technologies SAC
 0C:61:27	Actionte	Actiontec Electronics, Inc
 0C:61:CF	TexasIns	Texas Instruments
+0C:62:A6	HuiZhouG	Hui Zhou Gaoshengda Technology Co.,LTD
 0C:63:FC	NanjingS	Nanjing Signway Technology Co., Ltd
 0C:68:03	Cisco	Cisco Systems, Inc
+0C:6A:BC	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 0C:6A:E6	StanleyS	Stanley Security Solutions
 0C:6E:4F	Primevol	PrimeVOLT Co., Ltd.
 0C:6F:9C	ShawComm	Shaw Communications Inc.
+0C:70:4A	HuaweiTe	Huawei Technologies Co.,Ltd
 0C:71:5D	SamsungE	Samsung Electronics Co.,Ltd
 0C:72:2C	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 0C:72:D9	Zte	zte corporation
 0C:73:BE	Dongguan	Dongguan Haimai Electronie Technology Co.,Ltd
+0C:73:EB	IeeeRegi	IEEE Registration Authority
+0C:73:EB:00:00:00/28	GeminiDa	Gemini Data Loggers (UK) Limited
+0C:73:EB:10:00:00/28	EversecT	Eversec Technology Corporation
+0C:73:EB:20:00:00/28	Deltapat	Deltapath, Inc.
+0C:73:EB:30:00:00/28	TiinlabA	Tiinlab Acoustic Technology (Shenzhen) Co., Ltd.
+0C:73:EB:40:00:00/28	U-Pass	U-PASS.CO.,LTD
+0C:73:EB:50:00:00/28	HustyMSt	Husty M.Styczen J.Hupert Sp.J.
+0C:73:EB:60:00:00/28	GreenFox	Green Fox Electro AS
+0C:73:EB:70:00:00/28	DinkleEn	Dinkle Enterprise Co., Ltd.
+0C:73:EB:80:00:00/28	BeijingM	Beijing Miiiw Technology Co., Ltd
+0C:73:EB:90:00:00/28	BeijingL	Beijing L&S Lancom Platform Tech. Co., Ltd.
+0C:73:EB:A0:00:00/28	PiInnovo	Pi Innovo LLC
+0C:73:EB:B0:00:00/28	Synacces	Synaccess Networks
+0C:73:EB:C0:00:00/28	Shenzhen	Shenzhen Samchung Video Technology Co., Ltd.
+0C:73:EB:D0:00:00/28	D-Link（S	D-Link （Shanghai）Limited Corp.
+0C:73:EB:E0:00:00/28	TaiwanPu	Taiwan Pulse Motion Co., Ltd.
 0C:74:C2	Apple	Apple, Inc.
+0C:75:12	Shenzhen	Shenzhen Kunlun TongTai Technology  Co.,Ltd.
 0C:75:23	BeijingG	Beijing Gehua Catv Network Co.,Ltd
 0C:75:6C	AnarenMi	Anaren Microwave, Inc.
 0C:75:BD	Cisco	Cisco Systems, Inc
 0C:77:1A	Apple	Apple, Inc.
+0C:7C:28	Nokia
 0C:7D:7C	KexiangI	Kexiang Information Technology Co, Ltd.
+0C:80:63	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 0C:81:12	Private
 0C:82:30	Shenzhen	Shenzhen Magnus Technologies Co.,Ltd
 0C:82:68	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
@@ -17809,6 +17913,7 @@
 0C:8A:87	Aglogica	AgLogica Holdings, Inc
 0C:8B:D3	ItelMobi	Itel Mobile Limited
 0C:8B:FD	IntelCor	Intel Corporate
+0C:8C:24	Shenzhen	SHENZHEN BILIAN ELECTRONIC CO.，LTD
 0C:8C:8F	KamoTech	Kamo Technology Limited
 0C:8C:DC	SuuntoOy	Suunto Oy
 0C:8D:98	TopEight	Top Eight Ind Corp
@@ -17819,9 +17924,12 @@
 0C:93:01	PtPrasim	PT. Prasimax Inovasi Teknologi
 0C:93:FB	BnsSolut	BNS Solutions
 0C:96:BF	HuaweiTe	Huawei Technologies Co.,Ltd
+0C:96:E6	CloudNet	Cloud Network Technology (Samoa) Limited
 0C:98:38	XiaomiCo	Xiaomi Communications Co Ltd
+0C:9A:42	Fn-LinkT	FN-LINK TECHNOLOGY LIMITED
 0C:9B:13	Shanghai	Shanghai Magic Mobile Telecommunication Co.Ltd.
 0C:9D:56	ConsortC	Consort Controls Ltd
+0C:9D:92	AsustekC	ASUSTek COMPUTER INC.
 0C:9E:91	Sankosha	Sankosha Corporation
 0C:A1:38	BlinqWir	Blinq Wireless Inc.
 0C:A2:F4	Chameleo	Chameleon Technology (UK) Limited
@@ -17830,18 +17938,24 @@
 0C:A6:94	SunitecE	Sunitec Enterprise Co.,Ltd
 0C:A8:A7	SamsungE	Samsung Electronics Co.,Ltd
 0C:AC:05	UnitendT	Unitend Technologies Inc.
+0C:AE:7D	TexasIns	Texas Instruments
 0C:AF:5A	GenusPow	Genus Power Infrastructures Limited
 0C:B2:B7	TexasIns	Texas Instruments
 0C:B3:19	SamsungE	Samsung Electronics Co.,Ltd
+0C:B3:4F	Shenzhen	Shenzhen Xiaoqi Intelligent Technology Co., Ltd.
 0C:B4:59	Marketec	Marketech International Corp.
+0C:B4:A4	XintaiAu	Xintai Automobile Intelligent Network Technology
 0C:B4:EF	Digience	Digience Co.,Ltd.
+0C:B5:27	HuaweiTe	Huawei Technologies Co.,Ltd
 0C:B5:DE	AlcatelL	Alcatel Lucent
+0C:B6:D2	D-LinkIn	D-Link International
 0C:B9:12	Jm-Data	JM-DATA GmbH
 0C:B9:37	UbeeInte	Ubee Interactive Co., Limited
 0C:BC:9F	Apple	Apple, Inc.
 0C:BD:51	TctMobil	TCT mobile ltd
 0C:BF:15	Genetec	Genetec Inc.
 0C:BF:3F	Shenzhen	Shenzhen Lencotion Technology Co.,Ltd
+0C:BF:74	MorseMic	Morse Micro
 0C:C0:C0	MagnetiM	Magneti Marelli Sistemas Electronicos Mexico
 0C:C3:A7	Meritec
 0C:C4:7A	SuperMic	Super Micro Computer, Inc.
@@ -17853,6 +17967,7 @@
 0C:C7:31	Currant	Currant, Inc.
 0C:C8:1F	SummerIn	Summer Infant, Inc.
 0C:C9:C6	SamwinHo	Samwin Hong Kong Limited
+0C:CB:85	Motorola	Motorola Mobility LLC, a Lenovo Company
 0C:CB:8D	AscoNuma	ASCO Numatics GmbH
 0C:CC:26	Airenetw	Airenetworks
 0C:CD:D3	Eastrive	Eastriver Technology Co., Ltd.
@@ -17873,6 +17988,7 @@
 0C:DC:CC	InalaTec	Inala Technologies
 0C:DD:EF	Nokia	Nokia Corporation
 0C:DF:A4	SamsungE	Samsung Electronics Co.,Ltd
+0C:E0:DC	SamsungE	Samsung Electronics Co.,Ltd
 0C:E0:E4	Plantron	Plantronics, Inc.
 0C:E5:D3	DhElectr	DH electronics GmbH
 0C:E7:09	FoxCrypt	Fox Crypto B.V.
@@ -17901,6 +18017,7 @@
 0C:EF:AF:F0:00:00/28	Private
 0C:F0:19	MalgnTec	Malgn Technology Co., Ltd.
 0C:F0:B4	Globalsa	Globalsat International Technology Ltd
+0C:F3:46	XiaomiCo	Xiaomi Communications Co Ltd
 0C:F3:61	JavaInfo	Java Information
 0C:F3:EE	EmMicroe	EM Microelectronic
 0C:F4:05	BeijingS	Beijing Signalway Technologies Co.,Ltd
@@ -17955,12 +18072,13 @@
 10:12:18	Korins	Korins Inc.
 10:12:48	Itg	ITG, Inc.
 10:12:50	Integrat	Integrated Device Technology (Malaysia) Sdn. Bhd.
+10:12:B4	SichuanT	Sichuan Tianyi Comheart Telecom Co.,Ltd
 10:13:31	Technico	Technicolor
 10:13:EE	JustecIn	Justec International Technology INC.
 10:18:9E	ElmoMoti	Elmo Motion Control
 10:1B:54	HuaweiTe	Huawei Technologies Co.,Ltd
 10:1C:0C	Apple	Apple, Inc.
-10:1D:51	8meshNet	8Mesh Networks
+10:1D:51	8meshNet	8Mesh Networks Limited
 10:1D:C0	SamsungE	Samsung Electronics Co.,Ltd
 10:1F:74	HewlettP	Hewlett Packard
 10:22:79	Zerodesk	ZeroDesktop, Inc.
@@ -17998,7 +18116,9 @@
 10:56:11	ArrisGro	ARRIS Group, Inc.
 10:56:CA	PeplinkI	Peplink International Ltd.
 10:58:87	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
+10:59:17	Tonal
 10:5A:F7	AdbItali	ADB Italia
+10:5B:AD	MegaWell	Mega Well Limited
 10:5C:3B	Perma-Pi	Perma-Pipe, Inc.
 10:5C:BF	Durobyte	DuroByte Inc
 10:5F:06	Actionte	Actiontec Electronics, Inc
@@ -18006,8 +18126,10 @@
 10:60:4B	HewlettP	Hewlett Packard
 10:62:C9	Adatis	Adatis GmbH & Co. KG
 10:62:D0	Technico	Technicolor CH USA Inc.
+10:62:E5	HewlettP	Hewlett Packard
 10:62:EB	D-LinkIn	D-Link International
 10:64:E2	AdfwebCo	ADFweb.com s.r.l.
+10:65:30	Dell	Dell Inc.
 10:65:A3	CoreBran	Core Brands LLC
 10:65:CF	Iqsim
 10:66:82	NecPlatf	NEC Platforms, Ltd.
@@ -18025,22 +18147,28 @@
 10:78:D2	Elitegro	Elitegroup Computer Systems Co.,Ltd.
 10:7A:86	U&UEngin	U&U ENGINEERING INC.
 10:7B:44	AsustekC	ASUSTek COMPUTER INC.
+10:7B:A4	OliveDov	Olive & Dove Co.,Ltd.
 10:7B:EF	ZyxelCom	Zyxel Communications Corporation
 10:7D:1A	Dell	Dell Inc.
+10:81:B4	HunanGre	Hunan Greatwall Galaxy Science and Technology Co.,Ltd.
 10:83:D2	Microsev	Microseven Systems, LLC
 10:86:8C	ArrisGro	ARRIS Group, Inc.
 10:88:0F	DarumaTe	Daruma Telecomunicações e Informática S.A.
 10:88:CE	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 10:8A:1B	Raonix	RAONIX Inc.
 10:8C:CF	Cisco	Cisco Systems, Inc
+10:8E:E0	SamsungE	Samsung Electronics Co.,Ltd
 10:92:66	SamsungE	Samsung Electronics Co.,Ltd
 10:93:E9	Apple	Apple, Inc.
+10:94:BB	Apple	Apple, Inc.
 10:95:4B	Megabyte	Megabyte Ltd.
 10:98:36	Dell	Dell Inc.
+10:98:C3	MurataMa	Murata Manufacturing Co., Ltd.
 10:9A:B9	TosiboxO	Tosibox Oy
 10:9A:DD	Apple	Apple, Inc.
 10:9F:A9	Actionte	Actiontec Electronics, Inc
 10:A1:3B	Fujikura	Fujikura Rubber Ltd.
+10:A2:4E	Gold3lin	GOLD3LINK ELECTRONICS CO., LTD
 10:A4:B9	BaiduOnl	Baidu Online Network Technology (Beijing) Co., Ltd
 10:A4:BE	Shenzhen	SHENZHEN BILIAN ELECTRONIC CO.，LTD
 10:A5:D0	MurataMa	Murata Manufacturing Co., Ltd.
@@ -18051,8 +18179,10 @@
 10:AF:78	Shenzhen	Shenzhen ATUE Technology Co., Ltd
 10:B1:F8	HuaweiTe	Huawei Technologies Co.,Ltd
 10:B2:6B	Base	base Co.,Ltd.
+10:B3:6F	BoweiTec	Bowei Technology Company Limited
 10:B7:13	Private
 10:B7:F6	Plastofo	Plastoform Industries Ltd.
+10:B9:F7	Niko-Ser	Niko-Servodan
 10:B9:FE	LikaSrl	Lika srl
 10:BA:A5	GanaI&C	GANA I&C CO., LTD
 10:BD:18	Cisco	Cisco Systems, Inc
@@ -18060,6 +18190,8 @@
 10:BE:F5	D-LinkIn	D-Link International
 10:BF:48	AsustekC	ASUSTek COMPUTER INC.
 10:C0:7C	Blu-RayD	Blu-ray Disc Association
+10:C1:72	HuaweiTe	Huawei Technologies Co.,Ltd
+10:C2:2F	ChinaEnt	China Entropy Co., Ltd.
 10:C2:5A	Technico	Technicolor CH USA Inc.
 10:C2:BA	Utt	UTT Co., Ltd.
 10:C3:7B	AsustekC	ASUSTek COMPUTER INC.
@@ -18069,6 +18201,7 @@
 10:C6:7E	Shenzhen	Shenzhen Juchin Technology Co., Ltd
 10:C6:FC	GarminIn	Garmin International
 10:C7:3F	MidasKla	Midas Klark Teknik Ltd
+10:C7:53	QingdaoI	Qingdao Intelligent&Precise Electronics Co.,Ltd.
 10:CA:81	Precia
 10:CC:1B	Liverock	Liverock technologies,INC
 10:CC:DB	AximumPr	Aximum Produits Electroniques
@@ -18086,11 +18219,13 @@
 10:DD:F4	MaxwayEl	Maxway Electronics CO.,LTD
 10:DE:E4	Automati	automationNEXT GmbH
 10:DF:8B	Shenzhen	Shenzhen CareDear Communication Technology Co.,Ltd
+10:DF:FC	Siemens	Siemens AG
 10:E2:D5	QiHardwa	Qi Hardware Inc.
 10:E3:C7	SeohwaTe	Seohwa Telecom
 10:E4:AF	AprLlc	Apr, Llc
 10:E6:8F	Kwangsun	Kwangsung Electronics Korea Co.,Ltd.
 10:E6:AE	SourceTe	Source Technologies, LLC
+10:E7:C6	HewlettP	Hewlett Packard
 10:E8:78	Nokia
 10:E8:EE	Phasespa	PhaseSpace
 10:EA:59	CiscoSpv	Cisco SPVTG
@@ -18103,6 +18238,7 @@
 10:F4:9A	T3Innova	T3 Innovation
 10:F6:81	VivoMobi	vivo Mobile Communication Co., Ltd.
 10:F9:6F	LgElectr	LG Electronics (Mobile Communications)
+10:F9:EB	Industri	Industria Fueguina de Relojería Electrónica s.a.
 10:F9:EE	Nokia	Nokia Corporation
 10:FA:CE	Reacheng	Reacheng Communication Technology Co.,Ltd
 10:FB:F0	Kangshen	KangSheng LTD.
@@ -18115,15 +18251,18 @@
 14:04:67	SnkTechn	SNK Technologies Co.,Ltd.
 14:07:08	Private
 14:07:E0	Abrantix	Abrantix AG
+14:09:DC	HuaweiTe	Huawei Technologies Co.,Ltd
 14:0C:5B	Plnetwor	PLNetworks
 14:0C:76	FreeboxS	Freebox Sas
 14:0D:4F	Flextron	Flextronics International
 14:10:9F	Apple	Apple, Inc.
+14:11:14	TecnoMob	Tecno Mobile Limited
 14:13:30	Anakreon	Anakreon UK LLP
 14:13:57	AtpElect	ATP Electronics, Inc.
 14:14:4B	RuijieNe	Ruijie Networks Co.,LTD
 14:14:E6	NingboSa	Ningbo Sanhe Digital Co.,Ltd
 14:15:7C	TokyoCos	Tokyo Cosmos Electric Co.,Ltd.
+14:16:9E	Wingtech	Wingtech Group (HongKong）Limited
 14:18:77	Dell	Dell Inc.
 14:1A:51	Treetech	Treetech Sistemas Digitais
 14:1A:A3	Motorola	Motorola Mobility LLC, a Lenovo Company
@@ -18147,6 +18286,8 @@
 14:1F:BA:D0:00:00/28	AjisDali	AJIS(DALIAN)co.,LTD
 14:1F:BA:E0:00:00/28	PosSyste	POS Systema LLC
 14:1F:BA:F0:00:00/28	Private
+14:20:5E	Apple	Apple, Inc.
+14:22:33	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 14:22:DB	Eero	eero inc.
 14:23:D7	Eutronix	Eutronix Co., Ltd.
 14:28:82	MidicomE	Midicom Electronics Co.Ltd
@@ -18166,6 +18307,7 @@
 14:35:B3	FutureDe	Future Designs, Inc.
 14:36:05	Nokia	Nokia Corporation
 14:36:C6	LenovoMo	Lenovo Mobile Communication Technology Ltd.
+14:37:19	PtPrakar	PT Prakarsa Visi Valutama
 14:37:3B	Procom	PROCOM Systems
 14:3A:EA	Dynapowe	Dynapower Company LLC
 14:3D:F2	BeijingS	Beijing Shidai Hongyuan Network Communication Co.,Ltd
@@ -18177,11 +18319,14 @@
 14:43:19	Creative	Creative&Link Technology Limited
 14:44:4A	ApolloSe	Apollo Seiko Ltd.
 14:46:E4	Avistel
+14:48:02	Yeolrim	THE YEOLRIM Co.,Ltd.
 14:48:8B	Shenzhen	Shenzhen Doov Technology Co.,Ltd
 14:49:78	DigitalC	Digital Control Incorporated
 14:49:E0	SamsungE	SAMSUNG ELECTRO-MECHANICS(THAILAND)
 14:4C:1A	MaxCommu	Max Communication GmbH
 14:4D:67	ZioncomE	Zioncom Electronics (Shenzhen) Ltd.
+14:4E:34	RemoteSo	Remote Solution
+14:4F:8A	IntelCor	Intel Corporate
 14:4F:D7	IeeeRegi	IEEE Registration Authority
 14:4F:D7:00:00:00/28	Annapurn	annapurnalabs
 14:4F:D7:10:00:00/28	ZehnderG	Zehnder Group AG
@@ -18201,7 +18346,9 @@
 14:54:12	Entis	Entis Co., Ltd.
 14:56:45	Savitech	Savitech Corp.
 14:56:8E	SamsungE	Samsung Electronics Co.,Ltd
+14:57:9F	HuaweiTe	Huawei Technologies Co.,Ltd
 14:58:D0	HewlettP	Hewlett Packard
+14:59:C0	Netgear
 14:5A:05	Apple	Apple, Inc.
 14:5A:83	Logi-D	Logi-D inc
 14:5B:D1	ArrisGro	ARRIS Group, Inc.
@@ -18212,8 +18359,10 @@
 14:61:02	AlpineEl	Alpine Electronics, Inc.
 14:61:2F	Avaya	Avaya Inc
 14:63:08	JabilCir	JABIL CIRCUIT (SHANGHAI) LTD.
+14:69:A2	SichuanT	Sichuan Tianyi Comheart Telecom Co.,Ltd
 14:6A:0B	CypressE	Cypress Electronics Limited
 14:6B:72	Shenzhen	Shenzhen Fortune Ship Technology Co., Ltd.
+14:6B:9C	Shenzhen	SHENZHEN BILIAN ELECTRONIC CO.，LTD
 14:6E:0A	Private
 14:73:73	TubitakU	Tubitak Uekae
 14:74:11	Rim
@@ -18233,10 +18382,13 @@
 14:90:90	KongtopI	KongTop industrial(shen zhen)CO.,LTD
 14:91:82	BelkinIn	Belkin International Inc.
 14:93:46	PniSenso	PNI sensor corporation
+14:94:2F	Usys	Usys Co.,Ltd.
 14:94:48	BluCastl	Blu Castle S.A.
+14:96:E5	SamsungE	Samsung Electronics Co.,Ltd
 14:98:7D	Technico	Technicolor CH USA Inc.
 14:99:E2	Apple	Apple, Inc.
 14:9A:10	Microsof	Microsoft Corporation
+14:9B:2F	JiangsuZ	JiangSu ZhongXie Intelligent Technology co., LTD
 14:9D:09	HuaweiTe	Huawei Technologies Co.,Ltd
 14:9E:CF	Dell	Dell Inc.
 14:9F:3C	SamsungE	Samsung Electronics Co.,Ltd
@@ -18246,6 +18398,7 @@
 14:A3:64	SamsungE	Samsung Electronics Co.,Ltd
 14:A5:1A	HuaweiTe	Huawei Technologies Co.,Ltd
 14:A6:2C	SMDezacS	S.M. Dezac S.A.
+14:A7:2B	Currento	currentoptronics Pvt.Ltd
 14:A7:8B	Zhejiang	Zhejiang Dahua Technology Co., Ltd.
 14:A8:6B	Shenzhen	ShenZhen Telacom Science&Technology Co., Ltd
 14:A9:E3	Mst	Mst Corporation
@@ -18266,14 +18419,18 @@
 14:C0:89	DuneHd	Dune Hd Ltd
 14:C1:26	Nokia	Nokia Corporation
 14:C1:FF	Shenzhen	ShenZhen QianHai Comlan communication Co.,LTD
+14:C2:13	Apple	Apple, Inc.
 14:C2:1D	SabtechI	Sabtech Industries
 14:C3:C2	KASchmer	K.A. Schmersal GmbH & Co. KG
+14:C6:97	Guangdon	Guangdong Oppo Mobile Telecommunications Corp.,Ltd
 14:C9:13	LgElectr	LG Electronics
+14:CA:A0	Hu&Co
 14:CC:20	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 14:CF:8D	Ohsung
 14:CF:92	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 14:CF:E2	ArrisGro	ARRIS Group, Inc.
 14:D1:1F	HuaweiTe	Huawei Technologies Co.,Ltd
+14:D1:69	HuaweiTe	Huawei Technologies Co.,Ltd
 14:D4:FE	ArrisGro	ARRIS Group, Inc.
 14:D6:4D	D-LinkIn	D-Link International
 14:D7:6E	ConchEle	CONCH ELECTRONIC Co.,Ltd
@@ -18284,11 +18441,13 @@
 14:E4:EC	MlogicLl	mLogic LLC
 14:E6:E4	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 14:E7:C8	Integrat	Integrated Device Technology (Malaysia) Sdn. Bhd.
+14:E9:B2	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 14:EB:33	Bsmedias	BSMediasoft Co., Ltd.
 14:ED:A5	Wächter	Wächter GmbH Sicherheitssysteme
 14:ED:BB	2wire	2Wire Inc
 14:ED:E4	Kaiam	Kaiam Corporation
 14:EE:9D	AirnavLl	AirNav Systems LLC
+14:EF:CF	Schreder
 14:F0:C5	Xtremio	Xtremio Ltd.
 14:F2:8E	Shenyang	ShenYang ZhongKe-Allwin Technology Co.LTD
 14:F4:2A	SamsungE	Samsung Electronics Co.,Ltd
@@ -18296,18 +18455,21 @@
 14:F8:93	WuhanFib	Wuhan FiberHome Digital Technology Co.,Ltd.
 14:FE:AF	Sagittar	Sagittar Limited
 14:FE:B5	Dell	Dell Inc.
-18:00:2D	SonyMobi	Sony Mobile Communications AB
+18:00:2D	SonyMobi	Sony Mobile Communications Inc
 18:00:DB	Fitbit	Fitbit Inc.
 18:01:7D	HarbinAr	Harbin Arteor technology co., LTD
 18:01:E3	BittiumW	Bittium Wireless Ltd
+18:01:F1	XiaomiCo	Xiaomi Communications Co Ltd
 18:03:73	Dell	Dell Inc.
 18:03:FA	IbtInter	IBT Interfaces
+18:04:ED	TexasIns	Texas Instruments
 18:06:75	DilaxInt	Dilax Intelcom GmbH
 18:06:FF	AcerComp	Acer Computer(Shanghai) Limited.
 18:0B:52	Nanotron	Nanotron Technologies GmbH
 18:0C:14	Isonea	iSonea Limited
 18:0C:77	Westingh	Westinghouse Electric Company, LLC
 18:0C:AC	Canon	Canon Inc.
+18:0F:76	D-LinkIn	D-Link International
 18:10:4E	Cedint-U	CEDINT-UPM
 18:12:12	CeptonTe	Cepton Technologies
 18:14:20	TebSas	Teb Sas
@@ -18317,6 +18479,7 @@
 18:17:25	CameoCom	Cameo Communications, Inc.
 18:19:3F	TamtronO	Tamtron Oy
 18:1B:EB	Actionte	Actiontec Electronics, Inc
+18:1D:EA	IntelCor	Intel Corporate
 18:1E:78	Sagemcom	Sagemcom Broadband SAS
 18:1E:B0	SamsungE	Samsung Electronics Co.,Ltd
 18:20:12	AztechAs	Aztech Associates Inc.
@@ -18333,6 +18496,7 @@
 18:2C:B4	Nectarso	Nectarsoft Co., Ltd.
 18:2D:98	JinwooIn	Jinwoo Industrial system
 18:30:09	WoojinIn	Woojin Industrial Systems Co., Ltd.
+18:31:BF	AsustekC	ASUSTek COMPUTER INC.
 18:32:A2	LaonTech	Laon Technology Co., Ltd.
 18:33:9D	Cisco	Cisco Systems, Inc
 18:34:51	Apple	Apple, Inc.
@@ -18340,9 +18504,11 @@
 18:36:FC	ElecsysI	Elecsys International Corporation
 18:38:25	WuhanLin	Wuhan Lingjiu High-tech Co.,Ltd.
 18:38:64	Cap-Tech	CAP-TECH INTERNATIONAL CO., LTD.
+18:38:AE	ConspinS	Conspin Solution
 18:39:19	Unicoi	Unicoi Systems
 18:39:6E	SunseaTe	Sunsea Telecommunications Co.,Ltd.
 18:3A:2D	SamsungE	Samsung Electronics Co.,Ltd
+18:3A:48	Vostrone	VostroNet
 18:3B:D2	BydPreci	BYD Precision Manufacture Company Ltd.
 18:3D:A2	IntelCor	Intel Corporate
 18:3F:47	SamsungE	Samsung Electronics Co.,Ltd
@@ -18354,13 +18520,17 @@
 18:46:17	SamsungE	Samsung Electronics Co.,Ltd
 18:48:D8	Fastback	Fastback Networks
 18:4A:6F	Alcatel-	Alcatel-Lucent Shanghai Bell Co., Ltd
+18:4B:0D	RuckusWi	Ruckus Wireless
+18:4C:08	Rockwell	Rockwell Automation
 18:4E:94	MessoaTe	Messoa Technologies Inc.
 18:4F:32	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
+18:50:2A	Soarnex
 18:52:07	SichuanT	Sichuan Tianyi Comheart Telecomco., Ltd
 18:52:53	Pixord	Pixord Corporation
 18:52:82	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 18:53:E0	HanyangD	Hanyang Digitech Co.Ltd
 18:55:0F	CiscoSpv	Cisco SPVTG
+18:56:80	IntelCor	Intel Corporate
 18:59:33	CiscoSpv	Cisco SPVTG
 18:59:36	XiaomiCo	Xiaomi Communications Co Ltd
 18:5A:E8	Zenotech	Zenotech.Co.,Ltd
@@ -18369,9 +18539,11 @@
 18:60:24	HewlettP	Hewlett Packard
 18:61:C7	Lemonbea	lemonbeat GmbH
 18:62:2C	Sagemcom	Sagemcom Broadband SAS
+18:62:E4	TexasIns	Texas Instruments
 18:64:72	ArubaNet	Aruba Networks
 18:65:71	TopVicto	Top Victory Electronics (Taiwan) Co., Ltd.
 18:65:90	Apple	Apple, Inc.
+18:66:C7	Shenzhen	Shenzhen Libre Technology Co., Ltd
 18:66:DA	Dell	Dell Inc.
 18:66:E3	Veros	Veros Systems, Inc.
 18:67:3F	HanoverD	Hanover Displays Limited
@@ -18380,6 +18552,7 @@
 18:68:6A	Zte	zte corporation
 18:68:82	BewardR&	Beward R&D Co., Ltd.
 18:68:CB	Hangzhou	Hangzhou Hikvision Digital Technology Co.,Ltd.
+18:69:DA	ChinaMob	China Mobile Group Device Co.,Ltd.
 18:6D:99	Adanis	Adanis Inc.
 18:71:17	EtaPlusE	eta plus electronic gmbh
 18:74:2E	AmazonTe	Amazon Technologies Inc.
@@ -18391,6 +18564,7 @@
 18:80:90	Cisco	Cisco Systems, Inc
 18:80:CE	Barberry	Barberry Solutions Ltd
 18:80:F5	Alcatel-	Alcatel-Lucent Shanghai Bell Co., Ltd
+18:81:0E	Apple	Apple, Inc.
 18:82:19	AlibabaC	Alibaba Cloud Computing Ltd.
 18:83:31	SamsungE	Samsung Electronics Co.,Ltd
 18:83:BF	Arcadyan	Arcadyan Technology Corporation
@@ -18400,6 +18574,7 @@
 18:87:96	Htc	HTC Corporation
 18:88:57	BeijingJ	Beijing Jinhong Xi-Dian Information Technology Corp.
 18:89:5B	SamsungE	Samsung Electronics Co.,Ltd
+18:89:A0	WuhanFun	Wuhan Funshion Online Technologies Co.,Ltd
 18:89:DF	Cerebrex	CerebrEX Inc.
 18:8B:15	Shenzhen	ShenZhen ZhongRuiJing Technology co.,LTD
 18:8B:45	Cisco	Cisco Systems, Inc
@@ -18408,7 +18583,9 @@
 18:8E:F9	G2c	G2C Co. Ltd.
 18:90:D8	Sagemcom	Sagemcom Broadband SAS
 18:92:2C	VirtualI	Virtual Instruments
+18:93:7F	AmpakTec	AMPAK Technology, Inc.
 18:93:D7	TexasIns	Texas Instruments
+18:94:C6	Shenzhen	ShenZhen Chenyee Technology Co., Ltd.
 18:97:FF	Techfait	TechFaith Wireless Technology Limited
 18:99:F5	SichuanC	Sichuan Changhong Electric Ltd.
 18:9A:67	Cse-Serv	CSE-Servelec Limited
@@ -18428,16 +18605,19 @@
 18:9B:A5:C0:00:00/28	ChristEl	Christ Electronic System GmbH
 18:9B:A5:D0:00:00/28	Legendsk	legendsky tech
 18:9B:A5:E0:00:00/28	TaiwanNa	Taiwan Name Plate Co.,LTD
+18:9C:27	ArrisGro	ARRIS Group, Inc.
 18:9C:5D	Cisco	Cisco Systems, Inc
 18:9E:FC	Apple	Apple, Inc.
 18:A2:8A	Essel-T	Essel-T Co., Ltd
 18:A3:E8	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 18:A6:F7	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
+18:A7:F1	QingdaoH	Qingdao Haier Technology Co.,Ltd
 18:A9:05	HewlettP	Hewlett Packard
 18:A9:58	Provisio	Provision Thai Co., Ltd.
 18:A9:9B	Dell	Dell Inc.
 18:AA:45	FonTechn	Fon Technology
 18:AB:F5	UltraEle	Ultra Electronics Electrics
+18:AC:9E	ItelMobi	Itel Mobile Limited
 18:AD:4D	Polostar	Polostar Technology Corporation
 18:AE:BB	SiemensC	Siemens Convergence Creators GmbH&Co.KG
 18:AF:61	Apple	Apple, Inc.
@@ -18452,8 +18632,10 @@
 18:B8:1F	ArrisGro	ARRIS Group, Inc.
 18:BC:5A	Zhejiang	Zhejiang Tmall Technology Co., Ltd.
 18:BD:AD	L-Tech	L-TECH CORPORATION
+18:BE:92	DeltaNet	Delta Networks, Inc.
 18:C0:86	Broadcom
 18:C1:9D	Integrat	Integrated Device Technology (Malaysia) Sdn. Bhd.
+18:C2:BF	Buffalo	Buffalo.Inc
 18:C4:51	TucsonEm	Tucson Embedded Systems
 18:C5:01	Shenzhen	Shenzhen Gongjin Electronics Co.,Lt
 18:C5:8A	HuaweiTe	Huawei Technologies Co.,Ltd
@@ -18468,6 +18650,7 @@
 18:D6:6A	Inmarsat
 18:D6:C7	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 18:D6:CF	KurthEle	Kurth Electronic GmbH
+18:D7:17	Guangdon	Guangdong Oppo Mobile Telecommunications Corp.,Ltd
 18:D9:49	QvisLabs	Qvis Labs, LLC
 18:DB:F2	Dell	Dell Inc.
 18:DC:56	YulongCo	Yulong Computer Telecommunication Scientific (Shenzhen) Co.,Ltd
@@ -18479,11 +18662,13 @@
 18:E7:28	Cisco	Cisco Systems, Inc
 18:E7:F4	Apple	Apple, Inc.
 18:E8:0F	VikingEl	Viking Electronics Inc.
+18:E8:29	Ubiquiti	Ubiquiti Networks Inc.
 18:E8:DD	Modulete	Moduletek
 18:EE:69	Apple	Apple, Inc.
 18:EF:63	Cisco	Cisco Systems, Inc
 18:F0:E4	XiaomiCo	Xiaomi Communications Co Ltd
 18:F1:45	NetcommW	NetComm Wireless Limited
+18:F1:D8	Apple	Apple, Inc.
 18:F2:92	Shannon	Shannon Systems
 18:F4:6A	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 18:F6:43	Apple	Apple, Inc.
@@ -18497,6 +18682,7 @@
 18:FF:0F	IntelCor	Intel Corporate
 18:FF:2E	Shenzhen	Shenzhen Rui Ying Da Technology Co., Ltd
 1A:75:FB	Autosar
+1C:00:42	NariTech	NARI Technology Co., Ltd.
 1C:06:56	Idy	IDY Corporation
 1C:08:C1	LgInnote	Lg Innotek
 1C:0B:52	EpicomSA	Epicom S.A
@@ -18514,6 +18700,7 @@
 1C:1A:C0	Apple	Apple, Inc.
 1C:1B:0D	Giga-Byt	GIGA-BYTE TECHNOLOGY CO.,LTD.
 1C:1B:68	ArrisGro	ARRIS Group, Inc.
+1C:1B:B5	IntelCor	Intel Corporate
 1C:1C:FD	DalianHi	Dalian Hi-Think Computer Technology, Corp
 1C:1D:67	HuaweiTe	Huawei Technologies Co.,Ltd
 1C:1D:86	Cisco	Cisco Systems, Inc
@@ -18538,6 +18725,7 @@
 1C:21:D1:F0:00:00/28	Private
 1C:23:2C	SamsungE	Samsung Electronics Co.,Ltd
 1C:23:4F	EdmiEuro	EDMI  Europe Ltd
+1C:24:CD	AskeyCom	Askey Computer Corp.
 1C:25:E1	ChinaMob	China Mobile IOT Company Limited
 1C:27:DD	DatangGo	Datang Gohighsec(zhejiang)Information Technology Co.,Ltd.
 1C:33:0E	Pernixda	PernixData
@@ -18555,6 +18743,7 @@
 1C:40:24	Dell	Dell Inc.
 1C:40:E8	Shenzhen	SHENZHEN PROGRESS&WIN TECHNOLOGY CO.,LTD
 1C:41:58	GemaltoM	Gemalto M2M GmbH
+1C:42:7D	Guangdon	Guangdong Oppo Mobile Telecommunications Corp.,Ltd
 1C:43:EC	JapanCir	Japan Circuit Co.,Ltd
 1C:44:19	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 1C:45:93	TexasIns	Texas Instruments
@@ -18572,6 +18761,7 @@
 1C:55:3A	Qiangua	QianGua Corp.
 1C:56:FE	Motorola	Motorola Mobility LLC, a Lenovo Company
 1C:57:D8	Kraftway	Kraftway Corporation PLC
+1C:59:9B	HuaweiTe	Huawei Technologies Co.,Ltd
 1C:5A:0B	Tegile	Tegile Systems
 1C:5A:3E	SamsungE	Samsung Electronics Co.,Ltd
 1C:5A:6B	PhilipsE	Philips Electronics Nederland BV
@@ -18580,7 +18770,7 @@
 1C:5C:F2	Apple	Apple, Inc.
 1C:5F:2B	D-LinkIn	D-Link International
 1C:5F:FF	BeijingE	Beijing Ereneben Information Technology Co.,Ltd Shenzhen Branch
-1C:60:DE	Shenzhen	Shenzhen Mercury Communication Technologies Co.,Ltd.
+1C:60:DE	MercuryC	Mercury Communication Technologies Co.,Ltd.
 1C:62:B8	SamsungE	Samsung Electronics Co.,Ltd
 1C:63:B7	Openprod	OpenProducts 237 AB
 1C:65:9D	LiteonTe	Liteon Technology Corporation
@@ -18601,7 +18791,7 @@
 1C:76:CA	TerasicT	Terasic Technologies Inc.
 1C:77:F6	Guangdon	Guangdong Oppo Mobile Telecommunications Corp.,Ltd
 1C:78:39	Shenzhen	Shenzhen Tencent Computer System Co., Ltd.
-1C:7B:21	SonyMobi	Sony Mobile Communications AB
+1C:7B:21	SonyMobi	Sony Mobile Communications Inc
 1C:7B:23	QingdaoH	Qingdao Hisense Communications Co.,Ltd.
 1C:7C:11	Eid
 1C:7C:45	VitekInd	Vitek Industrial Video Products, Inc.
@@ -18682,7 +18872,7 @@
 1C:94:92	RuagSchw	RUAG Schweiz AG
 1C:95:5D	I-LaxEle	I-LAX ELECTRONICS INC.
 1C:95:9F	Veethree	Veethree Electronics And Marine LLC
-1C:96:5A	WeifangG	Weifang GoerTek Technology Co.,Ltd.
+1C:96:5A	WeifangG	Weifang Goertek Electronics Co.,Ltd
 1C:97:3D	PricomDe	PRICOM Design
 1C:98:EC	HewlettP	Hewlett Packard Enterprise
 1C:99:4C	MurataMa	Murata Manufacturing Co., Ltd.
@@ -18718,6 +18908,7 @@
 1C:AD:D1	BosungEl	Bosung Electronics Co., Ltd.
 1C:AF:05	SamsungE	Samsung Electronics Co.,Ltd
 1C:AF:F7	D-LinkIn	D-Link International
+1C:B0:44	AskeyCom	Askey Computer Corp
 1C:B0:94	Htc	HTC Corporation
 1C:B1:7F	NecPlatf	NEC Platforms, Ltd.
 1C:B2:43	Tdc	TDC A/S
@@ -18748,6 +18939,7 @@
 1C:C1:1A	Wavetron	Wavetronix
 1C:C1:DE	HewlettP	Hewlett Packard
 1C:C3:16	Milesigh	MileSight Technology Co., Ltd.
+1C:C3:EB	Guangdon	Guangdong Oppo Mobile Telecommunications Corp.,Ltd
 1C:C5:86	Absolute	Absolute Acoustics
 1C:C6:3C	Arcadyan	Arcadyan Technology Corporation
 1C:C7:2D	Shenzhen	Shenzhen Huapu Digital CO.,Ltd
@@ -18793,6 +18985,22 @@
 1C:F5:E7	TurtleIn	Turtle Industry Co., Ltd.
 1C:FA:68	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 1C:FC:BB	Realfict	Realfiction ApS
+1C:FD:08	IeeeRegi	IEEE Registration Authority
+1C:FD:08:00:00:00/28	InseatSo	InSeat Solutions, LLC
+1C:FD:08:10:00:00/28	Shenzhen	Shenzhen SEWO Technology Co.,Ltd.
+1C:FD:08:20:00:00/28	Hihi	HiHi Ltd
+1C:FD:08:30:00:00/28	UmeoxInn	Umeox Innovations Co.,Ltd
+1C:FD:08:40:00:00/28	SabikOff	SABIK Offshore GmbH
+1C:FD:08:50:00:00/28	BeijingH	Beijing Hengxin Rainbow Information Technology Co.,Ltd
+1C:FD:08:60:00:00/28	A&BTechn	A&B Technology
+1C:FD:08:70:00:00/28	SunweitI	sunweit industrial limited
+1C:FD:08:80:00:00/28	Shenzhen	ShenZhen DeLippo Technology Co., LTD
+1C:FD:08:90:00:00/28	Label
+1C:FD:08:A0:00:00/28	BanmakTe	Banmak Technogies Co.,Ltd
+1C:FD:08:B0:00:00/28	Guangzho	guangzhou huiqun intelligent technology co. LTD
+1C:FD:08:C0:00:00/28	Shanghai	Shanghai YottaTech Co Ltd (上海尧它科技有限公司）
+1C:FD:08:D0:00:00/28	TianjinK	Tianjin Keyvia Electric Co.,Ltd
+1C:FD:08:E0:00:00/28	MeshboxF	Meshbox Foundation Pte. Ltd.
 1C:FE:A7	Identyte	IDentytech Solutins Ltd.
 20:01:4F	LineaRes	Linea Research Ltd
 20:02:AF	MurataMa	Murata Manufacturing Co., Ltd.
@@ -18804,37 +19012,46 @@
 20:0B:C7	HuaweiTe	Huawei Technologies Co.,Ltd
 20:0C:C8	Netgear
 20:0E:95	Iec–Tc9W	IEC – TC9 WG43
+20:0F:70	Foxtech
 20:10:7A	GemtekTe	Gemtek Technology Co., Ltd.
 20:12:57	MostLuck	Most Lucky Trading Ltd
 20:12:D5	Scientec	Scientech Materials Corporation
 20:13:E0	SamsungE	Samsung Electronics Co.,Ltd
+20:16:3D	Integrat	Integrated Device Technology (Malaysia) Sdn. Bhd.
+20:16:B9	IntelCor	Intel Corporate
 20:16:D8	LiteonTe	Liteon Technology Corporation
 20:18:0E	Shenzhen	Shenzhen Sunchip Technology Co., Ltd
 20:1A:06	CompalIn	COMPAL INFORMATION (KUNSHAN) CO., LTD.
 20:1D:03	Elatec	Elatec GmbH
+20:1F:31	IntenoBr	Inteno Broadband Technology AB
 20:21:A5	LgElectr	LG Electronics (Mobile Communications)
 20:25:64	Pegatron	Pegatron Corporation
 20:25:98	Teleview
+20:28:3E	HuaweiTe	Huawei Technologies Co.,Ltd
 20:28:BC	Visionsc	Visionscape Co,. Ltd.
 20:2B:C1	HuaweiTe	Huawei Technologies Co.,Ltd
 20:2C:B7	KongYueE	Kong Yue Electronics & Information Industry (Xinhui) Ltd.
 20:2D:07	SamsungE	Samsung Electronics Co.,Ltd
+20:2D:23	Collinea	Collinear Networks Inc.
 20:2D:F8	DigitalM	Digital Media Cartridge Ltd.
 20:31:EB	Hdsn
 20:36:5B	Megafone	Megafone Limited
 20:37:06	Cisco	Cisco Systems, Inc
 20:37:BC	KuipersE	Kuipers Electronic Engineering BV
+20:39:56	HmdGloba	HMD Global Oy
 20:3A:07	Cisco	Cisco Systems, Inc
 20:3A:EF	Sivantos	Sivantos GmbH
 20:3C:AE	Apple	Apple, Inc.
 20:3D:66	ArrisGro	ARRIS Group, Inc.
 20:3D:B2	HuaweiTe	Huawei Technologies Co.,Ltd
+20:3D:BD	LgInnote	LG Innotek
 20:40:05	Feno	feno GmbH
 20:41:5A	SmartehD	Smarteh d.o.o.
 20:44:3A	Schneide	Schneider Electric Asia Pacific Ltd
 20:46:A1	Vecow	VECOW Co., Ltd
 20:46:F9	Advanced	Advanced Network Devices (dba:AND)
 20:47:47	Dell	Dell Inc.
+20:47:DA	XiaomiCo	Xiaomi Communications Co Ltd
 20:47:ED	Bskyb	BSkyB Ltd
 20:4A:AA	HanscanS	Hanscan Spain S.A.
 20:4C:03	ArubaNet	Aruba Networks
@@ -18844,7 +19061,7 @@
 20:4E:71	JuniperN	Juniper Networks
 20:4E:7F	Netgear
 20:53:CA	RiskTech	Risk Technology Ltd
-20:54:76	SonyMobi	Sony Mobile Communications AB
+20:54:76	SonyMobi	Sony Mobile Communications Inc
 20:54:FA	HuaweiTe	Huawei Technologies Co.,Ltd
 20:55:31	SamsungE	Samsung Electronics Co.,Ltd
 20:55:32	GotechIn	Gotech International Technology Limited
@@ -18860,6 +19077,7 @@
 20:62:74	Microsof	Microsoft Corporation
 20:63:5F	Abeeway
 20:64:32	SamsungE	Samsung Electro Mechanics Co., Ltd.
+20:67:7C	HewlettP	Hewlett Packard Enterprise
 20:67:B1	Pluto	Pluto inc.
 20:68:9D	LiteonTe	Liteon Technology Corporation
 20:6A:8A	WistronI	Wistron Infocomm (Zhongshan) Corporation
@@ -18897,16 +19115,19 @@
 20:9B:CD	Apple	Apple, Inc.
 20:A2:E4	Apple	Apple, Inc.
 20:A2:E7	Lee-Dick	Lee-Dickens Ltd
+20:A6:0C	XiaomiCo	Xiaomi Communications Co Ltd
 20:A6:80	HuaweiTe	Huawei Technologies Co.,Ltd
 20:A6:CD	HewlettP	Hewlett Packard Enterprise
 20:A7:83	Micontro	miControl GmbH
 20:A7:87	BointecT	Bointec Taiwan Corporation Limited
-20:A8:B9	Siemens
+20:A8:B9	Siemens	Siemens Ag
 20:A9:0E	TctMobil	TCT mobile ltd
 20:A9:9B	Microsof	Microsoft Corporation
 20:AA:25	Ip-NetLl	IP-NET LLC
 20:AA:4B	Cisco-Li	Cisco-Linksys, LLC
 20:AB:37	Apple	Apple, Inc.
+20:AD:56	Continen	Continental Automotive Systems Inc.
+20:B0:01	Technico	Technicolor
 20:B0:F7	Enclustr	Enclustra GmbH
 20:B3:99	Enterasy	Enterasys
 20:B5:C6	MimosaNe	Mimosa Networks
@@ -18935,10 +19156,12 @@
 20:D5:BF	SamsungE	Samsung Electronics Co.,Ltd
 20:D6:07	Nokia	Nokia Corporation
 20:D7:5A	PoshMobi	Posh Mobile Limited
+20:D8:0B	JuniperN	Juniper Networks
 20:D9:06	Iota	Iota, Inc.
 20:DB:AB	SamsungE	Samsung Electronics Co., Ltd.
 20:DC:93	CheetahH	Cheetah Hi-Tech, Inc.
 20:DC:E6	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
+20:DE:88	IcRealti	IC Realtime LLC
 20:DF:3F	NanjingS	Nanjing SAC Power Grid Automation Co., Ltd.
 20:DF:B9	Google	Google, Inc.
 20:E0:9C	Nokia
@@ -18946,6 +19169,7 @@
 20:E5:2A	Netgear
 20:E5:64	ArrisGro	ARRIS Group, Inc.
 20:E7:91	SiemensH	Siemens Healthcare Diagnostics, Inc
+20:E8:82	Zte	zte corporation
 20:EA:C7	Shenzhen	Shenzhen Riopine Electronics Co., Ltd
 20:ED:74	AbilityE	Ability enterprise co.,Ltd.
 20:EE:28	Apple	Apple, Inc.
@@ -18958,6 +19182,7 @@
 20:F4:52	Shanghai	Shanghai IUV Software Development Co. Ltd
 20:F5:10	CodexDig	Codex Digital Limited
 20:F5:43	HuiZhouG	Hui Zhou Gaoshengda Technology Co.,LTD
+20:F7:7C	VivoMobi	vivo Mobile Communication Co., Ltd.
 20:F8:5E	DeltaEle	Delta Electronics
 20:FA:BB	Cambridg	Cambridge Executive Limited
 20:FD:F1	3comEuro	3COM EUROPE LTD
@@ -18966,10 +19191,12 @@
 24:00:BA	HuaweiTe	Huawei Technologies Co.,Ltd
 24:01:C7	Cisco	Cisco Systems, Inc
 24:05:0F	MtnElect	MTN Electronic Co. Ltd
+24:05:88	Google	Google, Inc.
 24:05:F5	Integrat	Integrated Device Technology (Malaysia) Sdn. Bhd.
 24:09:17	DevlinEl	Devlin Electronics Limited
 24:09:95	HuaweiTe	Huawei Technologies Co.,Ltd
 24:0A:11	TctMobil	TCT mobile ltd
+24:0A:63	ArrisGro	ARRIS Group, Inc.
 24:0A:64	Azurewav	AzureWave Technology Inc.
 24:0A:C4	Espressi	Espressif Inc.
 24:0B:0A	PaloAlto	Palo Alto Networks
@@ -18986,20 +19213,26 @@
 24:1A:8C	Squarehe	Squarehead Technology AS
 24:1B:13	Shanghai	Shanghai Nutshell Electronic Co., Ltd.
 24:1B:44	Hangzhou	Hangzhou Tuners Electronics Co., Ltd
+24:1B:7A	Apple	Apple, Inc.
 24:1C:04	Shenzhen	Shenzhen Jehe Technology Development Co., Ltd.
 24:1E:EB	Apple	Apple, Inc.
 24:1F:2C	Calsys	Calsys, Inc.
 24:1F:A0	HuaweiTe	Huawei Technologies Co.,Ltd
 24:20:C7	Sagemcom	Sagemcom Broadband SAS
-24:21:AB	SonyMobi	Sony Mobile Communications AB
+24:21:24	Nokia
+24:21:AB	SonyMobi	Sony Mobile Communications Inc
 24:24:0E	Apple	Apple, Inc.
 24:26:42	Sharp	SHARP Corporation.
+24:29:FE	Kyocera	KYOCERA Corporation
+24:2E:02	HuaweiTe	Huawei Technologies Co.,Ltd
+24:2E:90	PalitMic	Palit Microsystems, Ltd
 24:2F:FA	ToshibaG	Toshiba Global Commerce Solutions
 24:31:84	Sharp	SHARP Corporation
 24:33:6C	Private
 24:35:CC	Zhongsha	Zhongshan Scinan Internet of Things Co.,Ltd.
 24:37:4C	CiscoSpv	Cisco SPVTG
 24:37:EF	EmcElect	EMC Electronic Media Communication SA
+24:3A:82	Irts
 24:3C:20	Dynamode	Dynamode Group
 24:42:BC	Alinco	Alinco,incorporated
 24:44:27	HuaweiTe	Huawei Technologies Co.,Ltd
@@ -19009,6 +19242,7 @@
 24:4B:03	SamsungE	Samsung Electronics Co.,Ltd
 24:4B:81	SamsungE	Samsung Electronics Co.,Ltd
 24:4C:07	HuaweiTe	Huawei Technologies Co.,Ltd
+24:4C:E3	AmazonTe	Amazon Technologies Inc.
 24:4E:7B	IeeeRegi	IEEE Registration Authority
 24:4E:7B:00:00:00/28	TekelekE	Tekelek Europe Ltd
 24:4E:7B:10:00:00/28	Sonoscap	sonoscape
@@ -19026,6 +19260,7 @@
 24:4E:7B:D0:00:00/28	Private
 24:4E:7B:E0:00:00/28	WithwinT	WithWin Technology ShenZhen CO.,LTD
 24:4F:1D	IruleLlc	iRule LLC
+24:53:BF	Enernet
 24:58:80	Vizeo
 24:59:0B	WhiteSky	White Sky Inc. Limited
 24:5B:A7	Apple	Apple, Inc.
@@ -19055,11 +19290,13 @@
 24:79:2A	RuckusWi	Ruckus Wireless
 24:7C:4C	HermanMi	Herman Miller
 24:7E:12	Cisco	Cisco Systems, Inc
+24:7E:51	Zte	zte corporation
 24:7F:20	Sagemcom	Sagemcom Broadband SAS
 24:7F:3C	HuaweiTe	Huawei Technologies Co.,Ltd
 24:80:00	Westcont	Westcontrol AS
 24:81:AA	KshInter	KSH International Co., Ltd.
 24:82:8A	ProwaveT	Prowave Technologies Ltd.
+24:84:98	BeijingJ	Beijing Jiaoda Microunion Tech.Co.,Ltd.
 24:86:F4	Ctek	Ctek, Inc.
 24:87:07	Senergy	SEnergy Corporation
 24:88:94	Shenzhen	shenzhen lensun Communication Technology LTD
@@ -19097,6 +19334,7 @@
 24:BC:82	DaliWire	Dali Wireless, Inc.
 24:BC:F8	HuaweiTe	Huawei Technologies Co.,Ltd
 24:BE:05	HewlettP	Hewlett Packard
+24:BE:18	Dadoutek	Dadoutek Company Limited
 24:BF:74	Private
 24:C0:B3	Rsf
 24:C1:BD	CrrcDali	CRRC DALIAN R&D CO.,LTD.
@@ -19104,15 +19342,18 @@
 24:C4:2F	PhilipsL	Philips Lifeline
 24:C4:4A	Zte	zte corporation
 24:C6:96	SamsungE	Samsung Electronics Co.,Ltd
-24:C8:48	MywerkSy	mywerk system GmbH
+24:C8:48	MywerkPo	mywerk Portal GmbH
 24:C8:6E	ChaneyIn	Chaney Instrument Co.
 24:C9:A1	RuckusWi	Ruckus Wireless
 24:C9:DE	Genoray
+24:CA:CB	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 24:CB:E7	Myk	MYK, Inc.
 24:CF:21	Shenzhen	Shenzhen State Micro Technology Co., Ltd
 24:D1:3F	Mexus	Mexus Co.,Ltd
 24:D2:CC	Smartdri	SmartDrive Systems Inc.
+24:D3:F2	Zte	zte corporation
 24:D5:1C	Zhongtia	Zhongtian broadband technology co., LTD
+24:D7:6B	Syntroni	Syntronic AB
 24:D9:21	Avaya	Avaya Inc
 24:DA:11	NoNda	NO NDA Inc
 24:DA:9B	Motorola	Motorola Mobility LLC, a Lenovo Company
@@ -19131,19 +19372,25 @@
 24:E9:B3	Cisco	Cisco Systems, Inc
 24:EA:40	Helmholz	Helmholz GmbH & Co. KG
 24:EB:65	SaetISSR	SAET I.S. S.r.l.
+24:EC:51	AdfTechn	ADF Technologies Sdn Bhd
 24:EC:99	AskeyCom	Askey Computer Corp
 24:EC:D6	CsgScien	CSG Science & Technology Co.,Ltd.Hefei
 24:EE:3A	ChengduY	Chengdu Yingji Electronic Hi-tech Co Ltd
 24:F0:94	Apple	Apple, Inc.
 24:F0:FF	Ght	GHT Co., Ltd.
+24:F1:28	Telstra
 24:F2:7F	HewlettP	Hewlett Packard Enterprise
 24:F2:DD	RadiantZ	Radiant Zemax LLC
 24:F5:7E	Hwh	Hwh Co., Ltd.
 24:F5:A2	BelkinIn	Belkin International Inc.
 24:F5:AA	SamsungE	Samsung Electronics Co.,Ltd
 24:F6:77	Apple	Apple, Inc.
+24:FA:F3	Shanghai	Shanghai Flexem Technology Co.,Ltd.
+24:FB:65	HuaweiTe	Huawei Technologies Co.,Ltd
+24:FC:E5	SamsungE	Samsung Electronics Co.,Ltd
 24:FD:52	LiteonTe	Liteon Technology Corporation
 24:FD:5B	Smartthi	SmartThings, Inc.
+28:02:45	KonzeSys	Konze System Technology Co.,Ltd.
 28:02:D8	SamsungE	Samsung Electronics Co.,Ltd
 28:04:E0	FermaxEl	Fermax Electronica S.A.U.
 28:06:1E	NingboGl	Ningbo Global Useful Electric Co.,Ltd
@@ -19156,8 +19403,10 @@
 28:0E:8B	BeijingS	Beijing Spirit Technology Development Co., Ltd.
 28:10:1B	Magnacom
 28:10:7B	D-LinkIn	D-Link International
+28:11:A5	Bose	Bose Corporation
 28:14:71	Lantis	Lantis co., LTD.
 28:16:2E	2wire	2Wire Inc
+28:16:A8	Microsof	Microsoft Corporation
 28:16:AD	IntelCor	Intel Corporate
 28:17:CE	Omnisens	Omnisense Ltd
 28:18:78	Microsof	Microsoft Corporation
@@ -19192,6 +19441,7 @@
 28:2F:C2	Automoti	Automotive Data Solutions
 28:30:AC	Frontiir	Frontiir Co. Ltd.
 28:31:52	HuaweiTe	Huawei Technologies Co.,Ltd
+28:31:66	VivoMobi	vivo Mobile Communication Co., Ltd.
 28:32:C5	Humax	HUMAX Co., Ltd.
 28:34:10	EnigmaDi	Enigma Diagnostics Limited
 28:34:A2	Cisco	Cisco Systems, Inc
@@ -19214,13 +19464,17 @@
 28:36:38:E0:00:00/28	ScaHygie	SCA Hygiene Products AB
 28:37:13	Shenzhen	Shenzhen 3Nod Digital Technology Co., Ltd.
 28:37:37	Apple	Apple, Inc.
+28:38:5C	Flextron	Flextronics
 28:38:CF	Gen2wave
+28:39:26	Cybertan	CyberTAN Technology Inc.
 28:39:5E	SamsungE	Samsung Electronics Co.,Ltd
 28:39:E7	PrecenoT	Preceno Technology Pte.Ltd.
+28:3A:4D	CloudNet	Cloud Network Technology (Samoa) Limited
 28:3B:82	D-LinkIn	D-Link International
 28:3B:96	CoolCont	Cool Control LTD
 28:3C:E4	HuaweiTe	Huawei Technologies Co.,Ltd
-28:3F:69	SonyMobi	Sony Mobile Communications AB
+28:3E:76	CommonNe	Common Networks
+28:3F:69	SonyMobi	Sony Mobile Communications Inc
 28:40:1A	C8Medise	C8 MediSensors, Inc.
 28:41:21	Optisens	OptiSense Network, LLC
 28:44:30	Genesist	GenesisTechnical Systems (UK) Ltd
@@ -19242,12 +19496,14 @@
 28:5F:DB	HuaweiTe	Huawei Technologies Co.,Ltd
 28:60:46	LantechC	Lantech Communications Global, Inc.
 28:60:94	Capelec
-28:63:36	Siemens-	Siemens AG - Industrial Automation - EWA
+28:63:36	Siemens	Siemens AG
 28:65:6B	Keystone	Keystone Microtech Corporation
+28:66:E3	Azurewav	AzureWave Technology Inc.
 28:6A:B8	Apple	Apple, Inc.
 28:6A:BA	Apple	Apple, Inc.
 28:6C:07	XiaomiEl	XIAOMI Electronics,CO.,LTD
 28:6D:97	Samjin	SAMJIN Co., Ltd.
+28:6D:CD	BeijingW	Beijing Winner Microelectronics Co.,Ltd.
 28:6E:D4	HuaweiTe	Huawei Technologies Co.,Ltd
 28:6F:7F	Cisco	Cisco Systems, Inc
 28:71:84	SpirePay	Spire Payments
@@ -19277,7 +19533,9 @@
 28:99:3A	AristaNe	Arista Networks
 28:9A:4B	Steelser	SteelSeries ApS
 28:9A:FA	TctMobil	TCT mobile ltd
+28:9E:97	HuaweiTe	Huawei Technologies Co.,Ltd
 28:9E:DF	DanfossT	Danfoss Turbocor Compressors, Inc
+28:9E:FC	Sagemcom	Sagemcom Broadband SAS
 28:A0:2B	Apple	Apple, Inc.
 28:A1:83	AlpsElec	Alps Electric Co.,Ltd.
 28:A1:86	Enblink
@@ -19290,6 +19548,7 @@
 28:A6:AC	Seca	seca gmbh & co. kg
 28:A6:DB	HuaweiTe	Huawei Technologies Co.,Ltd
 28:AC:67	MachPowe	Mach Power, Rappresentanze Internazionali s.r.l.
+28:AC:9E	Cisco	Cisco Systems, Inc
 28:AD:3E	Shenzhen	Shenzhen TONG BO WEI Technology CO.,LTD
 28:AF:0A	SiriusXm	Sirius XM Radio Inc
 28:B0:CC	XenyaDOO	Xenya d.o.o.
@@ -19326,6 +19585,7 @@
 28:CF:08	Essys
 28:CF:DA	Apple	Apple, Inc.
 28:CF:E9	Apple	Apple, Inc.
+28:D0:CB	Cambridg	Cambridge Communication Systems Ltd
 28:D1:AF	Nokia	Nokia Corporation
 28:D2:44	LcfcHefe	LCFC(HeFei) Electronics Technology Co., Ltd.
 28:D4:36	JiangsuD	Jiangsu dewosi electric co., LTD
@@ -19396,6 +19656,8 @@
 28:FD:80:E0:00:00/28	T-RadioA	T-Radio AS
 28:FD:80:F0:00:00/28	Private
 28:FE:CD	Lemobile	Lemobile Information Technology (Beijing) Co., Ltd.
+28:FE:DE	Comesta	COMESTA, Inc.
+28:FF:3C	Apple	Apple, Inc.
 28:FF:3E	Zte	zte corporation
 2A:EA:15	TibitCom	Tibit Communications
 2A:FD:6A	CharterC	Charter Communications
@@ -19413,6 +19675,8 @@
 2C:0B:E9	Cisco	Cisco Systems, Inc
 2C:0E:3D	SamsungE	SAMSUNG ELECTRO-MECHANICS(THAILAND)
 2C:10:C1	Nintendo	Nintendo Co., Ltd.
+2C:15:E1	PhicommS	Phicomm (Shanghai) Co., Ltd.
+2C:18:75	Skyworth	Skyworth Digital Technology(Shenzhen) Co.,Ltd
 2C:18:AE	TrendEle	Trend Electronics Co., Ltd.
 2C:19:84	IdnTelec	IDN Telecom, Inc.
 2C:1A:31	Electron	Electronics Company Limited
@@ -19462,6 +19726,7 @@
 2C:27:9E:E0:00:00/28	Amaryllo	Amaryllo International Inc.
 2C:27:D7	HewlettP	Hewlett Packard
 2C:28:2D	BbkEduca	Bbk Educational Electronics Corp.,Ltd.
+2C:28:B7	Hangzhou	Hangzhou Ruiying technology co., LTD
 2C:29:97	Microsof	Microsoft Corporation
 2C:2D:48	BctElect	bct electronic GesmbH
 2C:30:33	Netgear
@@ -19494,8 +19759,25 @@
 2C:44:01	SamsungE	Samsung Electronics Co.,Ltd
 2C:44:1B	Spectrum	Spectrum Medical Limited
 2C:44:FD	HewlettP	Hewlett Packard
+2C:47:59	BeijingM	Beijing MEGA preponderance Science & Technology Co. Ltd
+2C:48:35	IeeeRegi	IEEE Registration Authority
+2C:48:35:00:00:00/28	Progress	Progress Rail Services, Inspection and Information Systems
+2C:48:35:10:00:00/28	Advanced	Advanced Electronics Company Ltd
+2C:48:35:20:00:00/28	RheonikM	Rheonik Messtechnik GmbH
+2C:48:35:30:00:00/28	NewtraxT	Newtrax Technologies Inc
+2C:48:35:40:00:00/28	Geartech	Geartech Ltd
+2C:48:35:50:00:00/28	ScoutSec	Scout Security, Inc.
+2C:48:35:60:00:00/28	ExertusO	Exertus Oy
+2C:48:35:70:00:00/28	Fast
+2C:48:35:80:00:00/28	DpsElect	DPS Electronics
+2C:48:35:90:00:00/28	Sureflap	SureFlap Ltd
+2C:48:35:A0:00:00/28	Collatz+	Collatz+Trojan GmbH
+2C:48:35:B0:00:00/28	Shanghai	Shanghai Visteon Automotive Electronics System CO. Ltd.
+2C:48:35:C0:00:00/28	Santec	Santec Corporation
+2C:48:35:D0:00:00/28	PhasorSo	Phasor Solutions Ltd
+2C:48:35:E0:00:00/28	Irootech	Irootech Technology Co.,Ltd
 2C:4D:54	AsustekC	ASUSTek COMPUTER INC.
-2C:4D:79	WeifangG	Weifang GoerTek Technology Co.,Ltd.
+2C:4D:79	WeifangG	Weifang Goertek Electronics Co.,Ltd
 2C:50:89	Shenzhen	Shenzhen Kaixuan Visual Technology Co.,Limited
 2C:53:4A	Shenzhen	Shenzhen Winyao Electronic Limited
 2C:54:2D	Cisco	Cisco Systems, Inc
@@ -19505,6 +19787,7 @@
 2C:55:D3	HuaweiTe	Huawei Technologies Co.,Ltd
 2C:56:DC	AsustekC	ASUSTek COMPUTER INC.
 2C:57:31	Wingtech	Wingtech Group (HongKong）Limited
+2C:58:4F	ArrisGro	ARRIS Group, Inc.
 2C:59:8A	LgElectr	LG Electronics (Mobile Communications)
 2C:59:E5	HewlettP	Hewlett Packard
 2C:5A:05	Nokia	Nokia Corporation
@@ -19516,6 +19799,7 @@
 2C:5D:93	RuckusWi	Ruckus Wireless
 2C:5F:F3	Pertroni	Pertronic Industries
 2C:60:0C	QuantaCo	Quanta Computer Inc.
+2C:61:04	Shenzhen	Shenzhen Fenglian Technology Co., Ltd.
 2C:61:F6	Apple	Apple, Inc.
 2C:62:5A	FinestSe	Finest Security Systems Co., Ltd
 2C:62:89	Regeners	Regenersis (Glenrothes) Ltd
@@ -19549,8 +19833,10 @@
 2C:73:60	EardaTec	Earda Technologies co Ltd
 2C:75:0F	Shanghai	Shanghai Dongzhou-Lawton Communication Technology Co. Ltd.
 2C:76:8A	HewlettP	Hewlett Packard
+2C:79:D7	Sagemcom	Sagemcom Broadband SAS
 2C:7B:5A	Milper	Milper Ltd
 2C:7B:84	OooPetrT	OOO Petr Telegin
+2C:7C:E4	WuhanTia	Wuhan Tianyu Information Industry Co., Ltd.
 2C:7E:81	ArrisGro	ARRIS Group, Inc.
 2C:7E:CF	Onzo	Onzo Ltd
 2C:80:65	HartingO	HARTING Inc. of North America
@@ -19565,12 +19851,14 @@
 2C:95:7F	Zte	zte corporation
 2C:96:62	InvenitB	Invenit BV
 2C:97:17	ICYBV	I.C.Y. B.V.
+2C:97:B1	HuaweiTe	Huawei Technologies Co.,Ltd
 2C:99:24	ArrisGro	ARRIS Group, Inc.
 2C:9A:A4	Eolo	Eolo SpA
 2C:9D:1E	HuaweiTe	Huawei Technologies Co.,Ltd
 2C:9E:5F	ArrisGro	ARRIS Group, Inc.
 2C:9E:EC	JabilCir	Jabil Circuit Penang
 2C:9E:FC	Canon	Canon Inc.
+2C:A0:2F	Veroguar	Veroguard Systems Pty Ltd
 2C:A1:57	Acromate	acromate, Inc.
 2C:A1:7D	ArrisGro	ARRIS Group, Inc.
 2C:A2:B4	FortifyT	Fortify Technologies, LLC
@@ -19592,13 +19880,16 @@
 2C:B4:3A	Apple	Apple, Inc.
 2C:B6:93	Radware
 2C:B6:9D	RedDigit	RED Digital Cinema
+2C:B8:ED	Sonicwal	SonicWall
 2C:BA:BA	SamsungE	Samsung Electronics Co.,Ltd
 2C:BE:08	Apple	Apple, Inc.
 2C:BE:97	Ingenieu	Ingenieurbuero Bickele und Buehler GmbH
 2C:C2:60	Oracle	Oracle Corporation
 2C:C5:48	Iadea	IAdea Corporation
 2C:C5:D3	RuckusWi	Ruckus Wireless
+2C:CA:0C	WithusPl	Withus Planet
 2C:CC:15	Nokia	Nokia Corporation
+2C:CC:44	SonyInte	Sony Interactive Entertainment Inc.
 2C:CD:27	Precor	Precor Inc
 2C:CD:43	SummitTe	Summit Technology Group
 2C:CD:69	AqaviCom	Aqavi.com
@@ -19625,6 +19916,7 @@
 2C:D1:DA	Sanjole	Sanjole, Inc.
 2C:D2:E7	Nokia	Nokia Corporation
 2C:D4:44	Fujitsu	Fujitsu Limited
+2C:D9:74	HuiZhouG	Hui Zhou Gaoshengda Technology Co.,LTD
 2C:DC:AD	WistronN	Wistron Neweb Corporation
 2C:DD:0C	Discover	Discovergy GmbH
 2C:DD:95	TaicangT	Taicang T&W Electronics
@@ -19650,6 +19942,39 @@
 30:05:3F	Jti	JTI Co.,Ltd.
 30:05:5C	BrotherI	Brother industries, LTD.
 30:07:4D	SamsungE	SAMSUNG ELECTRO-MECHANICS(THAILAND)
+30:09:F9	IeeeRegi	IEEE Registration Authority
+30:09:F9:00:00:00/28	HurrayCl	Hurray Cloud Technology Co., Ltd.
+30:09:F9:10:00:00/28	Shenzhen	Shenzhen Sunvell Electronics Co., Ltd.
+30:09:F9:20:00:00/28	BeijingN	Beijing Netswift Technology Co.,Ltd.
+30:09:F9:30:00:00/28	OooMicro	OOO Microlink-Svyaz
+30:09:F9:40:00:00/28	PunktTro	Punkt Tronics AG
+30:09:F9:50:00:00/28	Velsitec	VELSITEC-CLIBASE
+30:09:F9:60:00:00/28	BeijingM	Beijing Mydreamplus Information Technology Co., Ltd.
+30:09:F9:70:00:00/28	Maytroni	Maytronics Ltd.
+30:09:F9:80:00:00/28	EssenceS	essence security
+30:09:F9:90:00:00/28	Bonraybi	Bonraybio
+30:09:F9:A0:00:00/28	Shenzhen	Shenzhen Tencent Computer System Co., Ltd.
+30:09:F9:B0:00:00/28	SichuanN	Sichuan Nebula Networks Co.,LTD.
+30:09:F9:C0:00:00/28	Honeywel	Honeywell
+30:09:F9:D0:00:00/28	Technolo	Technology for Humankind
+30:09:F9:E0:00:00/28	ZhongliH	ZhongLi HengFeng (Shenzhen) Technology co.,Ltd.
+30:0A:60	IeeeRegi	IEEE Registration Authority
+30:0A:60:00:00:00/28	Kazutech	KAZUtechnica Co.,Ltd.
+30:0A:60:10:00:00/28	BeijingR	Beijing Ruiteng Zhongtian TECH Ltd.,Co
+30:0A:60:20:00:00/28	Advanced	Advanced Electronic Designs, Inc.
+30:0A:60:30:00:00/28	Private
+30:0A:60:40:00:00/28	AvicJonh	Avic Jonhon Optronic Technology Co., Ltd.
+30:0A:60:50:00:00/28	A9
+30:0A:60:60:00:00/28	Realtime	Realtime biometrics India pvt ltd
+30:0A:60:70:00:00/28	Newtons4	Newtons4th Ltd
+30:0A:60:80:00:00/28	Bronkhor	Bronkhorst High-Tech BV
+30:0A:60:90:00:00/28	WintekSy	WINTEK System Co., Ltd
+30:0A:60:A0:00:00/28	Ampetron	Ampetronic Ltd
+30:0A:60:B0:00:00/28	Giax	Giax GmbH
+30:0A:60:C0:00:00/28	ThermoPr	Thermo Process Instruments, LP
+30:0A:60:D0:00:00/28	SixthEne	Sixth Energy Technologies Private Limited
+30:0A:60:E0:00:00/28	ImageoSR	Imageo s.r.o.
+30:0A:C5	RuioTele	Ruio telecommunication technologies Co., Limited
 30:0B:9C	DeltaMob	Delta Mobile Systems, Inc.
 30:0C:23	Zte	zte corporation
 30:0D:2A	Zhejiang	Zhejiang Wellcom Technology Co.,Ltd.
@@ -19658,15 +19983,35 @@
 30:0E:E3	Aquantia	Aquantia Corporation
 30:10:B3	LiteonTe	Liteon Technology Corporation
 30:10:E4	Apple	Apple, Inc.
+30:13:89	SiemensA	Siemens AG, Automations & Drives,
 30:14:2D	Piciorgr	Piciorgros GmbH
 30:14:4A	WistronN	Wistron Neweb Corporation
 30:15:18	Ubiquito	Ubiquitous Communication Co. ltd.
 30:16:8D	Prolon
-30:17:C8	SonyMobi	Sony Mobile Communications AB
+30:17:C8	SonyMobi	Sony Mobile Communications Inc
 30:18:CF	DeosCont	DEOS control systems GmbH
 30:19:66	SamsungE	Samsung Electronics Co.,Ltd
 30:1A:28	MakoNetw	Mako Networks Ltd
+30:1F:9A	IeeeRegi	IEEE Registration Authority
+30:1F:9A:00:00:00/28	IlsanEle	Ilsan Electronics
+30:1F:9A:10:00:00/28	Dewesoft	Dewesoft d.o.o.
+30:1F:9A:20:00:00/28	ChisonMe	CHISON Medical Technologies Co., Ltd.
+30:1F:9A:30:00:00/28	Micomsof	Micomsoft Co.,Ltd.
+30:1F:9A:40:00:00/28	NcmSuppl	NCM Supplies, Inc.
+30:1F:9A:50:00:00/28	BeijingS	Beijing Surestar Technology Co. Ltd,
+30:1F:9A:60:00:00/28	YishengT	YiSheng technology  co.,LTD
+30:1F:9A:70:00:00/28	Triax	Triax A/S
+30:1F:9A:80:00:00/28	FineTriu	Fine Triumph Technology Corp.,Ltd.
+30:1F:9A:90:00:00/28	Private
+30:1F:9A:A0:00:00/28	HunanCha	Hunan Changsha Hengjian Technoldgy Develpment Co.,Ltd.
+30:1F:9A:B0:00:00/28	SmartCom	Smart Component Technologies LTD
+30:1F:9A:C0:00:00/28	OrigamiG	Origami Group Limited
+30:1F:9A:D0:00:00/28	Olimex	OLIMEX Ltd
+30:1F:9A:E0:00:00/28	Shenzhen	Shenzhen Fengliyuan Energy Conservating Technology Co. Ltd
 30:21:5B	Shenzhen	Shenzhen Ostar Display Electronic Co.,Ltd
+30:23:03	BelkinIn	Belkin International Inc.
+30:24:32	IntelCor	Intel Corporate
+30:29:52	Hillston	Hillstone Networks Inc
 30:29:BE	Shanghai	Shanghai MRDcom Co.,Ltd
 30:2D:E8	JdaLlcJd	JDA, LLC (JDA Systems)
 30:32:94	W-Ie-Ne-	W-IE-NE-R Plein & Baus GmbH
@@ -19676,7 +20021,7 @@
 30:35:AD	Apple	Apple, Inc.
 30:37:A6	Cisco	Cisco Systems, Inc
 30:38:55	Nokia	Nokia Corporation
-30:39:26	SonyMobi	Sony Mobile Communications AB
+30:39:26	SonyMobi	Sony Mobile Communications Inc
 30:39:55	Shenzhen	Shenzhen Jinhengjia Electronic Co., Ltd.
 30:39:F2	AdbBroad	ADB Broadband Italia
 30:3A:64	IntelCor	Intel Corporate
@@ -19684,11 +20029,15 @@
 30:3E:AD	SonavoxC	Sonavox Canada Inc
 30:41:74	AltecLan	Altec Lansing Llc
 30:42:25	Burg-Wäc	BURG-WÄCHTER KG
+30:42:A1	Ilumisys	ilumisys Inc. DBA Toggled
 30:44:49	Plath	PLATH GmbH
 30:44:87	HefeiRad	Hefei Radio Communication Technology Co., Ltd
 30:44:A1	Shanghai	Shanghai Nanchao Information Technology
+30:45:11	TexasIns	Texas Instruments
+30:45:96	HuaweiTe	Huawei Technologies Co.,Ltd
 30:46:9A	Netgear
 30:49:3B	NanjingZ	Nanjing Z-Com Wireless Co.,Ltd
+30:4B:07	Motorola	Motorola Mobility LLC, a Lenovo Company
 30:4C:7E	Panasoni	Panasonic Electric Works Automation Controls Techno Co.,Ltd.
 30:4E:C3	TianjinT	Tianjin Techua Technology Co., Ltd.
 30:51:F8	Byk-Gard	BYK-Gardner GmbH
@@ -19701,6 +20050,7 @@
 30:59:B7	Microsof	Microsoft
 30:5A:3A	AsustekC	ASUSTek COMPUTER INC.
 30:5D:38	Beissbar	Beissbarth
+30:5D:A6	AdvalySy	ADVALY SYSTEM Inc.
 30:60:23	ArrisGro	ARRIS Group, Inc.
 30:61:12	Pav	PAV GmbH
 30:61:18	Paradom	Paradom Inc.
@@ -19714,12 +20064,12 @@
 30:71:B2	Hangzhou	Hangzhou Prevail Optoelectronic Equipment Co.,LTD.
 30:73:50	InpecoSa	Inpeco SA
 30:74:96	HuaweiTe	Huawei Technologies Co.,Ltd
-30:75:12	SonyMobi	Sony Mobile Communications AB
+30:75:12	SonyMobi	Sony Mobile Communications Inc
 30:76:6F	LgElectr	LG Electronics (Mobile Communications)
 30:77:CB	MaikeInd	Maike Industry(Shenzhen)CO.,LTD
 30:78:5C	PartowTa	Partow Tamas Novin (Parman)
 30:78:6B	TianjinG	TIANJIN Golden Pentagon Electronics Co., Ltd.
-30:78:C2	Innowire	Innowireless, Co. Ltd.
+30:78:C2	Innowire	Innowireless / QUCELL Networks
 30:7B:AC	NewH3cTe	New H3C Technologies Co., Ltd
 30:7C:30	Rim
 30:7C:5E	JuniperN	Juniper Networks
@@ -19729,6 +20079,7 @@
 30:85:A9	AsustekC	ASUSTek COMPUTER INC.
 30:87:30	HuaweiTe	Huawei Technologies Co.,Ltd
 30:87:D9	RuckusWi	Ruckus Wireless
+30:88:41	SichuanA	Sichuan AI-Link Technology Co., Ltd.
 30:89:76	DalianLa	Dalian Lamba Technology Co.,Ltd
 30:89:99	Guangdon	Guangdong East Power Co.,
 30:89:D3	Hongkong	Hongkong Ucloudlink Network Technology Limited
@@ -19743,16 +20094,17 @@
 30:9B:AD	BbkEduca	Bbk Educational Electronics Corp.,Ltd.
 30:9C:23	Micro-St	Micro-Star INTL CO., LTD.
 30:9F:FB	ArdomusN	Ardomus Networks Corporation
+30:A1:FA	HuaweiTe	Huawei Technologies Co.,Ltd
 30:A2:20	ArgTelec	ARG Telecom
 30:A2:43	Shenzhen	Shenzhen Prifox Innovation Technology Co., Ltd.
-30:A8:DB	SonyMobi	Sony Mobile Communications AB
+30:A8:DB	SonyMobi	Sony Mobile Communications Inc
 30:A9:DE	LgInnote	LG Innotek
 30:AA:BD	Shanghai	Shanghai Reallytek Information Technology Co.,Ltd
 30:AE:7B	DeqingDu	Deqing Dusun Electron CO., LTD
 30:AE:A4	Espressi	Espressif Inc.
 30:AE:F6	RadioMob	Radio Mobile Access
 30:B1:64	PowerEle	Power Electronics International Inc.
-30:B2:16	HytecGer	Hytec Geraetebau GmbH
+30:B2:16	Abb-Powe	ABB AG - Power Grids - Grid Automation
 30:B3:A2	Shenzhen	Shenzhen Heguang Measurement & Control Technology Co.,Ltd
 30:B4:9E	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 30:B4:B8	LgElectr	LG Electronics
@@ -19760,6 +20112,7 @@
 30:B5:F1	AitexinT	Aitexin Technology Co., Ltd
 30:B6:2D	MojoNetw	Mojo Networks, Inc.
 30:B6:4F	JuniperN	Juniper Networks
+30:B7:D4	HitronTe	Hitron Technologies. Inc
 30:C0:1B	Shenzhen	Shenzhen Jingxun Software Telecommunication Technology Co.,Ltd
 30:C3:D9	AlpsElec	Alps Electric Co.,Ltd.
 30:C5:07	EciTelec	ECI Telecom Ltd.
@@ -19768,17 +20121,21 @@
 30:C8:2A	Wi-BizSr	WI-BIZ srl
 30:CB:F8	SamsungE	Samsung Electronics Co.,Ltd
 30:CD:A7	SamsungE	Samsung Electronics Co.,Ltd
+30:D1:6B	LiteonTe	Liteon Technology Corporation
 30:D1:7E	HuaweiTe	Huawei Technologies Co.,Ltd
 30:D3:2D	Devolo	devolo AG
 30:D3:57	Logosol	Logosol, Inc.
 30:D3:86	Zte	zte corporation
 30:D4:6A	Autosale	Autosales Incorporated
 30:D5:87	SamsungE	Samsung Electronics Co.,Ltd
+30:D6:59	MergingT	Merging Technologies SA
 30:D6:C9	SamsungE	Samsung Electronics Co.,Ltd
+30:D9:D9	Apple	Apple, Inc.
 30:DE:86	CedacSof	Cedac Software S.r.l.
 30:E0:90	Linctron	Linctronix Ltd,
 30:E1:71	HewlettP	Hewlett Packard
 30:E3:7A	IntelCor	Intel Corporate
+30:E3:D6	SpotifyU	Spotify USA Inc.
 30:E4:8E	Vodafone	Vodafone UK
 30:E4:DB	Cisco	Cisco Systems, Inc
 30:EB:1F	SkylabM&	Skylab M&C Technology Co.,Ltd
@@ -19799,6 +20156,7 @@
 30:FB:94	Shanghai	Shanghai Fangzhiwei Information Technology CO.,Ltd.
 30:FC:68	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 30:FD:11	Macrotec	MACROTECH (USA) INC.
+30:FD:38	Google	Google, Inc.
 30:FE:31	Nokia
 30:FF:F6	Hangzhou	HangZhou KuoHeng Technology Co.,ltd
 34:00:8A	IeeeRegi	IEEE Registration Authority
@@ -19820,6 +20178,7 @@
 34:00:A3	HuaweiTe	Huawei Technologies Co.,Ltd
 34:02:86	IntelCor	Intel Corporate
 34:02:9B	Cloudber	CloudBerry Technologies Private Limited
+34:03:DE	TexasIns	Texas Instruments
 34:04:9E	IeeeRegi	IEEE Registration Authority
 34:04:9E:00:00:00/28	Gochip	GoChip Inc.
 34:04:9E:10:00:00/28	Connecte	Connected IO Inc.
@@ -19841,11 +20200,13 @@
 34:08:04	D-Link	D-Link Corporation
 34:08:BC	Apple	Apple, Inc.
 34:0A:22	Top-Acce	TOP-ACCESS ELECTRONICS CO LTD
+34:0A:98	HuaweiTe	Huawei Technologies Co.,Ltd
 34:0A:FF	QingdaoH	Qingdao Hisense Communications Co.,Ltd.
 34:0B:40	MiosElet	Mios Elettronica Srl
 34:0C:ED	Moduel	Moduel AB
 34:12:90	Treeview	Treeview Co.,Ltd.
 34:12:98	Apple	Apple, Inc.
+34:12:F9	HuaweiTe	Huawei Technologies Co.,Ltd
 34:13:A8	Mediplan	Mediplan Limited
 34:13:E8	IntelCor	Intel Corporate
 34:14:5F	SamsungE	Samsung Electronics Co.,Ltd
@@ -19862,7 +20223,9 @@
 34:23:BA	SamsungE	SAMSUNG ELECTRO-MECHANICS(THAILAND)
 34:25:5D	Shenzhen	Shenzhen Loadcom Technology Co.,Ltd
 34:26:06	Carepred	CarePredict, Inc.
+34:27:92	FreeboxS	Freebox Sas
 34:28:F0	AtnInter	ATN International Limited
+34:29:12	HuaweiTe	Huawei Technologies Co.,Ltd
 34:29:8F	IeeeRegi	IEEE Registration Authority
 34:29:8F:00:00:00/28	Blackedg	BlackEdge Capital
 34:29:8F:10:00:00/28	ChengduM	Chengdu Meross Technology Co., Ltd.
@@ -19881,7 +20244,9 @@
 34:29:8F:E0:00:00/28	ArcTechn	ARC Technology Co., Ltd
 34:29:EA	McdElect	Mcd Electronics Sp. Z O.O.
 34:2A:F1	TexasIns	Texas Instruments
+34:2C:C4	CompalBr	Compal Broadband Networks, Inc.
 34:2D:0D	SamsungE	Samsung Electronics Co.,Ltd
+34:2E:B6	HuaweiTe	Huawei Technologies Co.,Ltd
 34:2F:6E	Anywire	Anywire corporation
 34:31:11	SamsungE	Samsung Electronics Co.,Ltd
 34:31:C4	Avm	AVM GmbH
@@ -19910,6 +20275,7 @@
 34:56:FE	CiscoMer	Cisco Meraki
 34:57:60	Mitrasta	MitraStar Technology Corp.
 34:5A:06	Sharp	SHARP Corporation
+34:5A:BA	TcloudIn	tcloud intelligence
 34:5B:11	EviHeat	Evi Heat Ab
 34:5B:BB	GdMideaA	GD Midea Air-Conditioning Equipment Co.,Ltd.
 34:5C:40	CargtHol	Cargt Holdings LLC
@@ -19917,10 +20283,12 @@
 34:61:78	Boeing	The Boeing Company
 34:62:88	Cisco	Cisco Systems, Inc
 34:64:A9	HewlettP	Hewlett Packard
+34:66:EA	VertuInt	Vertu International Corporation Limited
 34:68:4A	Terawork	Teraworks Co., Ltd.
 34:68:95	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 34:69:87	Zte	zte corporation
 34:6A:C2	HuaweiTe	Huawei Technologies Co.,Ltd
+34:6B:46	Sagemcom	Sagemcom Broadband SAS
 34:6B:D3	HuaweiTe	Huawei Technologies Co.,Ltd
 34:6C:0F	PramodTe	Pramod Telecom Pvt. Ltd
 34:6E:8A	Ecosense
@@ -19932,10 +20300,13 @@
 34:76:C5	I-ODataD	I-O DATA DEVICE, INC.
 34:78:77	O-NetCom	O-Net Communications (Shenzhen) Limited
 34:78:D7	GioneeCo	Gionee Communication Equipment Co.,Ltd.
+34:79:16	HuaweiTe	Huawei Technologies Co.,Ltd
 34:7A:60	ArrisGro	ARRIS Group, Inc.
 34:7C:25	Apple	Apple, Inc.
 34:7E:39	NokiaDan	Nokia Danmark A/S
 34:7E:5C	Sonos	Sonos, Inc.
+34:7E:CA	Nextwill
+34:80:0D	Cavium	Cavium Inc
 34:80:B3	XiaomiCo	Xiaomi Communications Co Ltd
 34:81:37	UnicardS	Unicard Sa
 34:81:C4	Avm	AVM GmbH
@@ -19949,6 +20320,7 @@
 34:88:5D	Logitech	Logitech Far East
 34:8A:7B	SamsungE	Samsung Electronics Co.,Ltd
 34:8A:AE	Sagemcom	Sagemcom Broadband SAS
+34:8B:75	LavaInte	LAVA INTERNATIONAL(H.K) LIMITED
 34:8F:27	RuckusWi	Ruckus Wireless
 34:95:DB	Logitec	Logitec Corporation
 34:96:72	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
@@ -19984,7 +20356,7 @@
 34:B7:FD	Guangzho	Guangzhou Younghead Electronic Technology Co.,Ltd
 34:BA:38	PalMohan	Pal Mohan Electronics Pvt Ltd
 34:BA:51	Se-KureC	Se-Kure Controls, Inc.
-34:BA:75	Tembo	Tembo Systems, Inc.
+34:BA:75	EverestN	Everest Networks, Inc
 34:BA:9A	Asiatelc	Asiatelco Technologies Co.
 34:BB:1F	Blackber	BlackBerry RTS
 34:BB:26	Motorola	Motorola Mobility LLC, a Lenovo Company
@@ -20028,21 +20400,26 @@
 34:D0:B8:E0:00:00/28	Kongqigu	Kongqiguanjia (Beijing)Technology co.，ltd
 34:D2:70	AmazonTe	Amazon Technologies Inc.
 34:D2:C4	RenaPrin	RENA GmbH Print Systeme
+34:D7:12	Smartisa	Smartisan Digital Co., Ltd
 34:D7:B4	Tributar	Tributary Systems, Inc.
 34:D9:54	Wibotic	WiBotic Inc.
+34:DA:C1	SaeTechn	SAE Technologies Development(Dongguan) Co., Ltd.
 34:DB:FD	Cisco	Cisco Systems, Inc
 34:DE:1A	IntelCor	Intel Corporate
 34:DE:34	Zte	zte corporation
 34:DF:2A	FujikonI	Fujikon Industrial Co.,Limited
 34:E0:CF	Zte	zte corporation
 34:E0:D7	Dongguan	Dongguan Qisheng Electronics Industrial Co., Ltd
+34:E1:2D	IntelCor	Intel Corporate
 34:E2:FD	Apple	Apple, Inc.
 34:E3:80	GenexisB	Genexis B.V.
 34:E4:2A	Automati	Automatic Bar Controls Inc.
+34:E5:EC	PaloAlto	Palo Alto Networks
 34:E6:AD	IntelCor	Intel Corporate
 34:E6:D7	Dell	Dell Inc.
 34:E7:0B	HanNetwo	HAN Networks Co., Ltd
 34:E7:1C	Shenzhen	Shenzhen YOUHUA Technology Co., Ltd
+34:E8:94	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 34:E9:11	VivoMobi	vivo Mobile Communication Co., Ltd.
 34:EA:34	Hangzhou	HangZhou Gubei Electronics Technology Co.,Ltd
 34:ED:0B	Shanghai	Shanghai XZ-COM.CO.,Ltd.
@@ -20103,7 +20480,9 @@
 38:2C:4A	AsustekC	ASUSTek COMPUTER INC.
 38:2D:D1	SamsungE	Samsung Electronics Co.,Ltd
 38:2D:E8	SamsungE	Samsung Electronics Co.,Ltd
+38:30:F9	LgElectr	LG Electronics (Mobile Communications)
 38:31:AC	Weg
+38:35:FB	Sagemcom	Sagemcom Broadband SAS
 38:37:8B	HuaweiTe	Huawei Technologies Co.,Ltd
 38:3A:21	IeeeRegi	IEEE Registration Authority
 38:3A:21:00:00:00/28	R3cInfor	R3C Information(Shenzhen) Co.，Ltd.
@@ -20137,7 +20516,9 @@
 38:4F:49	JuniperN	Juniper Networks
 38:4F:F0	Azurewav	AzureWave Technology Inc.
 38:52:1A	Nokia
+38:53:9C	Apple	Apple, Inc.
 38:56:10	CandyHou	CANDY HOUSE, Inc.
+38:56:B5	Peerbrid	Peerbridge Health Inc
 38:58:0C	Panacces	Panaccess Systems GmbH
 38:59:F8	Mindmade	MindMade Sp. z o.o.
 38:59:F9	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
@@ -20150,10 +20531,12 @@
 38:66:45	OosicTec	OOSIC Technology CO.,Ltd
 38:66:F0	Apple	Apple, Inc.
 38:67:93	AsiaOpti	Asia Optical Co., Inc.
+38:68:DD	Inventec	Inventec Corporation
 38:6B:1C	Shenzhen	Shenzhen Mercury Communication Technologies Co.,Ltd.
 38:6B:BB	ArrisGro	ARRIS Group, Inc.
 38:6C:9B	IvyBiome	Ivy Biomedical
 38:6E:21	WasionGr	Wasion Group Ltd.
+38:6E:88	Zte	zte corporation
 38:6E:A2	VivoMobi	vivo Mobile Communication Co., Ltd.
 38:70:0C	ArrisGro	ARRIS Group, Inc.
 38:71:DE	Apple	Apple, Inc.
@@ -20176,11 +20559,16 @@
 38:73:EA:E0:00:00/28	Shenzhen	Shenzhen Jixian Technology Co., Ltd.
 38:76:CA	Shenzhen	Shenzhen Smart Intelligent Technology Co.Ltd
 38:76:D1	Euronda	Euronda SpA
+38:78:62	SonyMobi	Sony Mobile Communications Inc
 38:7B:47	Akela	AKELA, Inc.
+38:80:DF	Motorola	Motorola Mobility LLC, a Lenovo Company
+38:81:D7	TexasIns	Texas Instruments
 38:83:45	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 38:86:02	Flexopti	Flexoptix GmbH
+38:89:2C	Apple	Apple, Inc.
 38:89:DC	OpticonS	Opticon Sensors Europe B.V.
 38:8A:B7	ItcNetwo	ITC Networks
+38:8B:59	Google	Google, Inc.
 38:8C:50	LgElectr	LG Electronics
 38:8E:E7	Fanhatta	Fanhattan LLC
 38:90:A5	Cisco	Cisco Systems, Inc
@@ -20207,9 +20595,11 @@
 38:AC:3D	Nephos	Nephos Inc
 38:AD:8E	NewH3cTe	New H3C Technologies Co., Ltd
 38:AD:BE	NewH3cTe	New H3C Technologies Co., Ltd
+38:AF:29	Zhejiang	Zhejiang Dahua Technology Co., Ltd.
 38:AF:D7	Fujitsu	Fujitsu Limited
 38:B1:2D	Sonotron	Sonotronic Nagel GmbH
 38:B1:DB	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
+38:B4:D3	BshHausg	BSH Hausgeraete GmbH
 38:B5:4D	Apple	Apple, Inc.
 38:B5:BD	EGOElekt	E.G.O. Elektro-Ger
 38:B7:25	WistronI	Wistron Infocomm (Zhongshan) Corporation
@@ -20230,6 +20620,7 @@
 38:B8:EB:C0:00:00/28	Ajax	Ajax Systems Inc
 38:B8:EB:D0:00:00/28	Yellowbr	Yellowbrick Data, Inc.
 38:B8:EB:E0:00:00/28	WyresSas	Wyres SAS
+38:BA:F8	IntelCor	Intel Corporate
 38:BB:23	Ozvision	OzVision America LLC
 38:BB:3C	Avaya	Avaya Inc
 38:BC:01	HuaweiTe	Huawei Technologies Co.,Ltd
@@ -20287,7 +20678,7 @@
 38:FD:FE	IeeeRegi	IEEE Registration Authority
 38:FD:FE:00:00:00/28	EdgeI&D	Edge I&D Co., Ltd.
 38:FD:FE:10:00:00/28	WaytoneB	WAYTONE (BEIIJNG) COMMUNICATIONS CO.,LTD
-38:FD:FE:20:00:00/28	BUGSst	B.U.G.SST,Inc
+38:FD:FE:20:00:00/28	SmartSol	Smart Solution Technology, Inc
 38:FD:FE:30:00:00/28	SiemensP	Siemens AG, PG IE R&D
 38:FD:FE:40:00:00/28	NewTelec	New Telecom Solutions LLC
 38:FD:FE:50:00:00/28	Captivea	CaptiveAire Systems Inc.
@@ -20306,7 +20697,9 @@
 3A:5E:03	CirrusDa	Cirrus Data Solutions, Inc
 3A:A3:F8	Ieee8021	IEEE 802.1 Working Group
 3A:BA:37	Cirrent
+3A:CF:C5	Quicklin	Quickline AG
 3C:00:00	3Com
+3C:01:EF	SonyMobi	Sony Mobile Communications Inc
 3C:02:B1	Creation	Creation Technologies LP
 3C:04:61	ArrisGro	ARRIS Group, Inc.
 3C:04:BF	Pravis	PRAVIS SYSTEMS Co.Ltd.,
@@ -20327,6 +20720,8 @@
 3C:11:B2	Fraunhof	Fraunhofer FIT
 3C:15:C2	Apple	Apple, Inc.
 3C:15:EA	Tescom	Tescom Co., Ltd.
+3C:15:FB	HuaweiTe	Huawei Technologies Co.,Ltd
+3C:17:10	Sagemcom	Sagemcom Broadband SAS
 3C:18:9F	Nokia	Nokia Corporation
 3C:18:A0	Luxshare	Luxshare Precision Industry Company Limited
 3C:19:15	GfiChron	GFI Chrono Time
@@ -20337,10 +20732,27 @@
 3C:1C:BE	JadakLlc	Jadak Llc
 3C:1E:04	D-LinkIn	D-Link International
 3C:1E:13	Hangzhou	Hangzhou Sunrise Technology Co., Ltd
+3C:24:F0	IeeeRegi	IEEE Registration Authority
+3C:24:F0:00:00:00/28	Shenzhen	Shenzhen Pinsida Technology Co.,Ltd.
+3C:24:F0:10:00:00/28	Abrites	Abrites Ltd.
+3C:24:F0:20:00:00/28	LaipacTe	Laipac Technology Inc.
+3C:24:F0:30:00:00/28	Wisycom
+3C:24:F0:40:00:00/28	Inter-Co	Inter-Coastal Electronics
+3C:24:F0:50:00:00/28	CaskyEte	CASKY eTech Co., Ltd.
+3C:24:F0:60:00:00/28	InterAct	Inter Action Corporation
+3C:24:F0:70:00:00/28	Swissdot	Swissdotnet SA
+3C:24:F0:80:00:00/28	SivatTec	Sivat Technology Co.,Ltd.
+3C:24:F0:90:00:00/28	Siemens-	Siemens AG - Siemens Deutschland Mobility
+3C:24:F0:A0:00:00/28	Shenzhen	Shenzhen Bestway Technology Co., Ltd
+3C:24:F0:B0:00:00/28	Comatis
+3C:24:F0:C0:00:00/28	Authenti	Authentico Technologies
+3C:24:F0:D0:00:00/28	TravisBV	Travis Holding B.V.
+3C:24:F0:E0:00:00/28	Getmobit	Getmobit Llc
 3C:25:D7	Nokia	Nokia Corporation
 3C:26:D5	SoteraWi	Sotera Wireless
 3C:27:63	SleQuali	SLE quality engineering GmbH & Co. KG
 3C:2A:F4	BrotherI	Brother Industries, LTD.
+3C:2C:30	Dell	Dell Inc.
 3C:2C:94	杭州德澜科技有限	杭州德澜科技有限公司（HangZhou Delan Technology Co.,Ltd）
 3C:2C:99	Edgecore	Edgecore Networks Corporation
 3C:2D:B7	TexasIns	Texas Instruments
@@ -20353,6 +20765,7 @@
 3C:35:56	Cognitec	Cognitec Systems GmbH
 3C:36:3D	Nokia	Nokia Corporation
 3C:36:E4	ArrisGro	ARRIS Group, Inc.
+3C:37:86	Netgear
 3C:38:88	Connectq	ConnectQuest, llc
 3C:39:C3	JwElectr	JW Electronics Co., Ltd.
 3C:39:E7	IeeeRegi	IEEE Registration Authority
@@ -20374,6 +20787,22 @@
 3C:3A:73	Avaya	Avaya Inc
 3C:3F:51	2crsi
 3C:40:4F	Guangdon	Guangdong Pisen Electronics Co.,Ltd
+3C:42:7E	IeeeRegi	IEEE Registration Authority
+3C:42:7E:00:00:00/28	Grandway	Grandway Technology (Shenzhen) Limited
+3C:42:7E:10:00:00/28	Dongguan	Dongguan Taide Industrial Co.,Ltd.
+3C:42:7E:20:00:00/28	Starloop	Starloop Tech Co., Ltd.
+3C:42:7E:30:00:00/28	Shenzhen	Shenzhen VETAS Communication Technology Co , Ltd.
+3C:42:7E:40:00:00/28	Teknowar	Teknoware Oy
+3C:42:7E:50:00:00/28	GeoplanK	Geoplan Korea
+3C:42:7E:60:00:00/28	EditSrl	Edit Srl
+3C:42:7E:70:00:00/28	Gjs	GJS Co., Ltd.
+3C:42:7E:80:00:00/28	UbtechRo	Ubtech Robotics Corp
+3C:42:7E:90:00:00/28	Taitex	Taitex Corporation
+3C:42:7E:A0:00:00/28	Snap40	snap40 Ltd
+3C:42:7E:B0:00:00/28	CompalEl	Compal Electronics INC.
+3C:42:7E:C0:00:00/28	PrivacyL	Privacy Labs
+3C:42:7E:D0:00:00/28	RoboxSma	ROBOX SMART MOTION (WUHU) CO.,LTD
+3C:42:7E:E0:00:00/28	XiaoniuN	Xiaoniu network technology (Shanghai) Co., Ltd.
 3C:43:8E	ArrisGro	ARRIS Group, Inc.
 3C:46:D8	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 3C:47:11	HuaweiTe	Huawei Technologies Co.,Ltd
@@ -20385,12 +20814,14 @@
 3C:4E:47	Etronic	Etronic A/S
 3C:52:82	HewlettP	Hewlett Packard
 3C:57:4F	ChinaMob	China Mobile Group Device Co.,Ltd.
+3C:57:6C	SamsungE	Samsung Electronics Co.,Ltd
 3C:57:BD	KesslerC	Kessler Crane Inc.
 3C:57:D5	Fiveco
 3C:59:1E	TclKingE	TCL King Electrical Appliances (Huizhou) Co., Ltd
 3C:5A:37	SamsungE	Samsung Electronics Co.,Ltd
 3C:5A:B4	Google	Google, Inc.
 3C:5C:C3	Shenzhen	Shenzhen First Blue Chip Technology Ltd
+3C:5C:C4	AmazonTe	Amazon Technologies Inc.
 3C:5E:C3	Cisco	Cisco Systems, Inc
 3C:5F:01	Synerchi	Synerchip Co., Ltd.
 3C:61:04	JuniperN	Juniper Networks
@@ -20400,13 +20831,31 @@
 3C:67:2C	Sciovid	Sciovid Inc.
 3C:67:8C	HuaweiTe	Huawei Technologies Co.,Ltd
 3C:68:16	Vxi	VXi Corporation
+3C:6A:2C	IeeeRegi	IEEE Registration Authority
+3C:6A:2C:00:00:00/28	RioLagoT	Rio Lago Technologies  LLC
+3C:6A:2C:10:00:00/28	OlibraLl	Olibra LLC
+3C:6A:2C:20:00:00/28	BoschAut	Bosch Automotive Products (Suzhou) Co., Ltd.
+3C:6A:2C:30:00:00/28	Figur8	figur8, Inc.
+3C:6A:2C:40:00:00/28	XiAnYepT	XI'AN YEP TELECOM TECHNOLOGY CO.,LTD
+3C:6A:2C:50:00:00/28	QingdaoI	Qingdao iGuan Technology Co., Ltd.
+3C:6A:2C:60:00:00/28	LaBarriè	La Barrière Automatique
+3C:6A:2C:70:00:00/28	Homegear	Homegear GmbH
+3C:6A:2C:80:00:00/28	TpRadio	TP Radio
+3C:6A:2C:90:00:00/28	Wicks	WICKS Co., Ltd.
+3C:6A:2C:A0:00:00/28	Metro
+3C:6A:2C:B0:00:00/28	PhytiumT	Phytium Technology Co., Ltd.
+3C:6A:2C:C0:00:00/28	EltovSys	Eltov System
+3C:6A:2C:D0:00:00/28	XiamenSm	Xiamen Smarttek CO., Ltd.
+3C:6A:2C:E0:00:00/28	BeijingD	Beijing Donghua Hongtai Polytron Technologies Inc
 3C:6A:7D	NiigataP	Niigata Power Systems Co., Ltd.
 3C:6A:9D	DexatekT	Dexatek Technology LTD.
+3C:6A:A7	IntelCor	Intel Corporate
 3C:6E:63	MitronOy	Mitron OY
 3C:6F:45	Fiberpro	Fiberpro Inc.
 3C:6F:EA	Panasoni	Panasonic India Pvt. Ltd.
 3C:6F:F7	Entek	EnTek Systems, Inc.
 3C:70:59	Makerbot	MakerBot Industries
+3C:71:BF	Espressi	Espressif Inc.
 3C:74:37	Rim
 3C:75:4A	ArrisGro	ARRIS Group, Inc.
 3C:77:E6	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
@@ -20422,6 +20871,7 @@
 3C:83:B5	AdvanceV	Advance Vision Electronics Co. Ltd.
 3C:86:A8	Sangshin	Sangshin elecom .co,, LTD
 3C:89:70	Neosfar
+3C:89:94	Bskyb	BSkyB Ltd
 3C:89:A6	Kapelse
 3C:8A:B0	JuniperN	Juniper Networks
 3C:8A:E5	TensunIn	Tensun Information Technology(Hangzhou) Co.,LTD
@@ -20438,9 +20888,11 @@
 3C:95:09	LiteonTe	Liteon Technology Corporation
 3C:97:0E	WistronI	Wistron InfoComm(Kunshan)Co.,Ltd.
 3C:97:7E	IpsTechn	IPS Technology Limited
+3C:98:72	Sercomm	Sercomm Corporation.
 3C:98:BF	QuestCon	Quest Controls, Inc.
 3C:99:F7	Lansente	Lansentechnology AB
 3C:9A:77	Technico	Technicolor CH USA Inc.
+3C:9B:D6	Vizio	Vizio, Inc
 3C:9F:81	Shenzhen	Shenzhen CATIC Bit Communications Technology Co.,Ltd
 3C:A0:67	LiteonTe	Liteon Technology Corporation
 3C:A1:0D	SamsungE	Samsung Electronics Co.,Ltd
@@ -20478,6 +20930,7 @@
 3C:CA:87	Iders	Iders Incorporated
 3C:CB:7C	TctMobil	TCT mobile ltd
 3C:CD:5A	Technisc	Technische Alternative GmbH
+3C:CD:5D	HuaweiTe	Huawei Technologies Co.,Ltd
 3C:CD:93	LgElectr	Lg Electronics Inc
 3C:CE:15	Mercedes	Mercedes-Benz USA, LLC
 3C:CE:73	Cisco	Cisco Systems, Inc
@@ -20495,16 +20948,20 @@
 3C:DF:A9	ArrisGro	ARRIS Group, Inc.
 3C:DF:BD	HuaweiTe	Huawei Technologies Co.,Ltd
 3C:E0:72	Apple	Apple, Inc.
+3C:E1:A1	Universa	Universal Global Scientific Industrial Co., Ltd.
 3C:E5:A6	Hangzhou	Hangzhou H3C Technologies Co., Limited
 3C:E5:B4	KidasenI	Kidasen Industria E Comercio De Antenas Ltda
 3C:E6:24	LgDispla	LG Display
 3C:E8:24	HuaweiTe	Huawei Technologies Co.,Ltd
 3C:EA:4F	2wire	2Wire Inc
+3C:EA:F9	Jubixcol	Jubixcoltd
 3C:EA:FB	Nse	Nse Ag
 3C:EF:8C	Zhejiang	Zhejiang Dahua Technology Co., Ltd.
 3C:F3:92	Virtualt	Virtualtek. Co. Ltd
+3C:F4:F9	Moda-Inn	Moda-InnoChips
 3C:F5:2C	Dspecial	DSPECIALISTS GmbH
 3C:F5:91	Guangdon	Guangdong Oppo Mobile Telecommunications Corp.,Ltd
+3C:F5:CC	NewH3cTe	New H3C Technologies Co., Ltd
 3C:F7:2A	Nokia	Nokia Corporation
 3C:F7:48	Shenzhen	Shenzhen Linsn Technology Development Co.,Ltd
 3C:F7:A4	SamsungE	Samsung Electronics Co.,Ltd
@@ -20520,6 +20977,7 @@
 40:01:7A	Cisco	Cisco Systems, Inc
 40:01:C6	3comEuro	3COM EUROPE LTD
 40:04:0C	A&T
+40:06:A0	TexasIns	Texas Instruments
 40:07:C0	Railtec	Railtec Systems GmbH
 40:0D:10	ArrisGro	ARRIS Group, Inc.
 40:0E:67	Tremol	Tremol Ltd.
@@ -20532,19 +20990,22 @@
 40:16:7E	AsustekC	ASUSTek COMPUTER INC.
 40:16:9F	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 40:16:FA	EkmMeter	EKM Metering
+40:17:E2	IntaiTec	Intai Technology Corp.
 40:18:B1	Aerohive	Aerohive Networks Inc.
 40:18:D7	Smartron	Smartronix, Inc.
-40:1B:5F	WeifangG	Weifang GoerTek Technology Co.,Ltd.
+40:1B:5F	WeifangG	Weifang Goertek Electronics Co.,Ltd
 40:1D:59	Biometri	Biometric Associates, LP
 40:22:ED	DigitalP	Digital Projection Ltd
 40:25:C2	IntelCor	Intel Corporate
+40:26:19	Apple	Apple, Inc.
 40:27:0B	Mobileec	Mobileeco Co., Ltd
 40:28:14	RfiEngin	RFI Engineering
-40:2B:A1	SonyMobi	Sony Mobile Communications AB
+40:2B:A1	SonyMobi	Sony Mobile Communications Inc
 40:2C:F4	Universa	Universal Global Scientific Industrial Co., Ltd.
 40:2E:28	Mixtelem	MiXTelematics
 40:30:04	Apple	Apple, Inc.
 40:30:67	ConlogPt	Conlog (Pty) Ltd
+40:31:3C	XiaomiEl	XIAOMI Electronics,CO.,LTD
 40:33:1A	Apple	Apple, Inc.
 40:33:6C	GodrejBo	Godrej & Boyce Mfg. co. ltd
 40:37:AD	MacroIma	Macro Image Technology, Inc.
@@ -20553,7 +21014,7 @@
 40:3F:8C	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 40:40:22	Ziv
 40:40:6B	Icomera
-40:40:A7	SonyMobi	Sony Mobile Communications AB
+40:40:A7	SonyMobi	Sony Mobile Communications Inc
 40:42:29	Layer3tv	Layer3TV, Inc
 40:45:DA	Spreadtr	Spreadtrum Communications (Shanghai) Co., Ltd.
 40:47:6A	Acquisit	AG Acquisition Corp. d.b.a. ASTRO Gaming
@@ -20582,6 +21043,7 @@
 40:4D:8E	HuaweiTe	Huawei Technologies Co.,Ltd
 40:4E:36	Htc	HTC Corporation
 40:4E:EB	HigherWa	Higher Way Electronic Co., Ltd.
+40:50:B5	Shenzhen	Shenzhen New Species Technology Co., Ltd.
 40:50:E0	MiltonSe	Milton Security Group LLC
 40:51:6C	GrandexI	Grandex International Corporation
 40:52:0D	PicoTech	Pico Technology
@@ -20589,6 +21051,7 @@
 40:55:39	Cisco	Cisco Systems, Inc
 40:56:0C	InHomeDi	In Home Displays Ltd
 40:56:2D	Smartron	Smartron India Pvt ltd
+40:56:62	Guotengs	GuoTengShengHua Electronics LTD.
 40:5A:9B	Anovo
 40:5C:FD	Dell	Dell Inc.
 40:5D:82	Netgear
@@ -20598,7 +21061,9 @@
 40:60:5A	HawkeyeT	Hawkeye Tech Co. Ltd
 40:61:86	Micro-St	MICRO-STAR INT'L CO.,LTD
 40:61:8E	Stella-G	Stella-Green Co
+40:62:31	Gifa
 40:62:B6	TeleSyst	Tele system communication
+40:62:EA	ChinaMob	China Mobile Group Device Co.,Ltd.
 40:64:A4	Furukawa	The Furukawa Electric Co., Ltd
 40:65:A3	Sagemcom	Sagemcom Broadband SAS
 40:66:7A	Mediola-	mediola - connected living AG
@@ -20620,6 +21085,7 @@
 40:7D:0F	HuaweiTe	Huawei Technologies Co.,Ltd
 40:7F:E0	GlorySta	Glory Star Technics (ShenZhen) Limited
 40:82:56	Continen	Continental Automotive GmbH
+40:83:1D	Apple	Apple, Inc.
 40:83:DE	ZebraTec	Zebra Technologies Inc
 40:84:93	Claviste	Clavister AB
 40:86:2E	JdmMobil	Jdm Mobile Internet Solution Co., Ltd.
@@ -20643,6 +21109,7 @@
 40:9F:38	Azurewav	AzureWave Technology Inc.
 40:9F:87	JideTech	Jide Technology (Hong Kong) Limited
 40:9F:C7	Baekchun	BAEKCHUN I&C Co., Ltd.
+40:A1:08	Motorola	Motorola (Wuhan) Mobility Technologies Communication Co., Ltd.
 40:A3:6B:00:00:00/28	FinRobot	Fin Robotics Inc
 40:A3:6B:10:00:00/28	Tw-Teamw	TW-TeamWare
 40:A3:6B:20:00:00/28	Toproott	TOPROOTTechnology Corp. Ltd.
@@ -20677,7 +21144,7 @@
 40:B6:88	LegicIde	LEGIC Identsystems AG
 40:B6:B1	Sungsam	SUNGSAM CO,.Ltd
 40:B7:F3	ArrisGro	ARRIS Group, Inc.
-40:B8:37	SonyMobi	Sony Mobile Communications AB
+40:B8:37	SonyMobi	Sony Mobile Communications Inc
 40:B8:9A	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 40:B9:3C	HewlettP	Hewlett Packard Enterprise
 40:BA:61	ArimaCom	ARIMA Communications Corp.
@@ -20687,14 +21154,17 @@
 40:BD:9E	Physio-C	Physio-Control, Inc
 40:BF:17	Digistar	Digistar Telecom. SA
 40:C2:45	Shenzhen	Shenzhen Hexicom Technology Co., Ltd.
+40:C3:C6	Snaprout	SnapRoute
 40:C4:D6	Chongqin	ChongQing Camyu Technology Development Co.,Ltd.
 40:C6:2A	Shanghai	Shanghai Jing Ren Electronic Technology Co., Ltd.
 40:C7:29	Sagemcom	Sagemcom Broadband SAS
 40:C7:C9	Naviit	Naviit Inc.
+40:C8:1F	Shenzhen	Shenzhen Xinguodu Technology Co., Ltd.
 40:C8:CB	AmTeleco	AM Telecom co., Ltd.
 40:CB:A8	HuaweiTe	Huawei Technologies Co.,Ltd
 40:CB:C0	Apple	Apple, Inc.
 40:CD:3A	Z3Techno	Z3 Technology
+40:CD:7A	QingdaoH	Qingdao Hisense Communications Co.,Ltd.
 40:CE:24	Cisco	Cisco Systems, Inc
 40:D2:8A	Nintendo	Nintendo Co., Ltd.
 40:D3:2D	Apple	Apple, Inc.
@@ -20720,7 +21190,7 @@
 40:D8:55:00:D0:00/36	Huns
 40:D8:55:00:E0:00/36	Brightwe	Brightwell Dispensers
 40:D8:55:00:F0:00/36	DigitalD	Digital Dynamics, Inc.
-40:D8:55:01:00:00/36	ApgCashD	Apg Cash Drawer
+40:D8:55:01:00:00/36	ApgCashD	APG Cash Drawer, LLC
 40:D8:55:01:10:00/36	FleximSe	Flexim Security Oy
 40:D8:55:01:20:00/36	Sencon	Sencon Inc.
 40:D8:55:01:30:00/36	GrandeVi	Grande Vitesse Systems
@@ -20782,7 +21252,7 @@
 40:D8:55:04:B0:00/36	VitalTec	Vital Tech Industria e Comercio Ltda
 40:D8:55:04:C0:00/36	Serveron	Serveron Corporation
 40:D8:55:04:D0:00/36	Machinep	MACHINEPERFORMANCE ApS
-40:D8:55:04:E0:00/36	Honeywel	Honeywell Aerospace/Intelligent Automation Corp.
+40:D8:55:04:E0:00/36	Honeywel	Honeywell International
 40:D8:55:04:F0:00/36	HaeinS&S	Haein S&S Co., Ltd
 40:D8:55:05:00:00/36	AtgUvTec	ATG UV Technology
 40:D8:55:05:10:00/36	CsInstru	CS Instruments Asia
@@ -20899,7 +21369,7 @@
 40:D8:55:0C:00:00/36	Act
 40:D8:55:0C:10:00/36	XeptoCom	Xepto Computing Inc
 40:D8:55:0C:20:00/36	ScTechsw	SC Techswarm SRL
-40:D8:55:0C:30:00/36	ApgCashD	Apg Cash Drawer
+40:D8:55:0C:30:00/36	ApgCashD	APG Cash Drawer, LLC
 40:D8:55:0C:40:00/36	Inspired	Inspired Systems
 40:D8:55:0C:50:00/36	MMElektr	M.M. Elektrolab
 40:D8:55:0C:60:00/36	Comtime	comtime GmbH
@@ -20948,7 +21418,7 @@
 40:D8:55:0F:10:00/36	Grossenb	Grossenbacher Systeme AG
 40:D8:55:0F:20:00/36	Sigmaphi	SigmaPhi Electronics
 40:D8:55:0F:30:00/36	Econ	ECON Systems Inc.
-40:D8:55:0F:40:00/36	MbConnec	MB Connect Line GmbH
+40:D8:55:0F:40:00/36	MbConnec	MB connect line GmbH Fernwartungssysteme
 40:D8:55:0F:50:00/36	CstGroup	CST Group
 40:D8:55:0F:60:00/36	Private
 40:D8:55:0F:70:00/36	ComlineE	Comline Elektronik Elektrotechnik GmbH
@@ -20959,7 +21429,7 @@
 40:D8:55:0F:C0:00/36	EumigInd	eumig industrie-tv GmbH
 40:D8:55:0F:D0:00/36	Monogram	MONOGRAM technologies ltd
 40:D8:55:0F:E0:00/36	CytechTe	Cytech Technology Pte Ltd
-40:D8:55:0F:F0:00/36	YuyamaMf	YUYAMA　MFG．ＣＯ．，ＬＴＤ．
+40:D8:55:0F:F0:00/36	YuyamaMf	YUYAMA MFG Co.,Ltd
 40:D8:55:10:00:00/36	TaskSist	Task Sistemas De Computacao S.A.
 40:D8:55:10:10:00/36	EPGElett	e.p.g. Elettronica Srl
 40:D8:55:10:20:00/36	PowerEle	Power Electronics Espana, S.L.
@@ -21191,6 +21661,7 @@
 40:D8:55:1E:40:00/36	Stek	STEK Ltd
 40:D8:55:50:D0:00/36	Shenzhen	Shenzhen MaiWei Cable TV Equipment CO.,LTD.
 40:D8:55:EE:60:00/36	Narinet	Narinet, Inc.
+40:DC:9D	Hajen
 40:E2:30	Azurewav	AzureWave Technology Inc.
 40:E3:D6	ArubaNet	Aruba Networks
 40:E7:30	DeyStora	DEY Storage Systems, Inc.
@@ -21213,8 +21684,10 @@
 40:ED:98:C0:00:00/28	Bloomsky	BloomSky,Inc.
 40:ED:98:D0:00:00/28	Hangzhou	Hangzhou GANX Technology Co.,Ltd.
 40:ED:98:E0:00:00/28	BordaTec	Borda Technology
+40:EE:DD	HuaweiTe	Huawei Technologies Co.,Ltd
 40:EF:4C	Fihonest	Fihonest communication co.,Ltd
 40:F0:2F	LiteonTe	Liteon Technology Corporation
+40:F0:4E	Integrat	Integrated Device Technology (Malaysia) Sdn. Bhd.
 40:F1:4C	IseEurop	ISE Europe SPRL
 40:F2:01	Sagemcom	Sagemcom Broadband SAS
 40:F2:E9	Ibm
@@ -21244,9 +21717,11 @@
 40:FC:89	ArrisGro	ARRIS Group, Inc.
 40:FE:0D	Maxio
 44:00:10	Apple	Apple, Inc.
+44:00:49	AmazonTe	Amazon Technologies Inc.
 44:03:2C	IntelCor	Intel Corporate
 44:03:A7	Cisco	Cisco Systems, Inc
 44:04:44	Guangdon	Guangdong Oppo Mobile Telecommunications Corp.,Ltd
+44:07:0B	Google	Google, Inc.
 44:09:B8	SalcompS	Salcomp (Shenzhen) CO., LTD.
 44:0C:FD	Netman	NetMan Co., Ltd.
 44:11:02	EdmiEuro	EDMI  Europe Ltd
@@ -21257,7 +21732,9 @@
 44:19:B6	Hangzhou	Hangzhou Hikvision Digital Technology Co.,Ltd.
 44:1C:A8	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 44:1E:91	ArvidaIn	ARVIDA Intelligent Electronics Technology  Co.,Ltd.
+44:1E:98	RuckusWi	Ruckus Wireless
 44:1E:A1	HewlettP	Hewlett Packard
+44:22:F1	SFac	S.Fac, Inc
 44:23:AA	Farmage	Farmage Co., Ltd.
 44:25:BB	BambooEn	Bamboo Entertainment Corporation
 44:29:38	Nietzsch	NietZsche enterprise Co.Ltd.
@@ -21270,6 +21747,7 @@
 44:32:C8	Technico	Technicolor CH USA Inc.
 44:33:4C	Shenzhen	Shenzhen Bilian electronic CO.,LTD
 44:34:8F	MxtIndus	Mxt Industrial Ltda
+44:34:A7	ArrisGro	ARRIS Group, Inc.
 44:35:6F	Neterix
 44:37:08	MrvComun	MRV Comunications
 44:37:19	2SaveEne	2 Save Energy Ltd
@@ -21283,10 +21761,12 @@
 44:44:50	Ottoq
 44:45:53	Microsoft
 44:46:49	DfiDiamo	DFI (Diamond Flower Industries)
+44:47:CC	Hangzhou	Hangzhou Hikvision Digital Technology Co.,Ltd.
 44:48:91	HdmiLice	HDMI Licensing, LLC
 44:48:C1	HewlettP	Hewlett Packard Enterprise
 44:4A:65	Silverfl	Silverflare Ltd.
 44:4A:B0	Zhejiang	Zhejiang Moorgen Intelligence Technology Co., Ltd
+44:4B:5D	GeHealth	GE Healthcare
 44:4C:0C	Apple	Apple, Inc.
 44:4C:A8	AristaNe	Arista Networks
 44:4E:1A	SamsungE	Samsung Electronics Co.,Ltd
@@ -21308,7 +21788,9 @@
 44:62:46	Comat	Comat AG
 44:65:0D	AmazonTe	Amazon Technologies Inc.
 44:65:6A	MegaVide	Mega Video Electronic(HK) Industry Co., Ltd
+44:65:7F	Calix	Calix Inc.
 44:66:6E	Ip-Line
+44:66:FC	Guangdon	Guangdong Oppo Mobile Telecommunications Corp.,Ltd
 44:67:55	OrbitIrr	Orbit Irrigation
 44:68:AB	Juin	Juin Company, Limited
 44:6A:2E	HuaweiTe	Huawei Technologies Co.,Ltd
@@ -21320,7 +21802,7 @@
 44:70:0B	Iffu
 44:70:98	MingHong	MING HONG TECHNOLOGY (SHEN ZHEN) LIMITED
 44:73:D6	Logitech
-44:74:6C	SonyMobi	Sony Mobile Communications AB
+44:74:6C	SonyMobi	Sony Mobile Communications Inc
 44:78:3E	SamsungE	Samsung Electronics Co.,Ltd
 44:7B:BB	Shenzhen	Shenzhen YOUHUA Technology Co., Ltd
 44:7B:C4	Dualshin	DualShine Technology(SZ)Co.,Ltd
@@ -21353,6 +21835,7 @@
 44:9E:F9	VivoMobi	vivo Mobile Communication Co., Ltd.
 44:9F:7F	Datacore	DataCore Software Corporation
 44:A4:2D	TctMobil	TCT mobile ltd
+44:A4:66	GroupeLd	Groupe Ldlc
 44:A6:89	PromaxEl	Promax Electronica Sa
 44:A6:E5	Thinking	Thinking Technology Co.,Ltd
 44:A7:CF	MurataMa	Murata Manufacturing Co., Ltd.
@@ -21387,7 +21870,7 @@
 44:D2:CA	AnviaTvO	Anvia TV Oy
 44:D3:CA	Cisco	Cisco Systems, Inc
 44:D4:37	IntenoBr	Inteno Broadband Technology AB
-44:D4:E0	SonyMobi	Sony Mobile Communications AB
+44:D4:E0	SonyMobi	Sony Mobile Communications Inc
 44:D5:A5	AddonCom	AddOn Computer
 44:D6:3D	TalariNe	Talari Networks
 44:D6:E1	SnuzaInt	Snuza International Pty. Ltd.
@@ -21400,6 +21883,7 @@
 44:E1:37	ArrisGro	ARRIS Group, Inc.
 44:E4:9A	Omnitron	Omnitronics Pty Ltd
 44:E4:D9	Cisco	Cisco Systems, Inc
+44:E4:EE	WistronN	Wistron Neweb Corporation
 44:E8:A5	MyrekaTe	Myreka Technologies Sdn. Bhd.
 44:E9:DD	Sagemcom	Sagemcom Broadband SAS
 44:EA:4B	Actlas	Actlas Inc.
@@ -21407,6 +21891,7 @@
 44:ED:57	Longicor	Longicorn, inc.
 44:EE:02	Mti	MTI Ltd.
 44:EE:30	Budelman	Budelmann Elektronik GmbH
+44:EF:CF	UgeneSol	UGENE SOLUTION inc.
 44:F0:34	Kaonmedi	Kaonmedia CO., LTD.
 44:F4:36	Zte	zte corporation
 44:F4:59	SamsungE	Samsung Electronics Co.,Ltd
@@ -21414,12 +21899,29 @@
 44:F8:49	UnionPac	Union Pacific Railroad
 44:FB:42	Apple	Apple, Inc.
 44:FD:A3	Everysig	Everysight LTD.
+44:FF:BA	Zte	zte corporation
 47:54:43	GtcNotRe	GTC (Not registered!)	# (This number is a multicast!)
 48:00:31	HuaweiTe	Huawei Technologies Co.,Ltd
 48:00:33	Technico	Technicolor CH USA Inc.
 48:02:2A	B-LinkEl	B-Link Electronic Limited
 48:03:62	DesayEle	DESAY ELECTRONICS(HUIZHOU)CO.,LTD
 48:06:6A	Tempered	Tempered Networks, Inc.
+48:0B:B2	IeeeRegi	IEEE Registration Authority
+48:0B:B2:00:00:00/28	RidangoA	Ridango AS
+48:0B:B2:10:00:00/28	BajaElec	Baja Electronics Technology Limited
+48:0B:B2:20:00:00/28	ThalesCe	Thales CETCA Avionics CO., Ltd
+48:0B:B2:30:00:00/28	Shanghai	shanghai Rinlink  Intelligent Technology Co., Ltd.
+48:0B:B2:40:00:00/28	Hangzhou	Hangzhou Freely Communication Co., Ltd.
+48:0B:B2:50:00:00/28	Solaredg	Solaredge LTD.
+48:0B:B2:60:00:00/28	Annapurn	annapurnalabs
+48:0B:B2:70:00:00/28	BeijingD	Beijing Dragon Resources Limited.
+48:0B:B2:80:00:00/28	Bravocom	BravoCom（xiamen）TechCo.Ltd
+48:0B:B2:90:00:00/28	Micropro	Microprogram Information Co., Ltd
+48:0B:B2:A0:00:00/28	XiamenRo	Xiamen Rongta Technology Co.,Ltd.
+48:0B:B2:B0:00:00/28	PopitOy	Popit Oy
+48:0B:B2:C0:00:00/28	Shenzhen	Shenzhen Topwell Technology Co..Ltd
+48:0B:B2:D0:00:00/28	M2lab	M2Lab Ltd.
+48:0B:B2:E0:00:00/28	BeijingM	Beijing MFOX technology Co., Ltd.
 48:0C:49	Nakayo	NAKAYO Inc
 48:0E:EC	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 48:0F:CF	HewlettP	Hewlett Packard
@@ -21429,15 +21931,19 @@
 48:13:F3	BbkEduca	Bbk Educational Electronics Corp.,Ltd.
 48:17:4C	Micropow	MicroPower technologies
 48:18:42	Shanghai	Shanghai Winaas Co. Equipment Co. Ltd.
+48:18:FA	Nocsys
 48:1A:84	PointerT	Pointer Telocation Ltd
 48:1B:D2	IntronSc	Intron Scientific co., ltd.
 48:1D:70	CiscoSpv	Cisco SPVTG
 48:26:E8	Tek-Air	Tek-Air Systems, Inc.
 48:27:EA	SamsungE	Samsung Electronics Co.,Ltd
 48:28:2F	Zte	zte corporation
+48:2A:E3	WistronI	Wistron InfoComm(Kunshan)Co.,Ltd.
+48:2C:A0	XiaomiCo	Xiaomi Communications Co Ltd
 48:2C:EA	Motorola	Motorola Inc Business Light Radios
 48:33:DD	ZennioAv	Zennio Avance Y Tecnologia, S.L.
 48:34:3D	Iep	IEP GmbH
+48:35:2E	Shenzhen	Shenzhen Wolck Network Product Co.,LTD
 48:36:5F	Wintecro	Wintecronics Ltd.
 48:39:74	ProwareT	Proware Technologies Co., Ltd.
 48:3B:38	Apple	Apple, Inc.
@@ -21452,6 +21958,7 @@
 48:46:F1	UrosOy	Uros Oy
 48:46:FB	HuaweiTe	Huawei Technologies Co.,Ltd
 48:49:C7	SamsungE	Samsung Electronics Co.,Ltd
+48:4A:E9	HewlettP	Hewlett Packard Enterprise
 48:4B:AA	Apple	Apple, Inc.
 48:4C:00	NetworkS	Network Solutions
 48:4D:7E	Dell	Dell Inc.
@@ -21462,6 +21969,7 @@
 48:54:E8	Winbond?
 48:55:5C	WuQiTech	Wu Qi Technologies,Inc.
 48:55:5F	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
+48:57:02	HuaweiTe	Huawei Technologies Co.,Ltd
 48:57:DD	Facebook	Facebook Inc
 48:59:29	LgElectr	LG Electronics (Mobile Communications)
 48:59:A4	Zte	zte corporation
@@ -21470,6 +21978,8 @@
 48:5B:39	AsustekC	ASUSTek COMPUTER INC.
 48:5D:36	Verizon
 48:5D:60	Azurewav	AzureWave Technology Inc.
+48:5F:99	CloudNet	Cloud Network Technology (Samoa) Limited
+48:60:5F	LgElectr	LG Electronics (Mobile Communications)
 48:60:BC	Apple	Apple, Inc.
 48:61:A3	ConcernA	Concern Axion JSC
 48:62:76	HuaweiTe	Huawei Technologies Co.,Ltd
@@ -21489,6 +21999,7 @@
 48:65:EE:C0:00:00/28	DnvGl	Dnv Gl
 48:65:EE:D0:00:00/28	WinnTech	Winn Technology Co.,Ltd
 48:65:EE:E0:00:00/28	Cnu
+48:68:34	SiliconM	Silicon Motion, Inc.
 48:6B:2C	BbkEduca	Bbk Educational Electronics Corp.,Ltd.
 48:6B:91	Fleetwoo	Fleetwood Group Inc.
 48:6D:BB	VestelEl	Vestel Elektronik San ve Tic. A.Ş.
@@ -21497,6 +22008,7 @@
 48:6F:D2	Storsimp	StorSimple Inc
 48:71:19	SgbGroup	Sgb Group Ltd.
 48:74:6E	Apple	Apple, Inc.
+48:75:83	Intellio	Intellion AG
 48:76:04	Private
 48:7A:55	AleInter	ALE International
 48:7A:DA	Hangzhou	Hangzhou H3C Technologies Co., Limited
@@ -21506,24 +22018,31 @@
 48:82:F2	AppelEle	Appel Elektronik GmbH
 48:83:C7	Sagemcom	Sagemcom Broadband SAS
 48:86:E8	Microsof	Microsoft Corporation
+48:87:2D	ShenZhen	Shen Zhen Da Xia Long Que Technology Co.,Ltd
 48:88:03	Mantechn	ManTechnology Inc.
+48:88:1E	Ethoswit	EthoSwitch LLC
 48:88:CA	Motorola	Motorola (Wuhan) Mobility Technologies Communication Co., Ltd.
-48:8A:D2	Shenzhen	Shenzhen Mercury Communication Technologies Co.,Ltd.
+48:8A:D2	MercuryC	Mercury Communication Technologies Co.,Ltd.
 48:8D:36	Arcadyan	Arcadyan Corporation
 48:8E:42	Digalog	DIGALOG GmbH
 48:8E:EF	HuaweiTe	Huawei Technologies Co.,Ltd
 48:91:53	Weinmann	Weinmann Geräte für Medizin GmbH + Co. KG
 48:91:F6	Shenzhen	Shenzhen Reach software technology CO.,LTD
+48:98:CA	SichuanA	Sichuan AI-Link Technology Co., Ltd.
 48:9A:42	Technoma	Technomate Ltd
 48:9B:E2	SciInnov	SCI Innovations Ltd
 48:9D:18	Flashbay	Flashbay Limited
 48:9D:24	Blackber	BlackBerry RTS
+48:A0:F8	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 48:A1:95	Apple	Apple, Inc.
 48:A2:2D	Shenzhen	Shenzhen Huaxuchang Telecom Technology Co.,Ltd
 48:A2:B7	KodofonJ	Kodofon JSC
 48:A3:80	GioneeCo	Gionee Communication Equipment Co.,Ltd.
+48:A4:72	IntelCor	Intel Corporate
+48:A6:B8	Sonos	Sonos, Inc.
 48:A6:D2	GjsunOpt	GJsun Optical Science and Tech Co.,Ltd.
 48:A7:4E	Zte	zte corporation
+48:A9:1C	Apple	Apple, Inc.
 48:A9:D2	WistronN	Wistron Neweb Corporation
 48:AA:5D	StoreEle	Store Electronic Systems
 48:AD:08	HuaweiTe	Huawei Technologies Co.,Ltd
@@ -21535,6 +22054,7 @@
 48:B9:C2	Teletics	Teletics Inc.
 48:BA:4E	HewlettP	Hewlett Packard
 48:BC:A6	​AsungTe	​ASUNG TECHNO CO.,Ltd
+48:BD:3D	NewH3cTe	New H3C Technologies Co., Ltd
 48:BE:2D	Symanitr	Symanitron
 48:BF:6B	Apple	Apple, Inc.
 48:BF:74	Baicells	Baicells Technologies Co.,LTD
@@ -21562,6 +22082,7 @@
 48:DA:96	EddySmar	Eddy Smart Home Solutions Inc.
 48:DB:50	HuaweiTe	Huawei Technologies Co.,Ltd
 48:DC:FB	Nokia	Nokia Corporation
+48:DD:9D	ItelMobi	Itel Mobile Limited
 48:DF:1C	WuhanNec	Wuhan NEC Fibre Optic Communications industry Co. Ltd
 48:DF:37	HewlettP	Hewlett Packard Enterprise
 48:E1:AF	Vity
@@ -21574,6 +22095,7 @@
 48:EE:07	SilverPa	Silver Palm Technologies LLC
 48:EE:0C	D-LinkIn	D-Link International
 48:EE:86	Utstarco	UTStarcom (China) Co.,Ltd
+48:F0:27	ChengduN	Chengdu newifi Co.,Ltd
 48:F0:7B	AlpsElec	Alps Electric Co.,Ltd.
 48:F2:30	Ubizcore	Ubizcore Co.,LTD
 48:F3:17	Private
@@ -21590,9 +22112,11 @@
 48:FE:EA	HomaBV	Homa B.V.
 4A:07:D6	Ieee8021	IEEE 802.1 Working Group
 4A:19:1B	ZigbeeAl	ZigBee Alliance
+4A:5A:6F	AppliedM	Applied Materials
 4A:72:06	Caire	CAIRE, Inc.
 4A:DA:10	EmotivaA	Emotiva Audio Corp
 4C:00:82	Cisco	Cisco Systems, Inc
+4C:01:43	Eero	eero inc.
 4C:02:2E	CmrKorea	Cmr Korea Co., Ltd
 4C:02:89	LexCompu	Lex Computech Co., Ltd
 4C:06:8A	BaslerEl	Basler Electric Company
@@ -21603,8 +22127,10 @@
 4C:0B:BE	Microsof	Microsoft
 4C:0D:EE	JabilCir	JABIL CIRCUIT (SHANGHAI) LTD.
 4C:0F:6E	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
-4C:0F:C7	EardaEle	Earda Electronics Co.,Ltd
+4C:0F:C7	EardaTec	Earda Technologies co Ltd
+4C:11:59	VisionIn	Vision Information & Communications
 4C:11:BF	Zhejiang	Zhejiang Dahua Technology Co., Ltd.
+4C:12:65	ArrisGro	ARRIS Group, Inc.
 4C:13:65	EmplusTe	Emplus Technologies
 4C:14:80	Noregon	Noregon Systems, Inc
 4C:14:A3	TclTechn	TCL Technoly Electronics (Huizhou) Co., Ltd.
@@ -21616,8 +22142,9 @@
 4C:1A:3A	PrimaRes	PRIMA Research And Production Enterprise Ltd.
 4C:1A:3D	Guangdon	Guangdong Oppo Mobile Telecommunications Corp.,Ltd
 4C:1A:95	Novakon	Novakon Co., Ltd.
+4C:1B:86	Arcadyan	Arcadyan Corporation
 4C:1F:CC	HuaweiTe	Huawei Technologies Co.,Ltd
-4C:21:D0	SonyMobi	Sony Mobile Communications AB
+4C:21:D0	SonyMobi	Sony Mobile Communications Inc
 4C:22:58	Cozybit	cozybit, Inc.
 4C:25:78	Nokia	Nokia Corporation
 4C:26:E7	Welgate	Welgate Co., Ltd.
@@ -21630,12 +22157,14 @@
 4C:32:D9	MRuttyHo	M Rutty Holdings Pty. Ltd.
 4C:33:4E	Hightech
 4C:34:88	IntelCor	Intel Corporate
+4C:36:4E	Panasoni	Panasonic Corporation  Connected Solutions Company
 4C:38:D5	MitacCom	Mitac Computing Technology Corporation
 4C:38:D8	ArrisGro	ARRIS Group, Inc.
 4C:39:09	HplElect	HPL Electric & Power Private Limited
 4C:39:10	NewtekEl	Newtek Electronics co., Ltd.
 4C:3B:74	VogtecHK	VOGTEC(H.K.) Co., Ltd
 4C:3C:16	SamsungE	Samsung Electronics Co.,Ltd
+4C:3F:D3	TexasIns	Texas Instruments
 4C:42:4C	Informat	Information Modes software modified addresses (not registered?)
 4C:48:DA	BeijingA	Beijing Autelan Technology Co.,Ltd
 4C:49:E3	XiaomiCo	Xiaomi Communications Co Ltd
@@ -21648,6 +22177,7 @@
 4C:55:85	Hamilton	Hamilton Systems
 4C:55:B8	Turkcell	Turkcell Teknoloji
 4C:55:CC	ZentriPt	Zentri Pty Ltd
+4C:56:9D	Apple	Apple, Inc.
 4C:57:CA	Apple	Apple, Inc.
 4C:5D:CD	OyFinnis	Oy Finnish Electric Vehicle Technologies Ltd
 4C:5E:0C	Routerbo	Routerboard.com
@@ -21714,6 +22244,7 @@
 4C:A9:28	Insensi
 4C:AA:16	Azurewav	AzureWave Technologies (Shanghai) Inc.
 4C:AB:33	KstTechn	KST technology
+4C:AB:FC	Zte	zte corporation
 4C:AC:0A	Zte	zte corporation
 4C:AE:1C	SainxtTe	SaiNXT Technologies LLP
 4C:AE:31	Shenghai	ShengHai Electronics (Shenzhen) Ltd
@@ -21734,6 +22265,7 @@
 4C:BC:42	Shenzhen	Shenzhen Hangsheng Electronics Co.,Ltd.
 4C:BC:A5	SamsungE	Samsung Electronics Co.,Ltd
 4C:BD:8F	Hangzhou	Hangzhou Hikvision Digital Technology Co.,Ltd.
+4C:C0:0A	VivoMobi	vivo Mobile Communication Co., Ltd.
 4C:C2:06	Somfy
 4C:C4:52	ShangHai	Shang Hai Tyd. Electon Technology Ltd.
 4C:C6:02	Radios	Radios, Inc.
@@ -21744,8 +22276,11 @@
 4C:CC:34	Motorola	Motorola Solutions Inc.
 4C:CC:6A	Micro-St	Micro-Star INTL CO., LTD.
 4C:D0:8A	Humax	HUMAX Co., Ltd.
+4C:D0:CB	HuaweiTe	Huawei Technologies Co.,Ltd
+4C:D1:A1	HuaweiTe	Huawei Technologies Co.,Ltd
 4C:D6:37	QsonoEle	Qsono Electronics Co., Ltd
 4C:D7:B6	HelmerSc	Helmer Scientific
+4C:D9:8F	Dell	Dell Inc.
 4C:D9:C4	MagnetiM	Magneti Marelli Automotive Electronics (Guangzhou) Co. Ltd
 4C:DD:31	SamsungE	Samsung Electronics Co.,Ltd
 4C:DF:3D	TeamEngi	Team Engineers Advance Technologies India Pvt Ltd
@@ -21772,6 +22307,7 @@
 4C:EB:42	IntelCor	Intel Corporate
 4C:EC:EF	Soraa	Soraa, Inc.
 4C:ED:DE	AskeyCom	Askey Computer Corp
+4C:ED:FB	AsustekC	ASUSTek COMPUTER INC.
 4C:EE:B0	ShcNetzw	SHC Netzwerktechnik GmbH
 4C:EF:C0	AmazonTe	Amazon Technologies Inc.
 4C:F0:2E	VifaDenm	Vifa Denmark A/S
@@ -21813,6 +22349,7 @@
 50:0F:80	Cisco	Cisco Systems, Inc
 50:0F:F5	TendaTec	Tenda Technology Co.,Ltd.Dongguan branch
 50:11:EB	Silverne	SilverNet Ltd
+50:14:79	Irobot	iRobot Corporation
 50:14:B5	RichfitI	Richfit Information Technology Co., Ltd
 50:17:FF	Cisco	Cisco Systems, Inc
 50:18:4C	Platina	Platina Systems Inc.
@@ -21820,6 +22357,7 @@
 50:1A:C5	Microsof	Microsoft
 50:1C:B0	Cisco	Cisco Systems, Inc
 50:1C:BF	Cisco	Cisco Systems, Inc
+50:1D:93	HuaweiTe	Huawei Technologies Co.,Ltd
 50:1E:2D	Streamun	StreamUnlimited Engineering GmbH
 50:20:6B	EmersonC	Emerson Climate Technologies Transportation Solutions
 50:22:67	Pixelink
@@ -21827,6 +22365,7 @@
 50:26:90	Fujitsu	Fujitsu Limited
 50:27:C7	Technart	TECHNART Co.,Ltd
 50:29:4D	NanjingI	Nanjing Iot Sensor Technology Co,Ltd
+50:29:F5	Guangdon	Guangdong Oppo Mobile Telecommunications Corp.,Ltd
 50:2A:7E	SmartEle	Smart electronic GmbH
 50:2A:8B	TelekomR	Telekom Research and Development Sdn Bhd
 50:2B:73	TendaTec	Tenda Technology Co.,Ltd.Dongguan branch
@@ -21835,6 +22374,7 @@
 50:2D:F4	PhytecMe	Phytec Messtechnik GmbH
 50:2E:5C	Htc	HTC Corporation
 50:2E:CE	AsahiEle	Asahi Electronics Co.,Ltd
+50:2F:A8	Cisco	Cisco Systems, Inc
 50:31:AD	AbbGloba	ABB Global Industries and Services Private Limited
 50:32:37	Apple	Apple, Inc.
 50:32:75	SamsungE	Samsung Electronics Co.,Ltd
@@ -21857,21 +22397,28 @@
 50:4A:5E	Masimo	Masimo Corporation
 50:4A:6E	Netgear
 50:4B:5B	Controlt	CONTROLtronic GmbH
+50:4C:7E	41stInst	THE 41ST INSTITUTE OF CETC
 50:4E:DC	PingComm	Ping Communication
 50:4F:94	LoxoneEl	Loxone Electronics GmbH
 50:50:2A	Egardia
 50:50:65	Takt	TAKT Corporation
+50:50:CE	Hangzhou	Hangzhou Dianyixia Communication Technology Co. Ltd.
 50:52:D2	Hangzhou	Hangzhou Telin Technologies Co., Limited
 50:55:27	LgElectr	LG Electronics (Mobile Communications)
 50:56:63	TexasIns	Texas Instruments
 50:56:A8	Jolla	Jolla Ltd
 50:56:BF	SamsungE	Samsung Electronics Co.,Ltd
+50:57:9C	SeikoEps	Seiko Epson Corporation
 50:57:A8	Cisco	Cisco Systems, Inc
 50:58:00	WytecInt	WyTec International, Inc.
 50:58:4F	Waytotec	waytotec,Inc.
+50:59:67	IntentSo	Intent Solutions Inc
 50:5A:C6	Guangdon	Guangdong Super Telecom Co.,Ltd.
+50:5B:C2	LiteonTe	Liteon Technology Corporation
+50:5D:AC	HuaweiTe	Huawei Technologies Co.,Ltd
 50:60:28	Xirrus	Xirrus Inc.
 50:61:84	Avaya	Avaya Inc
+50:61:BF	Cisco	Cisco Systems, Inc
 50:61:D6	Indu-Sol	Indu-Sol GmbH
 50:63:13	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 50:64:2B	XiaomiEl	XIAOMI Electronics,CO.,LTD
@@ -21895,6 +22442,7 @@
 50:72:4D	BegBruec	BEG Brueck Electronic GmbH
 50:76:91	Tekpea	Tekpea, Inc.
 50:76:A6	EcilInfo	Ecil Informatica Ind. Com. Ltda
+50:76:AF	IntelCor	Intel Corporate
 50:77:05	SamsungE	Samsung Electronics Co.,Ltd
 50:79:5B	Interexp	Interexport Telecomunicaciones S.A.
 50:7A:55	Apple	Apple, Inc.
@@ -21923,7 +22471,9 @@
 50:9E:A7	SamsungE	Samsung Electronics Co.,Ltd
 50:9F:27	HuaweiTe	Huawei Technologies Co.,Ltd
 50:9F:3B	OiElectr	Oi Electric Co.,Ltd
+50:A0:09	XiaomiCo	Xiaomi Communications Co Ltd
 50:A0:54	Actineon
+50:A0:A4	Nokia
 50:A0:BF	AlbaFibe	Alba Fiber Systems Inc.
 50:A4:C8	SamsungE	Samsung Electronics Co.,Ltd
 50:A4:D0	IeeeRegi	IEEE Registration Authority
@@ -21942,6 +22492,7 @@
 50:A4:D0:C0:00:00/28	BeijingY	Beijing YangLian Networks Technology co., LTD
 50:A4:D0:D0:00:00/28	AxelTech	Axel Technology
 50:A4:D0:E0:00:00/28	Sagetech	Sagetech Corporation
+50:A6:7F	Apple	Apple, Inc.
 50:A6:E3	DavidCla	David Clark Company
 50:A7:15	Aboundi	Aboundi, Inc.
 50:A7:2B	HuaweiTe	Huawei Technologies Co.,Ltd
@@ -21957,6 +22508,7 @@
 50:B7:C3	SamsungE	Samsung Electronics Co.,Ltd
 50:B8:88	Wi2beTec	wi2be Tecnologia S/A
 50:B8:A2	ImtechTe	ImTech Technologies LLC,
+50:BC:96	Apple	Apple, Inc.
 50:BD:5F	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 50:C0:06	Carmanah	Carmanah Signs
 50:C2:71	Securete	Securetech Inc
@@ -21976,10 +22528,13 @@
 50:D6:D7	Takahata	Takahata Precision
 50:D7:53	Conelcom	CONELCOM GmbH
 50:DA:00	Hangzhou	Hangzhou H3C Technologies Co., Limited
+50:DB:3F	Shenzhen	Shenzhen Gongjin Electronics Co.,Lt
 50:DC:E7	AmazonTe	Amazon Technologies Inc.
+50:DC:FC	Ecocom
 50:DD:4F	Automati	Automation Components, Inc
 50:DF:95	Lytx
 50:E0:C7	Turcontr	TurControlSystme AG
+50:E0:EF	Nokia
 50:E1:4A	Private
 50:E5:49	Giga-Byt	GIGA-BYTE TECHNOLOGY CO.,LTD.
 50:E6:66	Shenzhen	Shenzhen Techtion Electronics Co., Ltd.
@@ -22029,8 +22584,10 @@
 54:05:36	VivagoOy	Vivago Oy
 54:05:5F	AlcatelL	Alcatel Lucent
 54:05:93	WooriEle	WOORI ELEC Co.,Ltd
+54:06:8B	NingboDe	Ningbo Deli Kebei Technology Co.LTD
 54:09:55	Zte	zte corporation
 54:09:8D	DeisterE	deister electronic GmbH
+54:10:31	Smarto
 54:10:EC	Microchi	Microchip Technology Inc.
 54:11:2F	SulzerPu	Sulzer Pump Solutions Finland Oy
 54:11:5F	AtamoPty	Atamo Pty Ltd
@@ -22050,6 +22607,7 @@
 54:27:1E	Azurewav	AzureWave Technology Inc.
 54:27:58	Motorola	Motorola (Wuhan) Mobility Technologies Communication Co., Ltd.
 54:27:6C	JiangsuH	Jiangsu Houge Technology Corp.
+54:27:8D	NxpChina	NXP (China) Management Ltd.
 54:2A:9C	LsyDefen	LSY Defense, LLC.
 54:2A:A2	AlphaNet	Alpha Networks Inc.
 54:2B:57	NightOwl	Night Owl SP
@@ -22065,10 +22623,12 @@
 54:39:DF	HuaweiTe	Huawei Technologies Co.,Ltd
 54:3B:30	Duagon	duagon AG
 54:3D:37	RuckusWi	Ruckus Wireless
+54:3E:64	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 54:40:AD	SamsungE	Samsung Electronics Co.,Ltd
 54:42:49	Sony	Sony Corporation
 54:44:08	Nokia	Nokia Corporation
 54:46:6B	Shenzhen	Shenzhen CZTIC Electronic Technology Co., Ltd
+54:48:10	Dell	Dell Inc.
 54:48:9C	Cdoubles	Cdoubles Electronics Co. Ltd.
 54:4A:00	Cisco	Cisco Systems, Inc
 54:4A:05	WenglorS	wenglor sensoric gmbh
@@ -22091,6 +22651,7 @@
 54:65:DE	ArrisGro	ARRIS Group, Inc.
 54:66:6C	Shenzhen	Shenzhen YOUHUA Technology Co., Ltd
 54:67:51	CompalBr	Compal Broadband Networks, Inc.
+54:6A:D8	ElsterWa	Elster Water Metering
 54:6C:0E	TexasIns	Texas Instruments
 54:6D:52	TopviewO	Topview Optronics Corp.
 54:72:4F	Apple	Apple, Inc.
@@ -22106,7 +22667,10 @@
 54:7F:54	Ingenico
 54:7F:A8	TelcoSRO	TELCO systems, s.r.o.
 54:7F:EE	Cisco	Cisco Systems, Inc
+54:80:28	HewlettP	Hewlett Packard Enterprise
+54:81:2D	PaxCompu	PAX Computer Technology(Shenzhen) Ltd.
 54:81:AD	EagleRes	Eagle Research Corporation
+54:83:3A	ZyxelCom	Zyxel Communications Corporation
 54:84:7B	DigitalD	Digital Devices GmbH
 54:88:0E	SamsungE	SAMSUNG ELECTRO-MECHANICS(THAILAND)
 54:89:22	Zelfy	Zelfy Inc
@@ -22115,6 +22679,7 @@
 54:92:BE	SamsungE	Samsung Electronics Co.,Ltd
 54:93:59	Shenzhen	Shenzhen Twowing Technologies Co.,Ltd.
 54:94:78	Silversh	Silvershore Technology Partners
+54:99:63	Apple	Apple, Inc.
 54:9A:11	IeeeRegi	IEEE Registration Authority
 54:9A:11:00:00:00/28	Shenzhen	Shenzhen Excera Technology Co.,Ltd.
 54:9A:11:10:00:00/28	Spearx	SpearX Inc.
@@ -22138,6 +22703,7 @@
 54:9D:85	Eneracce	EnerAccess inc
 54:9F:13	Apple	Apple, Inc.
 54:9F:35	Dell	Dell Inc.
+54:9F:AE	IbaseGam	iBASE Gaming Inc
 54:A0:4F	T-MacTec	t-mac Technologies Ltd
 54:A0:50	AsustekC	ASUSTek COMPUTER INC.
 54:A2:74	Cisco	Cisco Systems, Inc
@@ -22146,10 +22712,12 @@
 54:A5:1B	HuaweiTe	Huawei Technologies Co.,Ltd
 54:A5:4B	NscCommu	NSC Communications Siberia Ltd
 54:A6:19	Alcatel-	Alcatel-Lucent Shanghai Bell Co., Ltd
+54:A6:5C	Technico	Technicolor CH USA Inc.
 54:A9:D4	Minibar	Minibar Systems
 54:AB:3A	QuantaCo	Quanta Computer Inc.
 54:AE:27	Apple	Apple, Inc.
 54:B1:21	HuaweiTe	Huawei Technologies Co.,Ltd
+54:B2:03	Pegatron	Pegatron Corporation
 54:B5:6C	XiAnNova	Xi'an NovaStar Tech Co., Ltd
 54:B6:20	SuhdolE&	SUHDOL E&C Co.Ltd.
 54:B7:53	HunanFen	Hunan Fenghui Yinjia Science And Technology Co.,Ltd
@@ -22159,6 +22727,8 @@
 54:BD:79	SamsungE	Samsung Electronics Co.,Ltd
 54:BE:53	Zte	zte corporation
 54:BE:F7	Pegatron	Pegatron Corporation
+54:BF:64	Dell	Dell Inc.
+54:C3:3E	Ciena	Ciena Corporation
 54:C4:15	Hangzhou	Hangzhou Hikvision Digital Technology Co.,Ltd.
 54:C5:7A	SunnovoI	Sunnovo International Limited
 54:C8:0F	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
@@ -22210,6 +22780,7 @@
 56:58:57	AculabPl	Aculab plc	# audio bridges
 58:00:BB	JuniperN	Juniper Networks
 58:00:E3	LiteonTe	Liteon Technology Corporation
+58:03:FB	Hangzhou	Hangzhou Hikvision Digital Technology Co.,Ltd.
 58:04:54	IcommHk	Icomm Hk Limited
 58:04:CB	TianjinH	Tianjin Huisun Technology Co.,Ltd.
 58:05:28	LabrisNe	Labris Networks
@@ -22221,7 +22792,7 @@
 58:10:8C	Intelbra	Intelbras
 58:12:43	AcsipTec	AcSiP Technology Corp.
 58:16:26	Avaya	Avaya Inc
-58:17:0C	SonyMobi	Sony Mobile Communications AB
+58:17:0C	SonyMobi	Sony Mobile Communications Inc
 58:19:F8	ArrisGro	ARRIS Group, Inc.
 58:1C:BD	Affinegy
 58:1D:91	Advanced	Advanced Mobile Telecom co.,ltd.
@@ -22231,10 +22802,13 @@
 58:1F:EF	Tuttnaer	Tuttnaer LTD
 58:20:B1	HewlettP	Hewlett Packard
 58:21:36	KmbSRO	KMB systems, s.r.o.
+58:21:E9	Twpi
 58:23:8C	Technico	Technicolor CH USA Inc.
 58:2A:F7	HuaweiTe	Huawei Technologies Co.,Ltd
 58:2B:DB	Pax	Pax AB
+58:2D:34	Qingping	Qingping Electronics (Suzhou) Co., Ltd
 58:2E:FE	Lighting	Lighting Science Group
+58:2F:40	Nintendo	Nintendo Co.,Ltd
 58:2F:42	Universa	Universal Electric Corporation
 58:31:12	Drust
 58:32:77	Reliance	Reliance Communications LLC
@@ -22250,7 +22824,7 @@
 58:46:8F	KoncarEl	Koncar Electronics and Informatics
 58:46:E1	BaxterIn	Baxter International Inc
 58:47:04	Shenzhen	Shenzhen Webridge Technology Co.,Ltd
-58:48:22	SonyMobi	Sony Mobile Communications AB
+58:48:22	SonyMobi	Sony Mobile Communications Inc
 58:48:C0	Coflec
 58:49:25	E3Enterp	E3 Enterprise
 58:49:3B	PaloAlto	Palo Alto Networks
@@ -22265,6 +22839,7 @@
 58:55:CA	Apple	Apple, Inc.
 58:56:E8	ArrisGro	ARRIS Group, Inc.
 58:57:0D	DanfossS	Danfoss Solar Inverters
+58:5F:F6	Zte	zte corporation
 58:60:5F	HuaweiTe	Huawei Technologies Co.,Ltd
 58:61:63	QuantumN	Quantum Networks (SG) Pte. Ltd.
 58:63:56	Fn-LinkT	FN-LINK TECHNOLOGY LIMITED
@@ -22285,6 +22860,7 @@
 58:76:C5	DigiIS	DIGI I'S LTD
 58:7A:4D	Stonesof	Stonesoft Corporation
 58:7A:62	TexasIns	Texas Instruments
+58:7A:6A	Guangdon	Guangdong Oppo Mobile Telecommunications Corp.,Ltd
 58:7B:E9	AirproTe	AirPro Technology India Pvt. Ltd
 58:7E:61	QingdaoH	Qingdao Hisense Communications Co.,Ltd.
 58:7F:57	Apple	Apple, Inc.
@@ -22315,15 +22891,20 @@
 58:9C:FC	FreebsdF	FreeBSD Foundation
 58:A0:CB	Tracknet	TrackNet, Inc
 58:A2:B5	LgElectr	LG Electronics (Mobile Communications)
+58:A4:8E	PixartIm	PixArt Imaging Inc.
 58:A7:6F	Id	iD corporation
 58:A8:39	IntelCor	Intel Corporate
 58:AC:78	Cisco	Cisco Systems, Inc
 58:B0:35	Apple	Apple, Inc.
 58:B0:D4	Zunidata	ZuniData Systems Inc.
+58:B1:0F	SamsungE	Samsung Electronics Co.,Ltd
+58:B3:FC	Shenzhen	SHENZHEN RF-LINK TECHNOLOGY CO.,LTD.
 58:B4:2D	YstenTec	YSTen Technology Co.,Ltd
+58:B5:68	Securita	SECURITAS DIRECT ESPAÑA, SAU
 58:B6:33	RuckusWi	Ruckus Wireless
 58:B9:61	SolemEle	SOLEM Electronique
 58:B9:E1	Crystalf	Crystalfontz America, Inc.
+58:BA:D4	HuaweiTe	Huawei Technologies Co.,Ltd
 58:BC:27	Cisco	Cisco Systems, Inc
 58:BC:8F	Cognitiv	Cognitive Systems Corp.
 58:BD:A3	Nintendo	Nintendo Co., Ltd.
@@ -22334,14 +22915,17 @@
 58:C3:8B	SamsungE	Samsung Electronics Co.,Ltd
 58:C5:83	ItelMobi	Itel Mobile Limited
 58:C5:CB	SamsungE	Samsung Electronics Co.,Ltd
+58:C8:76	ChinaMob	China Mobile (Hangzhou) Information Technology Co., Ltd.
 58:C9:35	ChiunMai	Chiun Mai Communication Systems, Inc
 58:CF:4B	LufkinIn	Lufkin Industries
 58:D0:71	BwBroadc	BW Broadcast
 58:D0:8F	Ieee1904	IEEE 1904.1 Working Group
+58:D5:6E	D-LinkIn	D-Link International
 58:D6:7A	Tcplink
 58:D6:D3	DairyChe	Dairy Cheq Inc
 58:D7:59	HuaweiTe	Huawei Technologies Co.,Ltd
 58:D9:D5	TendaTec	Tenda Technology Co.,Ltd.Dongguan branch
+58:DB:15	TecnoMob	Tecno Mobile Limited
 58:DB:8D	Fast	Fast Co., Ltd.
 58:DC:6D	Exceptio	Exceptional Innovation, Inc.
 58:E0:2C	MicroTec	Micro Technic A/S
@@ -22350,6 +22934,7 @@
 58:E3:26	CompassT	Compass Technologies Inc.
 58:E4:76	CentronC	Centron Communications Technologies Fujian Co.,Ltd
 58:E6:36	EvrsafeT	EVRsafe Technologies
+58:E6:BA	Apple	Apple, Inc.
 58:E7:47	Deltanet	Deltanet AG
 58:E8:08	Autonics	Autonics Corporation
 58:E8:76	IeeeRegi	IEEE Registration Authority
@@ -22378,6 +22963,7 @@
 58:F4:96	SourceCh	Source Chain
 58:F6:7B	XiaMenUn	Xia Men UnionCore Technology LTD.
 58:F6:BF	KyotoUni	Kyoto University
+58:F9:87	HuaweiTe	Huawei Technologies Co.,Ltd
 58:F9:8E	Secudos	SECUDOS GmbH
 58:FB:84	IntelCor	Intel Corporate
 58:FC:73	ArriaLiv	Arria Live Media, Inc.
@@ -22399,11 +22985,14 @@
 58:FC:DB:E0:00:00/28	AppliedD	Applied Device Technologies
 58:FC:DB:F0:00:00/28	Private
 58:FD:20	BravidaS	Bravida Sakerhet AB
+58:FD:BE	Shenzhen	Shenzhen Taikaida Technology Co., Ltd
+5A:CB:D3	Simaudio	Simaudio Ltd
 5A:E6:60	Nyantec	nyantec GmbH
 5C:00:38	ViasatGr	Viasat Group S.p.A.
 5C:02:6A	AppliedV	Applied Vision Corporation
 5C:03:39	HuaweiTe	Huawei Technologies Co.,Ltd
 5C:07:6F	ThoughtC	Thought Creator
+5C:09:47	Apple	Apple, Inc.
 5C:09:79	HuaweiTe	Huawei Technologies Co.,Ltd
 5C:0A:5B	SamsungE	Samsung Electro Mechanics Co., Ltd.
 5C:0C:0E	GuizhouH	Guizhou Huaxintong Semiconductor Technology Co Ltd
@@ -22418,12 +23007,14 @@
 5C:17:D3	Lge
 5C:18:B5	TalonCom	Talon Communications
 5C:1A:6F	Cambridg	Cambridge Industries(Group) Co.,Ltd.
+5C:1D:D9	Apple	Apple, Inc.
 5C:20:D0	AsoniCom	Asoni Communication Co., Ltd.
 5C:22:C4	DaeEunEl	Dae Eun Eletronics Co., Ltd
 5C:24:43	O-SungTe	O-Sung Telecom Co., Ltd.
 5C:24:79	Baltech	Baltech AG
 5C:25:4C	AvireGlo	Avire Global Pte Ltd
 5C:26:0A	Dell	Dell Inc.
+5C:26:23	Wavelynx	WaveLynx Technologies Corporation
 5C:2A:EF	OpenAcce	Open Access Pty Ltd
 5C:2B:F5	VivintWi	Vivint Wireless Inc.
 5C:2E:59	SamsungE	Samsung Electronics Co.,Ltd
@@ -22458,11 +23049,13 @@
 5C:57:C8	Nokia	Nokia Corporation
 5C:58:19	Jingshen	Jingsheng Technology Co., Ltd.
 5C:59:48	Apple	Apple, Inc.
+5C:5A:EA	Ford
 5C:5B:35	Mist	Mist Systems, Inc.
 5C:5B:C2	Yik	YIK Corporation
 5C:5E:AB	JuniperN	Juniper Networks
 5C:5F:67	IntelCor	Intel Corporate
 5C:63:BF	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
+5C:63:C9	Intellit	Intellithings Ltd.
 5C:67:76	IdsImagi	IDS Imaging Development Systems GmbH
 5C:69:84	Nuvico
 5C:6A:7D	Kentkart	Kentkart Ege Elektronik San. Ve Tic. Ltd. Sti.
@@ -22511,8 +23104,9 @@
 5C:AF:06	LgElectr	LG Electronics (Mobile Communications)
 5C:B0:66	ArrisGro	ARRIS Group, Inc.
 5C:B3:95	HuaweiTe	Huawei Technologies Co.,Ltd
+5C:B3:F6	Human	Human, Incorporated
 5C:B4:3E	HuaweiTe	Huawei Technologies Co.,Ltd
-5C:B5:24	SonyMobi	Sony Mobile Communications AB
+5C:B5:24	SonyMobi	Sony Mobile Communications Inc
 5C:B5:59	CnexLabs	CNEX Labs
 5C:B6:CC	Novacomm	NovaComm Technologies Inc.
 5C:B8:CB	AllisCom	Allis Communications
@@ -22525,14 +23119,17 @@
 5C:C6:D0	Skyworth	Skyworth Digital Technology(Shenzhen) Co.,Ltd
 5C:C6:E9	EdifierI	Edifier International
 5C:C7:D7	AzroadTe	Azroad Technology Company Limited
+5C:C9:99	NewH3cTe	New H3C Technologies Co., Ltd
 5C:C9:D3	Palladiu	Palladium Energy Eletronica Da Amazonia Ltda
 5C:CA:1A	Microsof	Microsoft Mobile Oy
 5C:CA:32	Theben	Theben AG
 5C:CC:A0	Gridwiz	Gridwiz Inc.
 5C:CC:FF	Techrout	Techroutes Network Pvt Ltd
+5C:CD:7C	MeizuTec	MEIZU Technology Co.,Ltd.
 5C:CE:AD	Cdyne	CDYNE Corporation
 5C:CF:7F	Espressi	Espressif Inc.
 5C:D1:35	XtremePo	Xtreme Power Systems
+5C:D2:0B	Yytek	Yytek Co., Ltd.
 5C:D2:E4	IntelCor	Intel Corporate
 5C:D4:1B	UczoonTe	UCZOON Technology Co., LTD
 5C:D4:AB	Zektor
@@ -22588,6 +23185,7 @@
 5C:F9:6A	HuaweiTe	Huawei Technologies Co.,Ltd
 5C:F9:DD	Dell	Dell Inc.
 5C:F9:F0	AtomosEn	Atomos Engineering P/L
+5C:FB:7C	Shenzhen	Shenzhen Jingxun Software Telecommunication Technology Co.,Ltd
 5C:FC:66	Cisco	Cisco Systems, Inc
 5C:FF:35	Wistron	Wistron Corporation
 5C:FF:FF	Shenzhen	Shenzhen Kezhonglong Optoelectronic Technology Co., Ltd
@@ -22597,6 +23195,7 @@
 60:03:08	Apple	Apple, Inc.
 60:03:47	BillionE	Billion Electric Co. Ltd.
 60:04:17	Posbank	Posbank Co.,Ltd
+60:05:8A	HitachiM	Hitachi Metals, Ltd.
 60:08:10	HuaweiTe	Huawei Technologies Co.,Ltd
 60:08:37	IvviScie	ivvi Scientific(Nanchang)Co.Ltd
 60:0B:03	Hangzhou	Hangzhou H3C Technologies Co., Limited
@@ -22624,11 +23223,13 @@
 60:2A:54	Cardiote	CardioTek B.V.
 60:2A:D0	CiscoSpv	Cisco SPVTG
 60:2E:20	HuaweiTe	Huawei Technologies Co.,Ltd
+60:30:D4	Apple	Apple, Inc.
 60:31:3B	SunnovoI	Sunnovo International Limited
 60:31:97	ZyxelCom	Zyxel Communications Corporation
 60:32:F0	MplusTec	Mplus technology
 60:33:4B	Apple	Apple, Inc.
 60:35:53	BuwonTec	Buwon Technology
+60:35:C0	Sfr
 60:36:96	Sapling	The Sapling Company
 60:36:DD	IntelCor	Intel Corporate
 60:38:0E	AlpsElec	Alps Electric Co.,Ltd.
@@ -22649,7 +23250,7 @@
 60:48:26	Newbridg	Newbridge Technologies Int. Ltd.
 60:49:C1	Avaya	Avaya Inc
 60:4A:1C	Suyin	SUYIN Corporation
-60:4B:AA	Private
+60:4B:AA	MagicLea	Magic Leap, Inc.
 60:50:C1	KinetekS	Kinetek Sports
 60:51:2C	TctMobil	TCT mobile ltd
 60:52:D0	FactsEng	FACTS Engineering
@@ -22684,11 +23285,13 @@
 60:83:34	HuaweiTe	Huawei Technologies Co.,Ltd
 60:83:B2	GkwareEK	GkWare e.K.
 60:84:3B	Soladigm	Soladigm, Inc.
+60:84:BD	Buffalo	Buffalo.Inc
 60:86:45	AveryWei	Avery Weigh-Tronix, LLC
 60:89:3C	ThermoFi	Thermo Fisher Scientific P.O.A.
 60:89:B1	KeyDigit	Key Digital Systems
 60:89:B7	KaelMühe	KAEL MÜHENDİSLİK ELEKTRONİK TİCARET SANAYİ LİMİTED ŞİRKETİ
 60:8C:2B	HansonTe	Hanson Technology
+60:8C:4A	Apple	Apple, Inc.
 60:8C:E6	ArrisGro	ARRIS Group, Inc.
 60:8D:17	SentrusG	Sentrus Government Systems Division, Inc
 60:8E:08	SamsungE	Samsung Electronics Co.,Ltd
@@ -22697,6 +23300,7 @@
 60:91:F3	VivoMobi	vivo Mobile Communication Co., Ltd.
 60:92:17	Apple	Apple, Inc.
 60:96:20	Private
+60:97:DD	Microsys	MicroSys Electronics GmbH
 60:98:13	Shanghai	Shanghai Visking Digital Technology Co. LTD
 60:99:D1	Vuzix/Le	Vuzix / Lenovo
 60:9A:A4	GviSecur	Gvi Security Inc.
@@ -22709,6 +23313,7 @@
 60:A3:7D	Apple	Apple, Inc.
 60:A4:4C	AsustekC	ASUSTek COMPUTER INC.
 60:A4:D0	SamsungE	Samsung Electronics Co.,Ltd
+60:A7:30	Shenzhen	Shenzhen Yipinfang Internet Technology Co.,Ltd
 60:A8:FE	Nokia
 60:A9:B0	Merchand	Merchandising Technologies, Inc
 60:AC:C8	Kunteng	KunTeng Inc.
@@ -22738,8 +23343,11 @@
 60:CB:FB	Airscape	AirScape Inc.
 60:CD:A9	Abloomy
 60:CD:C5	TaiwanCa	Taiwan Carol Electronics., Ltd
+60:CE:92	RefinedI	The Refined Industry Company Limited
+60:D0:2C	RuckusWi	Ruckus Wireless
 60:D0:A9	SamsungE	Samsung Electronics Co.,Ltd
 60:D1:AA	VishalTe	Vishal Telecommunications Pvt Ltd
+60:D2:1C	SunnovoI	Sunnovo International Limited
 60:D2:62	TzukuriP	Tzukuri Pty Ltd
 60:D2:B9	RealandB	Realand Bio Co., Ltd.
 60:D3:0A	Quatius	Quatius Limited
@@ -22766,6 +23374,7 @@
 60:DA:83	Hangzhou	Hangzhou H3C Technologies Co., Limited
 60:DB:2A	Hns
 60:DE:44	HuaweiTe	Huawei Technologies Co.,Ltd
+60:DE:F3	HuaweiTe	Huawei Technologies Co.,Ltd
 60:E0:0E	ShinseiE	Shinsei Electronics Co Ltd
 60:E3:27	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 60:E3:AC	LgElectr	LG Electronics (Mobile Communications)
@@ -22778,6 +23387,7 @@
 60:EF:C6	Shenzhen	Shenzhen Chima Technologies Co Limited
 60:F1:3D	Jablocom	JABLOCOM s.r.o.
 60:F1:89	MurataMa	Murata Manufacturing Co., Ltd.
+60:F1:8A	HuaweiTe	Huawei Technologies Co.,Ltd
 60:F2:81	TranwoTe	Tranwo Technology Co., Ltd.
 60:F2:EF	Visionve	VisionVera International Co., Ltd.
 60:F3:DA	LogicWay	Logic Way GmbH
@@ -22787,6 +23397,7 @@
 60:F6:73	Terumo	Terumo Corporation
 60:F6:77	IntelCor	Intel Corporate
 60:F8:1D	Apple	Apple, Inc.
+60:FA:9D	HuaweiTe	Huawei Technologies Co.,Ltd
 60:FA:CD	Apple	Apple, Inc.
 60:FB:42	Apple	Apple, Inc.
 60:FD:56	Woorisys	WOORISYSTEMS CO., Ltd
@@ -22798,6 +23409,7 @@
 64:00:2D	Powerlin	Powerlinq Co., LTD
 64:00:6A	Dell	Dell Inc.
 64:00:F1	Cisco	Cisco Systems, Inc
+64:02:CB	ArrisGro	ARRIS Group, Inc.
 64:05:BE	NewLight	New Light Led
 64:05:E9	Shenzhen	Shenzhen WayOS Technology Crop., Ltd.
 64:09:4C	BeijingS	Beijing Superbee Wireless Technology Co.,Ltd
@@ -22811,6 +23423,7 @@
 64:10:84	HexiumTe	HEXIUM Technical Development Co., Ltd.
 64:12:25	Cisco	Cisco Systems, Inc
 64:12:69	ArrisGro	ARRIS Group, Inc.
+64:13:31	BoschCar	Bosch Car Multimedia (Wuhu) Co. Ltd.
 64:13:6C	Zte	zte corporation
 64:16:66	NestLabs	Nest Labs Inc.
 64:16:7F	Polycom
@@ -22818,6 +23431,7 @@
 64:16:F0	HuaweiTe	Huawei Technologies Co.,Ltd
 64:1A:22	Heliospe	Heliospectra AB
 64:1C:67	Digibras	DIGIBRAS INDUSTRIA DO BRASILS/A
+64:1C:AE	SamsungE	Samsung Electronics Co.,Ltd
 64:1C:B0	SamsungE	Samsung Electronics Co.,Ltd
 64:1E:81	Dowslake	Dowslake Microsystems
 64:20:0C	Apple	Apple, Inc.
@@ -22842,6 +23456,7 @@
 64:4B:C3	Shanghai	Shanghai WOASiS Telecommunications Ltd., Co.
 64:4B:F0	Caldigit	CalDigit, Inc
 64:4D:70	Dspace	dSPACE GmbH
+64:4F:42	Jetter	JETTER CO., Ltd.
 64:4F:74	Lenus	LENUS Co., Ltd.
 64:4F:B0	HyunjinC	Hyunjin.com
 64:51:06	HewlettP	Hewlett Packard
@@ -22855,12 +23470,15 @@
 64:56:01	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 64:59:F8	Vodafone	Vodafone Omnitel B.V.
 64:5A:04	ChiconyE	Chicony Electronics Co., Ltd.
+64:5A:ED	Apple	Apple, Inc.
+64:5D:86	IntelCor	Intel Corporate
 64:5D:92	SichuanT	Sichuan Tianyi Comheart Telecomco.,Ltd
 64:5D:D7	Shenzhen	Shenzhen Lifesense Medical Electronics Co., Ltd.
 64:5E:BE	Yahoo!Ja	Yahoo! JAPAN
 64:5F:FF	NicoletN	Nicolet Neuro
 64:61:84	Velux
 64:62:23	Cellient	Cellient Co., Ltd.
+64:62:8A	Evon	evon GmbH
 64:64:9B	JuniperN	Juniper Networks
 64:65:C0	Nuvon	Nuvon, Inc
 64:66:B3	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
@@ -22870,10 +23488,12 @@
 64:6A:52	Avaya	Avaya Inc
 64:6A:74	Auth-Ser	AUTH-SERVERS, LLC
 64:6C:B2	SamsungE	Samsung Electronics Co.,Ltd
+64:6D:6C	HuaweiTe	Huawei Technologies Co.,Ltd
 64:6E:69	LiteonTe	Liteon Technology Corporation
 64:6E:6C	RadioDat	Radio Datacom LLC
 64:6E:EA	Iskratel	Iskratel d.o.o.
 64:70:02	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
+64:70:33	Apple	Apple, Inc.
 64:72:D8	GoowiTec	GooWi Technology Co.,Limited
 64:73:E2	Arbiter	Arbiter Systems, Inc.
 64:74:F6	ShooterD	Shooter Detection Systems
@@ -22882,6 +23502,7 @@
 64:77:7D	HitronTe	Hitron Technologies. Inc
 64:77:91	SamsungE	Samsung Electronics Co.,Ltd
 64:79:A7	PhisonEl	Phison Electronics Corp.
+64:7B:CE	SamsungE	Samsung Electronics Co.,Ltd
 64:7B:D4	TexasIns	Texas Instruments
 64:7C:34	UbeeInte	Ubee Interactive Co., Limited
 64:7D:81	YokotaIn	Yokota Industrial Co,.Ltd
@@ -22908,6 +23529,7 @@
 64:9F:F7	KoneOyj	Kone OYj
 64:A0:E7	Cisco	Cisco Systems, Inc
 64:A2:32	OooSamli	OOO Samlight
+64:A2:F9	OneplusT	OnePlus Technology (Shenzhen) Co., Ltd
 64:A3:41	Wonderla	Wonderlan (Beijing) Technology Co., Ltd.
 64:A3:CB	Apple	Apple, Inc.
 64:A5:C3	Apple	Apple, Inc.
@@ -22931,10 +23553,12 @@
 64:BC:0C	LgElectr	LG Electronics (Mobile Communications)
 64:BC:11	Combiq	CombiQ AB
 64:C3:54	Avaya	Avaya Inc
+64:C3:D6	JuniperN	Juniper Networks
 64:C5:AA	SouthAfr	South African Broadcasting Corporation
 64:C6:67	Barnes&N	Barnes&Noble
 64:C6:AF	AxerraNe	AXERRA Networks Ltd
 64:C9:44	LarkTech	LARK Technologies, Inc
+64:CB:5D	SiaTeles	SIA TeleSet
 64:CB:A3	Pointmob	Pointmobile
 64:CC:2E	XiaomiCo	Xiaomi Communications Co Ltd
 64:CF:D9	TexasIns	Texas Instruments
@@ -22952,6 +23576,7 @@
 64:DB:18	Openpatt	OpenPattern
 64:DB:43	Motorola	Motorola (Wuhan) Mobility Technologies Communication Co., Ltd.
 64:DB:81	Syszone	Syszone Co., Ltd.
+64:DB:8B	Hangzhou	Hangzhou Hikvision Digital Technology Co.,Ltd.
 64:DB:A0	SelectCo	Select Comfort
 64:DC:01	StaticGr	Static Systems Group PLC
 64:DE:1C	Kingneti	Kingnetic Pte Ltd
@@ -22968,9 +23593,11 @@
 64:EB:8C	SeikoEps	Seiko Epson Corporation
 64:ED:57	ArrisGro	ARRIS Group, Inc.
 64:ED:62	Woori	WOORI SYSTEMS Co., Ltd
+64:EE:B7	NetcoreT	Netcore Technology Inc
 64:F2:42	GerdesAk	Gerdes Aktiengesellschaft
 64:F5:0E	KinionTe	Kinion Technology Company Limited
 64:F6:9D	Cisco	Cisco Systems, Inc
+64:F8:1C	HuaweiTe	Huawei Technologies Co., Ltd.
 64:F8:8A	ChinaMob	China Mobile IOT Company Limited
 64:F9:70	KenadeEl	Kenade Electronics Technology Co.,LTD.
 64:F9:87	Avvasi	Avvasi Inc.
@@ -23019,17 +23646,21 @@
 68:27:37	SamsungE	Samsung Electronics Co.,Ltd
 68:28:BA	Dejai
 68:28:F6	VubiqNet	Vubiq Networks, Inc.
+68:2C:7B	Cisco	Cisco Systems, Inc
 68:2D:DC	WuhanCha	Wuhan Changjiang Electro-Communication Equipment CO.,LTD
 68:31:FE	Teladin	Teladin Co.,Ltd.
 68:35:63	Shenzhen	Shenzhen Liown Electronics Co.,Ltd.
 68:36:B5	Drivesca	DriveScale, Inc.
 68:37:E9	AmazonTe	Amazon Technologies Inc.
+68:3A:1E	CiscoMer	Cisco Meraki
 68:3B:1E	Countwis	Countwise LTD
 68:3C:7D	MagicInt	Magic Intelligence Technology Limited
 68:3E:02	SiemensD	SIEMENS AG, Digital Factory, Motion Control System
 68:3E:34	MeizuTec	MEIZU Technology Co., Ltd.
 68:3E:EC	Ereca
 68:43:52	Bhuu	Bhuu Limited
+68:43:D7	Agilecom	Agilecom Photonics Solutions Guangdong Limited
+68:47:49	TexasIns	Texas Instruments
 68:48:98	SamsungE	Samsung Electronics Co.,Ltd
 68:4B:88	Galtroni	Galtronics Telemetry Inc.
 68:4C:A8	Shenzhen	Shenzhen Herotel Tech. Co., Ltd.
@@ -23057,7 +23688,7 @@
 68:6E:48	ProphetE	Prophet Electronic Technology Corp.,Ltd
 68:72:51	Ubiquiti	Ubiquiti Networks Inc.
 68:72:DC	CetoryTv	CETORY.TV Company Limited
-68:76:4F	SonyMobi	Sony Mobile Communications AB
+68:76:4F	SonyMobi	Sony Mobile Communications Inc
 68:78:48	Westunit	Westunitis Co., Ltd.
 68:78:4C	NortelNe	Nortel Networks
 68:79:24	Els-Gmbh	ELS-GmbH & Co. KG
@@ -23072,10 +23703,12 @@
 68:86:A7	Cisco	Cisco Systems, Inc
 68:86:E7	Orbotix	Orbotix, Inc.
 68:87:6B	InqMobil	INQ Mobile Limited
+68:89:75	Nuoxc
 68:89:C1	HuaweiTe	Huawei Technologies Co.,Ltd
 68:8A:B5	EdpServi	EDP Servicos
 68:8A:F0	Zte	zte corporation
 68:8D:B6	Aetek	Aetek Inc.
+68:8F:2E	HitronTe	Hitron Technologies. Inc
 68:8F:84	HuaweiTe	Huawei Technologies Co.,Ltd
 68:91:D0	IeeeRegi	IEEE Registration Authority
 68:91:D0:00:00:00/28	CentralR	Central Railway Manufacturing
@@ -23112,9 +23745,11 @@
 68:A3:78	FreeboxS	Freebox Sas
 68:A3:C4	LiteonTe	Liteon Technology Corporation
 68:A4:0E	BshHausg	BSH Hausgeräte GmbH
+68:A4:7D	SunCupid	Sun Cupid Technology (HK) LTD
 68:A6:82	Shenzhen	Shenzhen YOUHUA Technology Co., Ltd
 68:A8:28	HuaweiTe	Huawei Technologies Co.,Ltd
 68:A8:6D	Apple	Apple, Inc.
+68:A8:E1	Wacom	Wacom Co.,Ltd.
 68:AA:D2	Datecs	Datecs Ltd.,
 68:AB:1E	Apple	Apple, Inc.
 68:AB:8A	RfIdeas	RF IDeas
@@ -23133,12 +23768,15 @@
 68:C6:3A	Espressi	Espressif Inc.
 68:C9:0B	TexasIns	Texas Instruments
 68:CA:00	Octopus	Octopus Systems Limited
+68:CA:E4	Cisco	Cisco Systems, Inc
 68:CC:6E	HuaweiTe	Huawei Technologies Co.,Ltd
 68:CC:9C	MineSite	Mine Site Technologies
 68:CD:0F	UTek	U Tek Company Limited
 68:CE:4E	L-3Commu	L-3 Communications Infrared Products
+68:D1:BA	Shenzhen	Shenzhen YOUHUA Technology Co., Ltd
 68:D1:FD	Shenzhen	Shenzhen Trimax Technology Co.,Ltd
 68:D2:47	Portalis	Portalis LC
+68:D4:82	Shenzhen	Shenzhen Gongjin Electronics Co.,Lt
 68:D9:25	ProsysDe	ProSys Development Services
 68:D9:3C	Apple	Apple, Inc.
 68:DB:54	PhicommS	Phicomm (Shanghai) Co., Ltd.
@@ -23146,9 +23784,11 @@
 68:DB:96	OpwillTe	OPWILL Technologies CO .,LTD
 68:DB:CA	Apple	Apple, Inc.
 68:DC:E8	Packetst	PacketStorm Communications
+68:DD:26	Shanghai	Shanghai Focus Vision Security Technology Co.,Ltd
 68:DF:DD	XiaomiCo	Xiaomi Communications Co Ltd
 68:E1:66	Private
 68:E4:1F	Unglaube	Unglaube Identech GmbH
+68:E7:C2	SamsungE	Samsung Electronics Co.,Ltd
 68:E8:EB	LinktelT	Linktel Technologies Co.,Ltd
 68:EB:AE	SamsungE	Samsung Electronics Co.,Ltd
 68:EB:C5	Angstrem	Angstrem Telecom
@@ -23168,17 +23808,22 @@
 68:FB:7E	Apple	Apple, Inc.
 68:FB:95	Generalp	Generalplus Technology Inc.
 68:FC:B3	NextLeve	Next Level Security Systems, Inc.
+68:FE:DA	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
+68:FE:F7	Apple	Apple, Inc.
 6A:0E:20	Geofrenz	GeoFrenzy, Inc
 6A:1F:6C	Ipass	iPass, Inc.
+6A:40:65	OpenConn	Open Connectivity Foundation
 6A:73:7D	25gEther	25G Ethernet Consortium
+6A:B6:F2	EliTechn	Eli Technology Inc
 6A:E6:4A	S&OElect	S&O Electronics (Malaysia) Sdn. Bhd.
+6C:00:6B	SamsungE	Samsung Electronics Co.,Ltd
 6C:02:73	Shenzhen	Shenzhen Jin Yun Video Equipment Co., Ltd.
 6C:04:60	RbhAcces	RBH Access Technologies Inc.
 6C:05:D5	Ethertro	Ethertronics Inc
 6C:09:0A	Gematica	Gematica Srl
 6C:09:D6	Digiques	Digiquest Electronics LTD
 6C:0B:84	Universa	Universal Global Scientific Industrial Co., Ltd.
-6C:0E:0D	SonyMobi	Sony Mobile Communications AB
+6C:0E:0D	SonyMobi	Sony Mobile Communications Inc
 6C:0E:E6	ChengduX	Chengdu Xiyida Electronic Technology Co,.Ltd
 6C:0F:6A	JdcTech	JDC Tech Co., Ltd.
 6C:14:F7	Erhardt+	Erhardt+Leimer GmbH
@@ -23190,20 +23835,24 @@
 6C:1E:70	Guangzho	Guangzhou YBDS IT Co.,Ltd
 6C:1E:90	HansolTe	Hansol Technics Co., Ltd.
 6C:20:56	Cisco	Cisco Systems, Inc
+6C:21:A2	AmpakTec	AMPAK Technology, Inc.
 6C:22:AB	Ainswort	Ainsworth Game Technology
-6C:23:B9	SonyMobi	Sony Mobile Communications AB
+6C:23:B9	SonyMobi	Sony Mobile Communications Inc
 6C:24:83	Microsof	Microsoft Mobile Oy
 6C:25:B9	BbkEduca	Bbk Educational Electronics Corp.,Ltd.
 6C:27:79	Microsof	Microsoft Mobile Oy
 6C:29:95	IntelCor	Intel Corporate
 6C:2A:CB	PaxtonAc	Paxton Access Ltd
 6C:2C:06	OooNppSy	OOO NPP Systemotechnika-NN
+6C:2C:DC	Skyworth	Skyworth Digital Technology(Shenzhen) Co.,Ltd
 6C:2E:33	Accelink	Accelink Technologies Co.,Ltd.
 6C:2E:72	B&BExpor	B&B EXPORTING LIMITED
 6C:2E:85	Sagemcom	Sagemcom Broadband SAS
 6C:2F:2C	SamsungE	Samsung Electronics Co.,Ltd
 6C:32:DE	IndieonT	Indieon Technologies Pvt. Ltd.
 6C:33:A9	Magicjac	Magicjack LP
+6C:38:38	MarkingS	Marking System Technology Co., Ltd.
+6C:38:45	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 6C:38:A1	UbeeInte	Ubee Interactive Co., Limited
 6C:39:1D	BeijingZ	Beijing ZhongHuaHun Network Information center
 6C:3A:84	Shenzhen	Shenzhen Aero-Startech. Co.Ltd
@@ -23227,11 +23876,27 @@
 6C:54:CD	LampexEl	Lampex Electronics Limited
 6C:56:97	AmazonTe	Amazon Technologies Inc.
 6C:57:79	Aclima	Aclima, Inc.
-6C:59:40	Shenzhen	Shenzhen Mercury Communication Technologies Co.,Ltd.
+6C:59:40	MercuryC	Mercury Communication Technologies Co.,Ltd.
 6C:59:76	Shanghai	Shanghai Tricheer Technology Co.,Ltd.
 6C:5A:34	Shenzhen	Shenzhen Haitianxiong Electronic Co., Ltd.
 6C:5A:B5	TclTechn	TCL Technoly Electronics (Huizhou) Co., Ltd.
 6C:5C:14	Guangdon	Guangdong Oppo Mobile Telecommunications Corp.,Ltd
+6C:5C:3D	IeeeRegi	IEEE Registration Authority
+6C:5C:3D:00:00:00/28	Shenzhen	ShenZhen Hugsun Technology Co.,Ltd.
+6C:5C:3D:10:00:00/28	Shenzhen	Shenzhen Justek Technology Co., Ltd
+6C:5C:3D:20:00:00/28	VertivIn	Vertiv Industrial Systems
+6C:5C:3D:30:00:00/28	KwongMin	Kwong Ming Electrical Manufactory Limited
+6C:5C:3D:40:00:00/28	Hti	HTI Co., LTD.
+6C:5C:3D:50:00:00/28	UnitelEn	Unitel Engineering
+6C:5C:3D:60:00:00/28	Hangzhou	Hangzhou Netease Yanxuan Trading Co.,Ltd
+6C:5C:3D:70:00:00/28	Soundkin	SOUNDKING ELECTRONICS&SOUND CO., LTD.
+6C:5C:3D:80:00:00/28	Guangzho	Guangzhou Guangri Elevator Industry Co.,Ltd
+6C:5C:3D:90:00:00/28	Iskraura	IskraUralTEL
+6C:5C:3D:A0:00:00/28	Krtkl	krtkl inc.
+6C:5C:3D:B0:00:00/28	Reconova	Reconova Technologies
+6C:5C:3D:C0:00:00/28	ChoyangP	choyang powertech
+6C:5C:3D:D0:00:00/28	Syowatsu	Syowatsusinkougyo Co.,Ltd.
+6C:5C:3D:E0:00:00/28	ClintonE	Clinton Electronics Corporation
 6C:5C:DE	Sunrepor	SunReports, Inc.
 6C:5D:63	Shenzhen	ShenZhen Rapoo Technology Co., Ltd.
 6C:5E:7A	Ubiquito	Ubiquitous Internet Telecom Co., Ltd
@@ -23240,6 +23905,7 @@
 6C:61:26	RinicomH	Rinicom Holdings
 6C:62:6D	Micro-St	Micro-Star INT'L CO., LTD
 6C:64:1A	PenguinC	Penguin Computing
+6C:6C:D3	Cisco	Cisco Systems, Inc
 6C:6E:FE	CoreLogi	Core Logic Inc.
 6C:6F:18	Stereota	Stereotaxis, Inc.
 6C:70:39	Novar	Novar GmbH
@@ -23270,6 +23936,7 @@
 6C:99:89	Cisco	Cisco Systems, Inc
 6C:9A:C9	Valentin	Valentine Research, Inc.
 6C:9B:02	Nokia	Nokia Corporation
+6C:9B:C0	Chemopti	Chemoptics Inc.
 6C:9C:E9	NimbleSt	Nimble Storage
 6C:9C:ED	Cisco	Cisco Systems, Inc
 6C:A1:00	IntelCor	Intel Corporate
@@ -23280,6 +23947,7 @@
 6C:A8:49	Avaya	Avaya Inc
 6C:A8:58	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 6C:A9:06	Telefiel	Telefield Ltd
+6C:A9:28	HmdGloba	HMD Global Oy
 6C:A9:6F	Transpac	TransPacket AS
 6C:AA:B3	RuckusWi	Ruckus Wireless
 6C:AB:31	Apple	Apple, Inc.
@@ -23289,6 +23957,7 @@
 6C:AD:EF	KzBroadb	KZ Broadband Technologies, Ltd.
 6C:AD:F8	Azurewav	AzureWave Technology Inc.
 6C:AE:8B	Ibm	IBM Corporation
+6C:AF:15	WebastoS	Webasto SE
 6C:B0:CE	Netgear
 6C:B2:27	SonyVide	Sony Video & Sound Products Inc.
 6C:B2:AE	Cisco	Cisco Systems, Inc
@@ -23306,7 +23975,9 @@
 6C:C1:D2	ArrisGro	ARRIS Group, Inc.
 6C:C2:17	HewlettP	Hewlett Packard
 6C:C2:6B	Apple	Apple, Inc.
+6C:C3:74	TexasIns	Texas Instruments
 6C:C4:D5	HmdGloba	HMD Global Oy
+6C:C7:EC	SamsungE	SAMSUNG ELECTRO-MECHANICS(THAILAND)
 6C:CA:08	ArrisGro	ARRIS Group, Inc.
 6C:D0:32	LgElectr	LG Electronics
 6C:D1:46	SmartekD	Smartek d.o.o.
@@ -23318,6 +23989,8 @@
 6C:E0:B0	Sound4
 6C:E3:B6	NeraTele	Nera Telecommunications Ltd.
 6C:E4:CE	Villiger	Villiger Security Solutions AG
+6C:E4:DA	NecPlatf	NEC Platforms, Ltd.
+6C:E8:5C	Apple	Apple, Inc.
 6C:E8:73	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 6C:E9:07	Nokia	Nokia Corporation
 6C:E9:83	Gastron	Gastron Co., LTD.
@@ -23325,23 +23998,28 @@
 6C:EC:5A	HonHaiPr	Hon Hai Precision Ind. CO.,Ltd.
 6C:EC:A1	Shenzhen	Shenzhen Clou Electronics Co. Ltd.
 6C:EC:EB	TexasIns	Texas Instruments
+6C:ED:51	Nexcontr	NEXCONTROL Co.,Ltd
 6C:EF:C6	Shenzhen	Shenzhen Twowing Technologies Co.,Ltd.
 6C:F0:49	Giga-Byt	GIGA-BYTE TECHNOLOGY CO.,LTD.
 6C:F3:73	SamsungE	Samsung Electronics Co.,Ltd
 6C:F3:7F	ArubaNet	Aruba Networks
 6C:F5:E8	Mooredol	Mooredoll Inc.
 6C:F9:7C	Nanoptix	Nanoptix Inc.
-6C:F9:D2	ChengduG	Chengdu Goods for the Road Electronic Technology C
+6C:F9:D2	ChengduP	Chengdu Povodo Electronic Technology Co., Ltd
 6C:FA:58	Avaya	Avaya Inc
 6C:FA:89	Cisco	Cisco Systems, Inc
 6C:FA:A7	AmpakTec	AMPAK Technology, Inc.
 6C:FD:B9	ProwareT	Proware Technologies Co Ltd.
 6C:FF:BE	MpbCommu	MPB Communications Inc.
 70:01:36	FatekAut	FATEK Automation Corporation
+70:01:B5	Cisco	Cisco Systems, Inc
 70:02:58	01db-Met	01DB-METRAVIB
+70:03:7E	Technico	Technicolor CH USA Inc.
 70:05:14	LgElectr	LG Electronics (Mobile Communications)
 70:06:AC	Eastcomp	Eastcompeace Technology Co., Ltd
+70:0B:01	Sagemcom	Sagemcom Broadband SAS
 70:0B:C0	DewavTec	Dewav Technology Company
+70:0F:6A	Cisco	Cisco Systems, Inc
 70:0F:C7	Shenzhen	Shenzhen Ikinloop Technology Co.,Ltd.
 70:0F:EC	Poindus	Poindus Systems Corp.
 70:10:5C	Cisco	Cisco Systems, Inc
@@ -23352,9 +24030,11 @@
 70:14:A6	Apple	Apple, Inc.
 70:16:9F	Ethercat	EtherCAT Technology Group
 70:18:8B	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
+70:19:2F	HuaweiTe	Huawei Technologies Co.,Ltd
 70:1A:04	LiteonTe	Liteon Technology Corporation
 70:1A:ED	Advas	Advas Co., Ltd.
 70:1C:E7	IntelCor	Intel Corporate
+70:1D:08	99iotShe	99IOT Shenzhen co.,ltd
 70:1D:7F	ComtechT	Comtech Technology Co., Ltd.
 70:1D:C4	Northsta	NorthStar Battery Company, LLC
 70:1F:53	Cisco	Cisco Systems, Inc
@@ -23366,11 +24046,13 @@
 70:28:8B	SamsungE	Samsung Electronics Co.,Ltd
 70:29:00	Shenzhen	Shenzhen ChipTrip Technology Co,Ltd
 70:2A:7D	Epspot	EpSpot AB
+70:2A:D5	SamsungE	Samsung Electronics Co.,Ltd
 70:2B:1D	E-DomusI	E-Domus International Limited
 70:2C:1F	Wisol
 70:2D:84	I4cInnov	i4C Innovations
 70:2D:D1	NewingsC	Newings Communication CO., LTD.
 70:2E:22	Zte	zte corporation
+70:2E:D9	Guangzho	Guangzhou Shiyuan Electronics Co., Ltd.
 70:2F:4B	Polyvisi	PolyVision Inc.
 70:2F:97	AavaMobi	Aava Mobile Oy
 70:30:18	Avaya	Avaya Inc
@@ -23382,6 +24064,7 @@
 70:38:B4	LowTechS	Low Tech Solutions
 70:38:EE	Avaya	Avaya Inc
 70:3A:0E	ArubaNet	Aruba Networks
+70:3A:73	Shenzhen	Shenzhen Sundray Technologies Company Limited
 70:3A:CB	Google	Google, Inc.
 70:3A:D8	Shenzhen	Shenzhen Afoundry Electronic Co., Ltd
 70:3C:03	Radiant	RadiAnt Co.,Ltd
@@ -23399,10 +24082,13 @@
 70:4D:7B	AsustekC	ASUSTek COMPUTER INC.
 70:4E:01	Kwangwon	Kwangwon Tech Co., Ltd.
 70:4E:66	Shenzhen	Shenzhen Fast Technologies Co.,Ltd
+70:4F:08	Shenzhen	Shenzhen Huisheng Information Technology Co., Ltd.
 70:4F:57	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
+70:4F:B8	ArrisGro	ARRIS Group, Inc.
 70:50:AF	Bskyb	BSkyB Ltd
 70:52:C5	Avaya	Avaya Inc
 70:53:3F	AlfaInst	Alfa Instrumentos Eletronicos Ltda.
+70:54:B4	VestelEl	Vestel Elektronik San ve Tic. A.Ş.
 70:54:D2	Pegatron	Pegatron Corporation
 70:54:F5	HuaweiTe	Huawei Technologies Co.,Ltd
 70:55:F8	Cerebras	Cerebras Systems Inc
@@ -23417,6 +24103,7 @@
 70:5A:B6	CompalIn	COMPAL INFORMATION (KUNSHAN) CO., LTD.
 70:5B:2E	M2commun	M2Communication Inc.
 70:5C:AD	KonamiGa	Konami Gaming Inc
+70:5D:CC	EfmNetwo	EFM Networks
 70:5E:AA	ActionTa	Action Target, Inc.
 70:60:DE	Lavision	LaVision GmbH
 70:61:73	Calantec	Calantec GmbH
@@ -23426,7 +24113,9 @@
 70:65:A3	KandaoLi	Kandao lightforge Co., Ltd.
 70:66:1B	Sonova	Sonova AG
 70:68:79	SaijoDen	Saijo Denki International Co., Ltd.
+70:69:5A	Cisco	Cisco Systems, Inc
 70:6B:B9	Cisco	Cisco Systems, Inc
+70:6D:15	Cisco	Cisco Systems, Inc
 70:6D:EC	Wifi-Sof	Wifi-soft LLC
 70:6E:6D	Cisco	Cisco Systems, Inc
 70:6F:81	Private
@@ -23447,6 +24136,7 @@
 70:78:8B	VivoMobi	vivo Mobile Communication Co., Ltd.
 70:79:38	WuxiZhan	Wuxi Zhanrui Electronic Technology Co.,LTD
 70:79:90	HuaweiTe	Huawei Technologies Co.,Ltd
+70:79:B3	Cisco	Cisco Systems, Inc
 70:7B:E8	HuaweiTe	Huawei Technologies Co.,Ltd
 70:7C:18	AdataTec	ADATA Technology Co., Ltd
 70:7C:69	Avaya	Avaya Inc
@@ -23473,6 +24163,7 @@
 70:88:6B:A0:00:00/28	RhxtuneT	RHXTune Technology Co.,Ltd
 70:88:6B:B0:00:00/28	BeijingS	Beijing Strongleader Science & Technology Co., Ltd.
 70:88:6B:C0:00:00/28	Max4g	MAX4G, Inc.
+70:89:CC	ChinaMob	China Mobile Group Device Co.,Ltd.
 70:8A:09	HuaweiTe	Huawei Technologies Co.,Ltd
 70:8B:78	Citygrow	citygrow technology co., ltd
 70:8B:CD	AsustekC	ASUSTek COMPUTER INC.
@@ -23490,6 +24181,7 @@
 70:9E:29	SonyInte	Sony Interactive Entertainment Inc.
 70:9E:86	X6d	X6D Limited
 70:9F:2D	Zte	zte corporation
+70:9F:A9	TecnoMob	Tecno Mobile Limited
 70:A1:91	Trendset	Trendsetter Medical, LLC
 70:A2:B3	Apple	Apple, Inc.
 70:A4:1C	Advanced	Advanced Wireless Dynamics S.L.
@@ -23510,11 +24202,14 @@
 70:B3:D5:00:20:00/36	GogoBa	Gogo BA
 70:B3:D5:00:70:00/36	Sensoneo
 70:B3:D5:00:90:00/36	Holidayc	HolidayCoro
+70:B3:D5:00:A0:00/36	Fujicom	FUJICOM Co.,Ltd.
 70:B3:D5:00:D0:00/36	Scrona	Scrona AG
 70:B3:D5:00:E0:00/36	Magosys	Magosys Systems LTD
 70:B3:D5:01:00:00/36	HanwaEle	Hanwa Electronic Ind.Co.,Ltd.
 70:B3:D5:01:10:00/36	SumerDat	Sumer Data S.L
 70:B3:D5:01:20:00/36	KstTechn	KST technology
+70:B3:D5:01:40:00/36	FrakoKon	FRAKO Kondensatoren und Anlagenbau GmbH
+70:B3:D5:01:50:00/36	EnElectr	EN ElectronicNetwork Hamburg GmbH
 70:B3:D5:01:60:00/36	Guardian	Guardian Controls International Ltd
 70:B3:D5:01:A0:00/36	CubroAcr	Cubro Acronet GesmbH
 70:B3:D5:01:C0:00/36	KumuNetw	Kumu Networks
@@ -23522,18 +24217,23 @@
 70:B3:D5:01:E0:00/36	EpointEm	ePOINT Embedded Computing Limited
 70:B3:D5:01:F0:00/36	SpxFlowT	SPX Flow Technology BV
 70:B3:D5:02:20:00/36	Ravelin	Ravelin Ltd
+70:B3:D5:02:30:00/36	Cambridg	Cambridge Pixel
+70:B3:D5:02:40:00/36	G+DMobil	G+D Mobile Security
 70:B3:D5:02:50:00/36	ElsuhdNe	Elsuhd Net Ltd Co.
 70:B3:D5:02:60:00/36	Telstra
+70:B3:D5:02:70:00/36	RedcapSo	Redcap Solutions s.r.o.
 70:B3:D5:02:80:00/36	At-Autom	AT-Automation Technology GmbH
 70:B3:D5:02:90:00/36	MarimoEl	Marimo electronics Co.,Ltd.
 70:B3:D5:02:A0:00/36	BaeSurfa	BAE Systems Surface Ships Limited
 70:B3:D5:02:D0:00/36	NexttecS	NEXTtec srl
 70:B3:D5:02:E0:00/36	Monnit	Monnit Corporation
+70:B3:D5:02:F0:00/36	Legendai	Legendaire Technology Co., Ltd.
 70:B3:D5:03:00:00/36	TresentT	Tresent Technologies
 70:B3:D5:03:10:00/36	Shenzhen	Shenzhen Gaona Electronic Co.Ltd
 70:B3:D5:03:20:00/36	Ifreecom	iFreecomm Technology Co., Ltd
 70:B3:D5:03:30:00/36	SailmonB	Sailmon BV
 70:B3:D5:03:50:00/36	Hkw-Elek	HKW-Elektronik GmbH
+70:B3:D5:03:70:00/36	EiffageE	Eiffage Energie Electronique
 70:B3:D5:03:90:00/36	DowooDig	DoWoo Digitech
 70:B3:D5:03:B0:00/36	Ssl-Elec	SSL - Electrical Aerospace Ground Equipment Section
 70:B3:D5:03:C0:00/36	Ultimate	Ultimate Software
@@ -23544,17 +24244,20 @@
 70:B3:D5:04:20:00/36	CovelozT	Coveloz Technologies Inc.
 70:B3:D5:04:40:00/36	DonElect	Don Electronics Ltd
 70:B3:D5:04:60:00/36	Shenzhen	Shenzhen Rihuida Electronics Co,. Ltd
+70:B3:D5:04:90:00/36	AppEngin	APP Engineering, Inc.
 70:B3:D5:04:A0:00/36	GeckoRob	Gecko Robotics Inc
 70:B3:D5:04:B0:00/36	DreamISy	Dream I System Co., Ltd
 70:B3:D5:04:C0:00/36	MapnaGro	mapna group
 70:B3:D5:04:D0:00/36	SiconSrl	Sicon srl
 70:B3:D5:04:E0:00/36	Hugel	HUGEL GmbH
+70:B3:D5:05:00:00/36	Compusig	Compusign Systems Pty Ltd
 70:B3:D5:05:20:00/36	SudoPrem	Sudo Premium Engineering
 70:B3:D5:05:40:00/36	Groupeer	Groupeer Technologies
 70:B3:D5:05:80:00/36	TelinkSe	Telink Semiconductor CO, Limtied, Taiwan
 70:B3:D5:05:90:00/36	Pro-Digi	Pro-Digital Projetos Eletronicos Ltda
 70:B3:D5:05:A0:00/36	UniContr	Uni Control System Sp. z o. o.
 70:B3:D5:05:D0:00/36	Koms	KOMS Co.,Ltd.
+70:B3:D5:05:E0:00/36	Vitec
 70:B3:D5:05:F0:00/36	UnisorMu	Unisor Multisystems Ltd
 70:B3:D5:06:10:00/36	Intellid	IntelliDesign Pty Ltd
 70:B3:D5:06:20:00/36	RmMichae	RM Michaelides Software & Elektronik GmbH
@@ -23563,17 +24266,22 @@
 70:B3:D5:06:90:00/36	Ondemand	ONDEMAND LABORATORY Co., Ltd.
 70:B3:D5:06:B0:00/36	U-Tech
 70:B3:D5:06:C0:00/36	Apptek
+70:B3:D5:06:F0:00/36	BeijingD	Beijing Daswell Science and Technology Co.LTD
 70:B3:D5:07:00:00/36	Lumiplan	Lumiplan Duhamel
+70:B3:D5:07:30:00/36	LiteonTe	Liteon Technology Corporation
 70:B3:D5:07:50:00/36	Mo-SysEn	Mo-Sys Engineering Ltd
 70:B3:D5:07:70:00/36	Inaccess	InAccess Networks SA
 70:B3:D5:07:80:00/36	Orbiwise	OrbiWise SA
 70:B3:D5:07:90:00/36	Checkbil	CheckBill Co,Ltd.
 70:B3:D5:07:A0:00/36	ZaoZeo	Zao Zeo
+70:B3:D5:07:B0:00/36	Wallbe	wallbe GmbH
 70:B3:D5:07:D0:00/36	Panorami	Panoramic Power
 70:B3:D5:07:E0:00/36	EntecEle	ENTEC Electric & Electronic CO., LTD
 70:B3:D5:07:F0:00/36	Abalance	Abalance Corporation
 70:B3:D5:08:10:00/36	IstTechn	IST Technologies (SHENZHEN) Limited
 70:B3:D5:08:30:00/36	ZaoZeo	Zao Zeo
+70:B3:D5:08:40:00/36	RakoCont	Rako Controls Ltd
+70:B3:D5:08:50:00/36	HumanInt	Human Systems Integration
 70:B3:D5:08:60:00/36	HustyMSt	Husty M.Styczen J.Hupert Sp.J.
 70:B3:D5:08:70:00/36	TempusFu	Tempus Fugit Consoles bvba
 70:B3:D5:08:80:00/36	Optiscan	OptiScan Biomedical Corp.
@@ -23588,6 +24296,8 @@
 70:B3:D5:09:60:00/36	Havelsan	HAVELSAN A.Ş.
 70:B3:D5:09:70:00/36	AvantTec	Avant Technologies
 70:B3:D5:09:90:00/36	Schwer+K	Schwer+Kopka GmbH
+70:B3:D5:09:A0:00/36	AkseSrl	Akse srl
+70:B3:D5:09:B0:00/36	Jacarta	Jacarta Ltd
 70:B3:D5:09:D0:00/36	P&S	P&S GmbH
 70:B3:D5:09:E0:00/36	Mobiprom	MobiPromo
 70:B3:D5:09:F0:00/36	ComtechK	COMTECH Kft.
@@ -23598,9 +24308,11 @@
 70:B3:D5:0A:40:00/36	Communic	Communication Technology Ltd.
 70:B3:D5:0A:50:00/36	Fuelcell	Fuelcellpower
 70:B3:D5:0A:60:00/36	PaConsul	Pa Consulting Services
+70:B3:D5:0A:80:00/36	Symetric	Symetrics Industries d.b.a. Extant Aerospace
 70:B3:D5:0A:90:00/36	Proconne	ProConnections, Inc.
 70:B3:D5:0A:A0:00/36	Wanco	Wanco Inc
 70:B3:D5:0A:B0:00/36	KstTechn	KST technology
+70:B3:D5:0A:C0:00/36	Robocore	RoboCore Tecnologia
 70:B3:D5:0A:E0:00/36	NorsatIn	Norsat International Inc.
 70:B3:D5:0A:F0:00/36	Kmtronic	KMtronic ltd
 70:B3:D5:0B:00:00/36	RavenDes	Raven Systems Design, Inc
@@ -23614,6 +24326,7 @@
 70:B3:D5:0B:C0:00/36	Practica	Practical Software Studio LLC
 70:B3:D5:0B:D0:00/36	Andium
 70:B3:D5:0B:E0:00/36	Chamsys	ChamSys Ltd
+70:B3:D5:0B:F0:00/36	DenAutom	Den Automation
 70:B3:D5:0C:00:00/36	MoluTech	Molu Technology Inc., LTD.
 70:B3:D5:0C:10:00/36	NexusTec	Nexus Technologies Pty Ltd
 70:B3:D5:0C:20:00/36	LookEasy	Look Easy International Limited
@@ -23621,10 +24334,13 @@
 70:B3:D5:0C:50:00/36	Precitec	Precitec Optronik GmbH
 70:B3:D5:0C:60:00/36	Embedded	Embedded Arts Co., Ltd.
 70:B3:D5:0C:80:00/36	FinRobot	Fin Robotics Inc
+70:B3:D5:0C:90:00/36	LineageP	Lineage Power Pvt Ltd.,
 70:B3:D5:0C:D0:00/36	AmlOcean	AML Oceanographic
 70:B3:D5:0C:E0:00/36	Innomind	Innominds Software Inc
+70:B3:D5:0D:10:00/36	CommonSe	Common Sense Monitoring Solutions Ltd.
 70:B3:D5:0D:20:00/36	Unmanned	Unmanned Spa
 70:B3:D5:0D:30:00/36	TsatAs	Tsat As
+70:B3:D5:0D:40:00/36	Guangzho	Guangzhou Male Industrial Animation Technology Co.,Ltd.
 70:B3:D5:0D:60:00/36	TattileS	Tattile Srl
 70:B3:D5:0D:70:00/36	RussianT	Russian Telecom Equipment Company
 70:B3:D5:0D:80:00/36	LaserIma	Laser Imagineering GmbH
@@ -23634,15 +24350,20 @@
 70:B3:D5:0D:E0:00/36	Grossenb	Grossenbacher Systeme AG
 70:B3:D5:0D:F0:00/36	BEASa	B.E.A. sa
 70:B3:D5:0E:00:00/36	Plcis
+70:B3:D5:0E:10:00/36	MiwaveCo	MiWave Consulting, LLC
 70:B3:D5:0E:30:00/36	SintauSr	SinTau SrL
 70:B3:D5:0E:50:00/36	DeltaSol	Delta Solutions LLC
 70:B3:D5:0E:60:00/36	Nasdaq
 70:B3:D5:0E:80:00/36	Grossenb	Grossenbacher Systeme AG
+70:B3:D5:0E:A0:00/36	AevBroad	AEV Broadcast Srl
 70:B3:D5:0E:C0:00/36	AcsMotio	Acs Motion Control
 70:B3:D5:0E:E0:00/36	PictureE	Picture Elements, Inc.
 70:B3:D5:0E:F0:00/36	DexteraL	Dextera Labs
 70:B3:D5:0F:00:00/36	Avionica
 70:B3:D5:0F:10:00/36	BeijingO	Beijing One City Science & Technology Co., LTD
+70:B3:D5:0F:30:00/36	Monsoonr	MonsoonRF, Inc.
+70:B3:D5:0F:70:00/36	Bespoon
+70:B3:D5:0F:80:00/36	SpecialS	Special Services Group, LLC
 70:B3:D5:0F:A0:00/36	Insiderf	InsideRF Co., Ltd.
 70:B3:D5:0F:B0:00/36	CygnusLl	Cygnus LLC
 70:B3:D5:0F:C0:00/36	Vitalcar	vitalcare
@@ -23651,21 +24372,25 @@
 70:B3:D5:10:00:00/36	Gupsy	Gupsy GmbH
 70:B3:D5:10:30:00/36	Hanyoung	Hanyoung Nux Co.,Ltd
 70:B3:D5:10:40:00/36	PlumSpZO	Plum sp. z o.o
+70:B3:D5:10:50:00/36	BeijingN	Beijing Nacao Technology Co., Ltd.
 70:B3:D5:10:60:00/36	AplexTec	Aplex Technology Inc.
 70:B3:D5:10:80:00/36	TexCompu	Tex Computer Srl
-70:B3:D5:10:90:00/36	DitestFa	Ditest Fahrzeugdiagnose Gmbh
+70:B3:D5:10:90:00/36	DitestFa	DiTEST Fahrzeugdiagnose GmbH
 70:B3:D5:10:A0:00/36	SeasonDe	Season Design Technology
 70:B3:D5:10:C0:00/36	Vocality	Vocality International Ltd
+70:B3:D5:10:E0:00/36	Colorime	Colorimetry Research, Inc
 70:B3:D5:10:F0:00/36	Neqis
 70:B3:D5:11:20:00/36	DitestFa	DiTEST Fahrzeugdiagnose GmbH
 70:B3:D5:11:40:00/36	ProjectH	Project H Pty Ltd
 70:B3:D5:11:50:00/36	Welltec	Welltec Corp.
 70:B3:D5:11:90:00/36	Private
+70:B3:D5:11:B0:00/36	Hoseotel	HoseoTelnet Inc...
 70:B3:D5:11:C0:00/36	Samriddi	Samriddi Automations Pvt. Ltd.
 70:B3:D5:11:D0:00/36	DaktonMi	Dakton Microlabs LLC
 70:B3:D5:11:F0:00/36	Geppetto	Geppetto Electronics
 70:B3:D5:12:00:00/36	GspSprac	GSP Sprachtechnologie GmbH
 70:B3:D5:12:20:00/36	HenriHol	Henri Systems Holland bv
+70:B3:D5:12:30:00/36	Amfitech	Amfitech ApS
 70:B3:D5:12:40:00/36	Forschun	Forschungs- und Transferzentrum Leipzig e.V.
 70:B3:D5:12:50:00/36	Securoly	Securolytics, Inc.
 70:B3:D5:12:70:00/36	Vitec
@@ -23689,8 +24414,10 @@
 70:B3:D5:13:E0:00/36	StaraInd	Stara S/A Indústria de Implementos Agrícolas
 70:B3:D5:13:F0:00/36	Farmobil	Farmobile
 70:B3:D5:14:00:00/36	VirtaLab	Virta Laboratories, Inc.
+70:B3:D5:14:10:00/36	MTSRL	M.T. S.R.L.
 70:B3:D5:14:20:00/36	DaveSrl	Dave Srl
 70:B3:D5:14:40:00/36	GsElektr	GS Elektromedizinsiche Geräte G. Stemple GmbH
+70:B3:D5:14:50:00/36	SiconSrl	Sicon srl
 70:B3:D5:14:60:00/36	3cityEle	3City Electronics
 70:B3:D5:14:70:00/36	RomoWind	ROMO Wind A/S
 70:B3:D5:14:80:00/36	PowerEle	Power Electronics Espana, S.L.
@@ -23702,10 +24429,14 @@
 70:B3:D5:14:F0:00/36	MobileDe	Mobile Devices Unlimited
 70:B3:D5:15:20:00/36	XpedPty	Xped Corporation Pty Ltd
 70:B3:D5:15:30:00/36	Schneide	Schneider Electric Motion USA
+70:B3:D5:15:40:00/36	WalkHori	Walk Horizon Technology (Beijing) Co., Ltd.
+70:B3:D5:15:B0:00/36	Armstron	Armstrong International, Inc.
 70:B3:D5:15:C0:00/36	WoodsHol	Woods Hole Oceanographic Institution
 70:B3:D5:15:D0:00/36	VtronPty	Vtron Pty Ltd
+70:B3:D5:15:E0:00/36	SeasonEl	Season Electronics Ltd
 70:B3:D5:15:F0:00/36	Savroni̇	SAVRONİK ELEKTRONİK
-70:B3:D5:16:10:00/36	MbConnec	MB Connect Line GmbH
+70:B3:D5:16:10:00/36	MbConnec	MB connect line GmbH Fernwartungssysteme
+70:B3:D5:16:20:00/36	EspaiDeP	ESPAI DE PRODUCCIÓ I ELECTRÓNI
 70:B3:D5:16:30:00/36	BharatHe	Bharat Heavy Electricals Limited
 70:B3:D5:16:40:00/36	TokyoDra	Tokyo Drawing Ltd.
 70:B3:D5:16:60:00/36	SerialIm	Serial Image Inc.
@@ -23723,9 +24454,10 @@
 70:B3:D5:17:80:00/36	GamberJo	Gamber Johnson-LLC
 70:B3:D5:17:90:00/36	AltranUk	Altran Uk
 70:B3:D5:17:A0:00/36	Gencoa	Gencoa Ltd
+70:B3:D5:17:B0:00/36	VistecEl	Vistec Electron Beam GmbH
 70:B3:D5:17:D0:00/36	EntechEl	Entech Electronics
 70:B3:D5:17:E0:00/36	OculiVis	Oculi Vision
-70:B3:D5:17:F0:00/36	MbConnec	MB Connect Line GmbH
+70:B3:D5:17:F0:00/36	MbConnec	MB connect line GmbH Fernwartungssysteme
 70:B3:D5:18:00:00/36	LhaPty	LHA Systems (Pty) Ltd
 70:B3:D5:18:10:00/36	TaskSist	Task Sistemas
 70:B3:D5:18:20:00/36	KitronUa	Kitron UAB
@@ -23735,6 +24467,7 @@
 70:B3:D5:18:60:00/36	Rohde&Sc	Rohde&Schwarz Topex SA
 70:B3:D5:18:70:00/36	Elektron	Elektronik & Präzisionsbau Saalfeld GmbH
 70:B3:D5:18:80:00/36	BirketEn	Birket Engineering
+70:B3:D5:18:90:00/36	DaveSrl	Dave Srl
 70:B3:D5:18:B0:00/36	AplexTec	Aplex Technology Inc.
 70:B3:D5:18:C0:00/36	CmcIndus	CMC Industrial Electronics Ltd
 70:B3:D5:18:D0:00/36	ForoTel	Foro Tel
@@ -23746,10 +24479,12 @@
 70:B3:D5:19:B0:00/36	GlobalTe	Global Technical Systems
 70:B3:D5:19:C0:00/36	Kubu	Kubu, Inc.
 70:B3:D5:19:E0:00/36	J-Factor	J-Factor Embedded Technologies
+70:B3:D5:19:F0:00/36	KoizumiL	Koizumi Lighting Technology Corp.
 70:B3:D5:1A:00:00/36	Ufatech	Ufatech Ltd
 70:B3:D5:1A:10:00/36	Hmicro	HMicro Inc
 70:B3:D5:1A:30:00/36	Telairit	Telairity Semiconductor
 70:B3:D5:1A:50:00/36	Metronic	METRONIC APARATURA KONTROLNO - POMIAROWA
+70:B3:D5:1A:60:00/36	Robotelf	Robotelf Technologies (Chengdu) Co., Ltd.
 70:B3:D5:1A:80:00/36	StcRainb	STC Rainbow Ltd.
 70:B3:D5:1A:90:00/36	Oceanix	Oceanix Inc.
 70:B3:D5:1A:B0:00/36	AccessCo	Access Control Systems JSC
@@ -23762,15 +24497,22 @@
 70:B3:D5:1B:80:00/36	Oes	OES Inc.
 70:B3:D5:1B:90:00/36	RelisteG	RELISTE Ges.m.b.H.
 70:B3:D5:1B:B0:00/36	EfentoTP	EFENTO T P SZYDŁOWSKI K ZARĘBA SPÓŁKA JAWNA
+70:B3:D5:1B:E0:00/36	PotterEl	Potter Electric Signal Co. LLC
 70:B3:D5:1C:40:00/36	SmegSPA	Smeg S.p.A.
 70:B3:D5:1C:50:00/36	Elsag
 70:B3:D5:1C:70:00/36	HoshinEl	Hoshin Electronics Co., Ltd.
 70:B3:D5:1C:80:00/36	LdaAudio	LDA audio video profesional S.L.
+70:B3:D5:1C:B0:00/36	Matchx	MatchX GmbH
+70:B3:D5:1C:C0:00/36	AoogeeCo	AooGee Controls Co., LTD.
+70:B3:D5:1C:D0:00/36	Eleusi	ELEUSI GmbH
 70:B3:D5:1D:00:00/36	Shenzhen	Shenzhen INVT Electric Co.,Ltd
+70:B3:D5:1D:10:00/36	EurotekS	Eurotek Srl
+70:B3:D5:1D:30:00/36	AirobotO	AIROBOT OÜ
 70:B3:D5:1D:40:00/36	Brinkman	Brinkmann Audio GmbH
 70:B3:D5:1D:70:00/36	Private
 70:B3:D5:1D:A0:00/36	Promess	Promess Inc.
 70:B3:D5:1D:B0:00/36	HudsonRo	Hudson Robotics
+70:B3:D5:1D:C0:00/36	Tekvel	TEKVEL Ltd.
 70:B3:D5:1D:D0:00/36	RfCreati	Rf Creations Ltd
 70:B3:D5:1D:E0:00/36	DycecSA	Dycec, S.A.
 70:B3:D5:1E:00:00/36	Toproott	TOPROOTTechnology Corp. Ltd.
@@ -23778,11 +24520,14 @@
 70:B3:D5:1E:40:00/36	Tecnolog	Tecnologix s.r.l.
 70:B3:D5:1E:50:00/36	Vendnova	VendNovation LLC
 70:B3:D5:1E:60:00/36	SanminaI	Sanmina Israel
+70:B3:D5:1E:80:00/36	GogoBa	Gogo BA
 70:B3:D5:1E:90:00/36	Comtime	comtime GmbH
+70:B3:D5:1E:A0:00/36	SenseFor	Sense For Innovation
 70:B3:D5:1E:F0:00/36	Adtek
 70:B3:D5:1F:30:00/36	SmartEne	Smart Energy Code Company Limited
 70:B3:D5:1F:40:00/36	Hangzhou	Hangzhou Woosiyuan Communication Co.,Ltd.
 70:B3:D5:1F:50:00/36	MartecSP	Martec S.p.A.
+70:B3:D5:1F:80:00/36	Converge	Convergent Design
 70:B3:D5:1F:D0:00/36	BrsSiste	BRS Sistemas Eletrônicos
 70:B3:D5:1F:E0:00/36	Mobiprom	MobiPromo
 70:B3:D5:20:00:00/36	Nextev	NextEV Co., Ltd.
@@ -23799,16 +24544,23 @@
 70:B3:D5:20:E0:00/36	AmrehnPa	Amrehn & Partner EDV-Service GmbH
 70:B3:D5:20:F0:00/36	TielineR	Tieline Research Pty Ltd
 70:B3:D5:21:10:00/36	Fracarro	Fracarro srl
+70:B3:D5:21:30:00/36	EtonDeut	ETON Deutschland Electro Acoustic GmbH
 70:B3:D5:21:40:00/36	Signalpa	signalparser
 70:B3:D5:21:50:00/36	Dataspee	Dataspeed Inc
 70:B3:D5:21:60:00/36	Flextron	Flextronics
 70:B3:D5:21:70:00/36	TecnintH	Tecnint HTE SRL
+70:B3:D5:21:B0:00/36	Lab241	Lab241 Co.,Ltd.
+70:B3:D5:21:C0:00/36	EnyxSa	Enyx SA
 70:B3:D5:21:D0:00/36	Irf-Inte	iRF - Intelligent RF Solutions, LLC
 70:B3:D5:21:E0:00/36	Hildebra	Hildebrand Technology Limited
+70:B3:D5:21:F0:00/36	Chronome	Chronomedia
 70:B3:D5:22:00:00/36	Private
 70:B3:D5:22:20:00/36	MarioffO	Marioff Corporation Oy
+70:B3:D5:22:40:00/36	UrbanaSm	Urbana Smart Solutions Pte Ltd
+70:B3:D5:22:50:00/36	RcdRadio	RCD Radiokomunikace
 70:B3:D5:22:60:00/36	Yaviar
 70:B3:D5:22:70:00/36	Montalvo
+70:B3:D5:22:80:00/36	Heitec	Heitec Ag
 70:B3:D5:22:90:00/36	ControlS	CONTROL SYSTEMS Srl
 70:B3:D5:22:B0:00/36	Vitec
 70:B3:D5:22:C0:00/36	HiquelEl	Hiquel Elektronik- und Anlagenbau GmbH
@@ -23817,19 +24569,31 @@
 70:B3:D5:23:00:00/36	Ct	CT Company
 70:B3:D5:23:10:00/36	DeltaTau	Delta Tau Data Systems, Inc.
 70:B3:D5:23:20:00/36	Uconsys
+70:B3:D5:23:40:00/36	Edfelect	EDFelectronics JRMM Sp z o.o. sp.k.
+70:B3:D5:23:50:00/36	CameonSA	Cameon S.A.
+70:B3:D5:23:60:00/36	Monnit	Monnit Corporation
 70:B3:D5:23:80:00/36	AreteAss	Arete Associates
+70:B3:D5:23:A0:00/36	MesaLabs	Mesa Labs, Inc.
+70:B3:D5:23:B0:00/36	FinkTele	Fink Telecom Services
 70:B3:D5:23:C0:00/36	Quasonix	Quasonix, LLC
 70:B3:D5:23:E0:00/36	TornadoM	Tornado Modular Systems
+70:B3:D5:23:F0:00/36	Eta-Usa
+70:B3:D5:24:00:00/36	OrlacoPr	Orlaco Products B.V.
 70:B3:D5:24:10:00/36	BolideTe	Bolide Technology Group, Inc.
 70:B3:D5:24:30:00/36	Rohde&Sc	Rohde&Schwarz Topex SA
 70:B3:D5:24:50:00/36	Newtec	Newtec A/S
 70:B3:D5:24:60:00/36	SalineLe	Saline Lectronics, Inc.
+70:B3:D5:24:80:00/36	GlTech	Gl Tech Co.,Ltd
 70:B3:D5:24:B0:00/36	ToseiEng	Tosei Engineering Corp.
 70:B3:D5:24:D0:00/36	InfoCrea	INFO CREATIVE (HK) LTD
+70:B3:D5:24:E0:00/36	ChengduC	Chengdu Cove Technology CO.,LTD
+70:B3:D5:24:F0:00/36	ElbitBmd	ELBIT SYSTEMS BMD AND LAND EW - ELISRA LTD
 70:B3:D5:25:00:00/36	DatumEle	Datum Electronics Limited
 70:B3:D5:25:20:00/36	SierraNe	Sierra Nevada Corporation
+70:B3:D5:25:30:00/36	WimateTe	Wimate Technology Solutions Private Limited
 70:B3:D5:25:40:00/36	Spectrum	Spectrum Brands
 70:B3:D5:25:50:00/36	Asystems	Asystems Corporation
+70:B3:D5:25:70:00/36	LgElectr	LG Electronics
 70:B3:D5:25:90:00/36	ZebraEle	Zebra Elektronik A.S.
 70:B3:D5:25:A0:00/36	Deuta-We	DEUTA-WERKE GmbH
 70:B3:D5:25:B0:00/36	GidIndus	GID Industrial
@@ -23841,6 +24605,7 @@
 70:B3:D5:26:80:00/36	Cardinal	Cardinal Scale Mfg Co
 70:B3:D5:26:90:00/36	Gilbarco	Gilbarco Veeder-Root  ‎
 70:B3:D5:26:B0:00/36	SoramaBv	Sorama BV
+70:B3:D5:26:C0:00/36	EaElektr	EA Elektroautomatik GmbH & Co. KG
 70:B3:D5:26:E0:00/36	Hi-TechS	HI-TECH SYSTEM Co. Ltd.
 70:B3:D5:27:20:00/36	TelecomS	Telecom Sante
 70:B3:D5:27:30:00/36	WevoTech	WeVo Tech
@@ -23850,8 +24615,11 @@
 70:B3:D5:27:80:00/36	Private
 70:B3:D5:27:90:00/36	Private
 70:B3:D5:27:A0:00/36	TdEcophi	Td Ecophisika
+70:B3:D5:27:C0:00/36	MotionLi	MOTION LIB,Inc.
 70:B3:D5:27:D0:00/36	TelenorC	Telenor Connexion AB
 70:B3:D5:27:E0:00/36	MettlerT	Mettler Toledo Hi Speed
+70:B3:D5:27:F0:00/36	StAerosp	ST Aerospace Systems
+70:B3:D5:28:00:00/36	Computec	Computech International
 70:B3:D5:28:30:00/36	Textninj	TextNinja Co.
 70:B3:D5:28:40:00/36	Globalco	Globalcom Engineering SPA
 70:B3:D5:28:50:00/36	BentecDr	Bentec GmbH Drilling & Oilfield Systems
@@ -23864,22 +24632,31 @@
 70:B3:D5:28:D0:00/36	Technica	Technica Engineering GmbH
 70:B3:D5:28:E0:00/36	TexCompu	Tex Computer Srl
 70:B3:D5:28:F0:00/36	Overline	Overline Systems
+70:B3:D5:29:20:00/36	Private
+70:B3:D5:29:30:00/36	SolarRig	Solar RIg Technologies
 70:B3:D5:29:50:00/36	CelloEle	Cello Electronics (UK) Ltd
 70:B3:D5:29:60:00/36	Rohde&Sc	Rohde&Schwarz Topex SA
 70:B3:D5:29:70:00/36	Grossenb	Grossenbacher Systeme AG
 70:B3:D5:29:B0:00/36	Dermalum	DermaLumics S.L.
+70:B3:D5:29:C0:00/36	TekoTele	Teko Telecom Srl
 70:B3:D5:29:D0:00/36	Xtech2Si	XTech2 SIA
 70:B3:D5:29:F0:00/36	CodeHard	Code Hardware SA
 70:B3:D5:2A:10:00/36	BlinkSer	Blink Services AB
 70:B3:D5:2A:20:00/36	Visualwa	Visualware, Inc.
+70:B3:D5:2A:30:00/36	AttNussb	ATT Nussbaum Prüftechnik GmbH
+70:B3:D5:2A:40:00/36	GspSprac	GSP Sprachtechnologie GmbH
 70:B3:D5:2A:50:00/36	Taitotek	Taitotekniikka
 70:B3:D5:2A:70:00/36	Plasmabi	Plasmability, LLC
+70:B3:D5:2A:80:00/36	DynamicP	Dynamic Perspective GmbH
+70:B3:D5:2A:90:00/36	PowerEle	Power Electronics Espana, S.L.
 70:B3:D5:2A:A0:00/36	Flirtey	Flirtey Inc
 70:B3:D5:2A:B0:00/36	NasaJohn	NASA Johnson Space Center
 70:B3:D5:2A:C0:00/36	NewImagi	New Imaging Technologies
 70:B3:D5:2A:D0:00/36	OpgalOpt	Opgal Optronic Industries
+70:B3:D5:2A:E0:00/36	AlereTec	Alere Technologies AS
 70:B3:D5:2B:00:00/36	BeijingZ	Beijing Zhongyi Yue Tai Technology Co., Ltd
 70:B3:D5:2B:10:00/36	Wixcon	WIXCON Co., Ltd
+70:B3:D5:2B:20:00/36	SunCreat	Sun Creative (ZheJiang) Technology INC.
 70:B3:D5:2B:30:00/36	Has	HAS co.,ltd.
 70:B3:D5:2B:40:00/36	Foerster	Foerster-Technik GmbH
 70:B3:D5:2B:70:00/36	MatrixOr	Matrix Orbital Corporation
@@ -23889,13 +24666,17 @@
 70:B3:D5:2B:C0:00/36	EquiposD	EQUIPOS DE TELECOMUNICACIÓN OPTOELECTRÓNICOS, S.A.
 70:B3:D5:2B:D0:00/36	Mg-Senso	mg-sensor GmbH
 70:B3:D5:2B:E0:00/36	Coherent	Coherent Logix, Inc.
+70:B3:D5:2B:F0:00/36	FoshanVo	Foshan Vohom
 70:B3:D5:2C:20:00/36	QuantumD	Quantum Detectors
 70:B3:D5:2C:30:00/36	Proterra
+70:B3:D5:2C:90:00/36	SeasonDe	Season Design Technology
+70:B3:D5:2C:A0:00/36	TattileS	Tattile Srl
 70:B3:D5:2C:C0:00/36	WeworkCo	WeWork Companies, Inc.
 70:B3:D5:2C:D0:00/36	KoreaAir	Korea Airports Corporation
 70:B3:D5:2C:E0:00/36	Kdt
-70:B3:D5:2C:F0:00/36	MbConnec	MB Connect Line GmbH
+70:B3:D5:2C:F0:00/36	MbConnec	MB connect line GmbH Fernwartungssysteme
 70:B3:D5:2D:00:00/36	Ijin	ijin co.,ltd.
+70:B3:D5:2D:20:00/36	Shanghai	Shanghai Irisian Optronics Technology Co.,Ltd.
 70:B3:D5:2D:40:00/36	Ct	CT Company
 70:B3:D5:2D:50:00/36	TeucoGuz	Teuco Guzzini
 70:B3:D5:2D:60:00/36	KvazarLl	Kvazar LLC
@@ -23907,6 +24688,7 @@
 70:B3:D5:2E:30:00/36	Meiknolo	Meiknologic GmbH
 70:B3:D5:2E:50:00/36	FläktWoo	Fläkt Woods AB
 70:B3:D5:2E:70:00/36	Atos	Atos spa
+70:B3:D5:2E:80:00/36	Telefire
 70:B3:D5:2E:A0:00/36	Schneide	Schneider Electric Motion
 70:B3:D5:2E:B0:00/36	Brnet	Brnet Co.,Ltd.
 70:B3:D5:2E:C0:00/36	GrupoEpe	Grupo Epelsa S.L.
@@ -23917,11 +24699,13 @@
 70:B3:D5:2F:20:00/36	HealthCa	Health Care Originals, Inc.
 70:B3:D5:2F:30:00/36	ScameSis	Scame Sistemi srl
 70:B3:D5:2F:40:00/36	RadixonS	Radixon s.r.o.
+70:B3:D5:2F:50:00/36	EzeSyste	eze System, Inc.
 70:B3:D5:2F:60:00/36	TattileS	Tattile Srl
 70:B3:D5:2F:80:00/36	Tunstall	Tunstall A/S
 70:B3:D5:2F:90:00/36	Consospy
 70:B3:D5:2F:A0:00/36	TorayMed	Toray　Medical　Co.,Ltd
 70:B3:D5:2F:D0:00/36	SpecialP	Special Projects Group, Inc
+70:B3:D5:2F:E0:00/36	YahamOpt	Yaham Optoelectronics Co., Ltd
 70:B3:D5:30:00:00/36	NovoDr	Novo DR Ltd.
 70:B3:D5:30:30:00/36	FuchuGik	Fuchu Giken, Inc.
 70:B3:D5:30:40:00/36	TransasM	Transas Marine Limited
@@ -23935,6 +24719,7 @@
 70:B3:D5:31:30:00/36	DiehlCon	DIEHL Controls
 70:B3:D5:31:70:00/36	IotopiaS	Iotopia Solutions
 70:B3:D5:31:90:00/36	Iso/Tc22	ISO/TC 22/SC 31
+70:B3:D5:31:B0:00/36	Silterra	SilTerra Malaysia Sdn. Bhd.
 70:B3:D5:31:C0:00/36	Financie	FINANCIERE DE L'OMBREE (eolane)
 70:B3:D5:31:E0:00/36	Gillam-F	GILLAM-FEI S.A.
 70:B3:D5:32:30:00/36	TattileS	Tattile Srl
@@ -23944,9 +24729,12 @@
 70:B3:D5:32:70:00/36	Seneco	Seneco A/S
 70:B3:D5:32:80:00/36	Hipodrom	Hipodromo De Agua Caliente Sa Cv
 70:B3:D5:32:A0:00/36	WuhanXin	Wuhan Xingtuxinke ELectronic Co.,Ltd
+70:B3:D5:32:D0:00/36	HanwellT	Hanwell Technology Co., Ltd.
 70:B3:D5:32:F0:00/36	Movidius	Movidius SRL
 70:B3:D5:33:20:00/36	Innosent
+70:B3:D5:33:40:00/36	Dokuen	Dokuen Co. Ltd.
 70:B3:D5:33:60:00/36	Synacces	Synaccess Networks Inc.
+70:B3:D5:33:80:00/36	Opti-Sci	Opti-Sciences, Inc.
 70:B3:D5:33:90:00/36	SierraNe	Sierra Nevada Corporation
 70:B3:D5:33:B0:00/36	SealShie	Seal Shield, LLC
 70:B3:D5:33:C0:00/36	Videri	Videri Inc.
@@ -23967,6 +24755,7 @@
 70:B3:D5:35:10:00/36	KstTechn	KST technology
 70:B3:D5:35:20:00/36	Globalco	Globalcom Engineering SPA
 70:B3:D5:35:30:00/36	DigitalO	Digital Outfit
+70:B3:D5:35:50:00/36	Hongin	Hongin., Ltd
 70:B3:D5:35:70:00/36	Moviment	Movimento Group AB
 70:B3:D5:35:90:00/36	Boutroni	Boutronic
 70:B3:D5:35:A0:00/36	AppliedR	Applied Radar, Inc.
@@ -23974,8 +24763,10 @@
 70:B3:D5:35:D0:00/36	FreshIde	Fresh Idea Factory BV
 70:B3:D5:35:E0:00/36	EidosSPA	EIDOS s.p.a.
 70:B3:D5:35:F0:00/36	AplexTec	Aplex Technology Inc.
+70:B3:D5:36:00:00/36	PtEmsoni	PT. Emsonic Indonesia
 70:B3:D5:36:10:00/36	ParentPo	Parent Power
 70:B3:D5:36:20:00/36	Asiga
+70:B3:D5:36:30:00/36	ContecDt	Contec DTx
 70:B3:D5:36:40:00/36	Adamczew	ADAMCZEWSKI elektronische Messtechnik GmbH
 70:B3:D5:36:50:00/36	Circuitm	CircuitMeter Inc.
 70:B3:D5:36:70:00/36	LivingWa	Living Water
@@ -23987,6 +24778,7 @@
 70:B3:D5:37:00:00/36	Inphi	Inphi Corporation
 70:B3:D5:37:10:00/36	Bederov	BEDEROV GmbH
 70:B3:D5:37:40:00/36	OooNppMa	OOO NPP Mars-Energo
+70:B3:D5:37:50:00/36	AdelSyst	Adel System srl
 70:B3:D5:37:60:00/36	Private
 70:B3:D5:37:70:00/36	Monnit	Monnit Corporation
 70:B3:D5:37:80:00/36	Synchrot	synchrotron SOLEIL
@@ -23997,6 +24789,7 @@
 70:B3:D5:37:D0:00/36	DxShop	The DX Shop Limited
 70:B3:D5:37:F0:00/36	IdsInnom	IDS Innomic GmbH
 70:B3:D5:38:10:00/36	Crde
+70:B3:D5:38:20:00/36	NavalGro	Naval Group
 70:B3:D5:38:30:00/36	LpaExcil	LPA Excil Electronics
 70:B3:D5:38:40:00/36	Sensohiv	Sensohive Technologies
 70:B3:D5:38:70:00/36	GwfMesss	GWF MessSysteme AG
@@ -24012,17 +24805,21 @@
 70:B3:D5:39:C0:00/36	GdMissio	GD Mission Systems
 70:B3:D5:39:D0:00/36	ComarkIn	Comark Interactive Solutions
 70:B3:D5:39:E0:00/36	LanmarkC	Lanmark Controls Inc.
+70:B3:D5:3A:10:00/36	ReckeenH	Reckeen HDP Media sp. z o.o. sp. k.
 70:B3:D5:3A:50:00/36	Kmtronic	KMtronic ltd
 70:B3:D5:3A:70:00/36	Varikore	Varikorea
 70:B3:D5:3A:80:00/36	Jamhub	JamHub Corp.
 70:B3:D5:3A:90:00/36	Vivalnk
 70:B3:D5:3A:A0:00/36	Rcatsone
+70:B3:D5:3A:D0:00/36	Ct	CT Company
 70:B3:D5:3A:E0:00/36	ExicomTe	Exicom Technologies fze
 70:B3:D5:3A:F0:00/36	TurboTec	Turbo Technologies Corporation
+70:B3:D5:3B:00:00/36	Millenni	Millennial Net, Inc.
 70:B3:D5:3B:20:00/36	SiconSrl	Sicon srl
 70:B3:D5:3B:50:00/36	PrestonI	Preston Industries dba PolyScience
 70:B3:D5:3B:70:00/36	PaulSche	Paul Scherrer Institut (PSI)
 70:B3:D5:3B:80:00/36	Nvideon	nVideon, Inc.
+70:B3:D5:3B:A0:00/36	SilexIns	Silex Inside
 70:B3:D5:3B:B0:00/36	A-M	A-M Systems
 70:B3:D5:3B:C0:00/36	Scitroni	SciTronix
 70:B3:D5:3B:E0:00/36	Mydefenc	MyDefence Communication ApS
@@ -24030,13 +24827,17 @@
 70:B3:D5:3C:00:00/36	Dk-Techn	DK-Technologies A/S
 70:B3:D5:3C:20:00/36	Cellular	Cellular Specialties, Inc.
 70:B3:D5:3C:30:00/36	Aimco
+70:B3:D5:3C:40:00/36	Hagiwara	Hagiwara Solutions Co., Ltd.
 70:B3:D5:3C:50:00/36	P4qElect	P4Q ELECTRONICS, S.L.
 70:B3:D5:3C:60:00/36	AcdElekr	ACD Elekronik GmbH
+70:B3:D5:3C:70:00/36	Softcrea	Softcreate Corp.
+70:B3:D5:3C:90:00/36	Duerkopp	Duerkopp-Adler
 70:B3:D5:3C:A0:00/36	Tti	TTI Ltd
 70:B3:D5:3C:C0:00/36	Teropta	TerOpta Ltd
 70:B3:D5:3C:E0:00/36	Aditec	Aditec GmbH
 70:B3:D5:3C:F0:00/36	Engineer	Systems Engineering Arts Pty Ltd
 70:B3:D5:3D:20:00/36	Imagine	Imagine Inc.
+70:B3:D5:3D:40:00/36	SanminaI	Sanmina Israel
 70:B3:D5:3D:50:00/36	OxynetSo	oxynet Solutions
 70:B3:D5:3D:70:00/36	RemoteSe	Remote Sensing Solutions, Inc.
 70:B3:D5:3D:80:00/36	Abitsoft	Abitsoftware, Ltd.
@@ -24050,26 +24851,37 @@
 70:B3:D5:3E:30:00/36	Head
 70:B3:D5:3E:40:00/36	NeptecTe	Neptec Technologies Corp.
 70:B3:D5:3E:50:00/36	Ateme
+70:B3:D5:3E:60:00/36	Machineq
 70:B3:D5:3E:80:00/36	CosmosWe	COSMOS web Co., Ltd.
 70:B3:D5:3E:90:00/36	ApolloGi	APOLLO GIKEN Co.,Ltd.
 70:B3:D5:3E:D0:00/36	UltraEle	Ultra Electronics Sonar System Division
 70:B3:D5:3E:F0:00/36	VtronPty	Vtron Pty Ltd
 70:B3:D5:3F:00:00/36	Interval	Intervala
 70:B3:D5:3F:10:00/36	OlympusN	Olympus NDT Canada
+70:B3:D5:3F:20:00/36	H3d	H3D, Inc.
 70:B3:D5:3F:30:00/36	Spea	Spea Spa
 70:B3:D5:3F:40:00/36	WincodeT	Wincode Technology Co., Ltd.
+70:B3:D5:3F:50:00/36	DolbyLab	Dolby Laboratories, Inc.
 70:B3:D5:3F:60:00/36	SycompEl	Sycomp Electronic GmbH
+70:B3:D5:3F:70:00/36	Advansid
 70:B3:D5:3F:90:00/36	HerrickT	Herrick Tech Labs
 70:B3:D5:3F:E0:00/36	MentorGr	Mentor Graphics
 70:B3:D5:3F:F0:00/36	HydraCon	Hydra Controls
 70:B3:D5:40:00:00/36	VtronPty	Vtron Pty Ltd
+70:B3:D5:40:10:00/36	Private
+70:B3:D5:40:20:00/36	AkisTech	AKIS technologies
+70:B3:D5:40:30:00/36	MightyCu	Mighty Cube Co., Ltd.
 70:B3:D5:40:40:00/36	Ranix	RANIX,Inc.
 70:B3:D5:40:50:00/36	MgSRL	MG s.r.l.
+70:B3:D5:40:60:00/36	Acrodea	Acrodea, Inc.
 70:B3:D5:40:70:00/36	Idosens
 70:B3:D5:40:80:00/36	ComrodAs	Comrod AS
 70:B3:D5:40:A0:00/36	MonroeEl	Monroe Electronics, Inc.
+70:B3:D5:40:E0:00/36	LiaoyunI	Liaoyun Information Technology Co., Ltd.
+70:B3:D5:41:00:00/36	AvantTec	Avant Technologies, Inc
 70:B3:D5:41:20:00/36	TattileS	Tattile Srl
 70:B3:D5:41:30:00/36	Axess	Axess AG
+70:B3:D5:41:50:00/36	Idea	Idea Spa
 70:B3:D5:41:70:00/36	FigmentD	Figment Design Laboratories
 70:B3:D5:41:80:00/36	DevSyste	DEV Systemtechnik GmbH& Co KG
 70:B3:D5:41:A0:00/36	HyosungP	HYOSUNG Power & Industrial Systems
@@ -24082,16 +24894,22 @@
 70:B3:D5:42:A0:00/36	Critical	Critical Link LLC
 70:B3:D5:42:C0:00/36	DMarchio	D.Marchiori Srl
 70:B3:D5:42:D0:00/36	RchItali	RCH Italia SpA
+70:B3:D5:42:E0:00/36	DrZinngr	Dr. Zinngrebe GmbH
 70:B3:D5:42:F0:00/36	Sintokog	Sintokogio, Ltd
 70:B3:D5:43:00:00/36	AlgodueE	Algodue Elettronica Srl
 70:B3:D5:43:10:00/36	PowerEle	Power Electronics Espana, S.L.
 70:B3:D5:43:20:00/36	Deuta-We	DEUTA-WERKE GmbH
 70:B3:D5:43:30:00/36	Flexsolu	Flexsolution APS
+70:B3:D5:43:40:00/36	WitCom	Wit.com Inc
 70:B3:D5:43:50:00/36	WuhanXin	Wuhan Xingtuxinke ELectronic Co.,Ltd
+70:B3:D5:43:60:00/36	HenrichE	Henrich Electronics Corporation
+70:B3:D5:43:70:00/36	DigitalW	Digital Way
 70:B3:D5:43:90:00/36	Triled
 70:B3:D5:43:B0:00/36	Kalycito	Kalycito Infotech Private Limited
 70:B3:D5:43:D0:00/36	VeryxTec	Veryx Technologies Private Limited
+70:B3:D5:43:F0:00/36	Biosilve	biosilver .co.,ltd
 70:B3:D5:44:00:00/36	Discover	Discover Video
+70:B3:D5:44:10:00/36	Videopor	Videoport S.A.
 70:B3:D5:44:20:00/36	BlairCom	Blair Companies
 70:B3:D5:44:30:00/36	Slot3	Slot3 GmbH
 70:B3:D5:44:50:00/36	Advanced	Advanced Devices SpA
@@ -24106,16 +24924,20 @@
 70:B3:D5:45:D0:00/36	Sensapex	Sensapex Oy
 70:B3:D5:45:E0:00/36	Esol	eSOL Co.,Ltd.
 70:B3:D5:45:F0:00/36	Cloud4wi
+70:B3:D5:46:00:00/36	GuilinTr	Guilin Tryin Technology Co.,Ltd
 70:B3:D5:46:10:00/36	Tesec	TESEC Corporation
 70:B3:D5:46:20:00/36	Eartex
 70:B3:D5:46:50:00/36	Energism	Energisme
+70:B3:D5:46:90:00/36	Gentec	Gentec Systems  Co.
 70:B3:D5:46:B0:00/36	Airborne	Airborne Engineering Limited
 70:B3:D5:46:C0:00/36	Shanghai	Shanghai Chenzhu Instrument Co., Ltd.
 70:B3:D5:46:F0:00/36	ServaTra	serva transport systems GmbH
 70:B3:D5:47:00:00/36	KitronUa	Kitron Uab
+70:B3:D5:47:10:00/36	SyscoSic	SYSCO Sicherheitssysteme GmbH
 70:B3:D5:47:20:00/36	QuadioDe	Quadio Devices Private Limited
 70:B3:D5:47:50:00/36	Ewattch
 70:B3:D5:47:60:00/36	Fr-TeamI	FR-Team International SA
+70:B3:D5:47:80:00/36	Touchnet	Touchnet/OneCard
 70:B3:D5:47:90:00/36	LineageP	Lineage Power Pvt Ltd.,
 70:B3:D5:47:C0:00/36	Par-Tech	Par-Tech, Inc.
 70:B3:D5:47:F0:00/36	Ase	ASE GmbH
@@ -24142,14 +24964,17 @@
 70:B3:D5:4A:00:00/36	Fludia
 70:B3:D5:4A:10:00/36	Herholdt	Herholdt Controls srl
 70:B3:D5:4A:50:00/36	Intermin	Intermind Inc.
+70:B3:D5:4A:60:00/36	HzhyTech	Hzhy Technology
 70:B3:D5:4A:70:00/36	Aelettro	aelettronica group srl
 70:B3:D5:4A:90:00/36	Warecube	Warecube,Inc
 70:B3:D5:4A:A0:00/36	TwowayCo	Twoway Communications, Inc.
 70:B3:D5:4A:D0:00/36	Gaci
 70:B3:D5:4A:E0:00/36	Reinhard	Reinhardt System- und Messelectronic GmbH
+70:B3:D5:4A:F0:00/36	Agramkow	Agramkow Fluid Systems A/S
 70:B3:D5:4B:00:00/36	Tecogen	Tecogen Inc.
 70:B3:D5:4B:10:00/36	LaceLlc	Lace Llc.
 70:B3:D5:4B:20:00/36	CertusOp	Certus Operations Ltd
+70:B3:D5:4B:40:00/36	HiTech	Hi Tech Systems Ltd
 70:B3:D5:4B:60:00/36	Veilux	Veilux Inc.
 70:B3:D5:4B:70:00/36	AplexTec	Aplex Technology Inc.
 70:B3:D5:4B:80:00/36	Internat	International Roll-Call Corporation
@@ -24158,16 +24983,19 @@
 70:B3:D5:4B:B0:00/36	Plazma-T
 70:B3:D5:4B:D0:00/36	BoulderA	Boulder Amplifiers, Inc.
 70:B3:D5:4B:E0:00/36	Gy-FxSas	GY-FX SAS
+70:B3:D5:4C:00:00/36	Technica	Technica Engineering GmbH
 70:B3:D5:4C:10:00/36	QuercusT	Quercus Technologies, S. L.
 70:B3:D5:4C:20:00/36	HeraLabo	hera Laborsysteme GmbH
 70:B3:D5:4C:40:00/36	OooResea	OOO Research and Production Center Computer Technologies
 70:B3:D5:4C:50:00/36	MovingIm	Moving iMage Technologies LLC
+70:B3:D5:4C:60:00/36	BlueboxV	BlueBox Video Limited
 70:B3:D5:4C:70:00/36	Solveris	SOLVERIS sp. z o.o.
 70:B3:D5:4C:80:00/36	Hosokawa	Hosokawa Micron Powder Systems
 70:B3:D5:4C:D0:00/36	PowerEle	Power Electronics Espana, S.L.
 70:B3:D5:4C:E0:00/36	Agilack
 70:B3:D5:4C:F0:00/36	GreenHou	Green House Co., Ltd.
 70:B3:D5:4D:10:00/36	Contrave	Contraves Advanced Devices Sdn. Bhd.
+70:B3:D5:4D:40:00/36	NortekGl	Nortek Global HVAC
 70:B3:D5:4D:50:00/36	MoogReko	Moog Rekofa  GmbH
 70:B3:D5:4D:80:00/36	Versilis	Versilis Inc.
 70:B3:D5:4D:B0:00/36	Temperat	Temperature@lert
@@ -24175,15 +25003,19 @@
 70:B3:D5:4D:D0:00/36	Road-IqL	Road-iQ, LLC
 70:B3:D5:4D:E0:00/36	OsoTechn	Oso Technologies, Inc.
 70:B3:D5:4D:F0:00/36	NidecAvt	Nidec Avtron Automation Corp
+70:B3:D5:4E:00:00/36	Microvid	Microvideo
 70:B3:D5:4E:10:00/36	GrupoEpe	Grupo Epelsa S.L.
 70:B3:D5:4E:50:00/36	VizaarIn	viZaar industrial imaging AG
 70:B3:D5:4E:70:00/36	DigitalD	Digital Domain
 70:B3:D5:4E:90:00/36	AdetecSa	Adetec Sas
+70:B3:D5:4E:A0:00/36	Vocality	Vocality international T/A Cubic
 70:B3:D5:4E:B0:00/36	Infosoft	INFOSOFT DIGITAL DESIGN & SERVICES PRIVATE LIMITED
+70:B3:D5:4E:C0:00/36	Hangzhou	Hangzhou Youshi Industry Co., Ltd.
 70:B3:D5:4E:F0:00/36	Cmi	CMI, Inc.
 70:B3:D5:4F:00:00/36	LiSengTe	Li Seng Technology Ltd.,
 70:B3:D5:4F:40:00/36	Witagg	WiTagg, Inc
 70:B3:D5:4F:80:00/36	Private
+70:B3:D5:4F:90:00/36	Optoprec	OptoPrecision GmbH
 70:B3:D5:4F:C0:00/36	MettlerT	Mettler Toledo
 70:B3:D5:4F:E0:00/36	Witagg	WiTagg, Inc
 70:B3:D5:50:00:00/36	MistralS	Mistral Solutions Pvt. LTD
@@ -24197,7 +25029,10 @@
 70:B3:D5:50:E0:00/36	MicroTre	Micro Trend Automation Co., LTD
 70:B3:D5:51:10:00/36	NextSigh	Next Sight srl
 70:B3:D5:51:30:00/36	MbConnec	MB connect line GmbH Fernwartungssysteme
+70:B3:D5:51:50:00/36	Pcsc
+70:B3:D5:51:60:00/36	LineageP	Lineage Power Pvt Ltd.,
 70:B3:D5:51:70:00/36	Ispher
+70:B3:D5:51:80:00/36	Cruxell	CRUXELL Corp.
 70:B3:D5:51:B0:00/36	VitreaSm	Vitrea Smart Home Technologies
 70:B3:D5:51:C0:00/36	AtxNetwo	ATX Networks Corp
 70:B3:D5:51:D0:00/36	TecnintH	Tecnint HTE SRL
@@ -24206,6 +25041,7 @@
 70:B3:D5:52:30:00/36	TibitCom	Tibit Communications
 70:B3:D5:52:40:00/36	WuxiNewO	Wuxi New Optical Communication Co.,Ltd.
 70:B3:D5:52:50:00/36	Plantiga	Plantiga Technologies Inc
+70:B3:D5:52:60:00/36	FlownetL	FlowNet LLC
 70:B3:D5:52:80:00/36	AplexTec	Aplex Technology Inc.
 70:B3:D5:52:B0:00/36	GeAviati	GE Aviation Cheltenham
 70:B3:D5:52:C0:00/36	Centurya	Centuryarks Ltd.,
@@ -24213,14 +25049,19 @@
 70:B3:D5:52:E0:00/36	Swisspon	Swissponic Sagl
 70:B3:D5:53:00:00/36	Isis-Ex	iSiS-Ex Limited
 70:B3:D5:53:10:00/36	Ateme
+70:B3:D5:53:20:00/36	Talleres	Talleres de Escoriaza SA
 70:B3:D5:53:80:00/36	Sydetion	sydetion UG (h.b.)
 70:B3:D5:53:A0:00/36	Pano0ram	Pano0ramic Power
 70:B3:D5:53:B0:00/36	MrLoop	Mr.Loop
+70:B3:D5:53:C0:00/36	Airthing	Airthings
+70:B3:D5:53:D0:00/36	Accel	Accel Corp
 70:B3:D5:54:20:00/36	RtdsTech	RTDS Technologies Inc.
 70:B3:D5:54:40:00/36	SiliconS	Silicon Safe Ltd
+70:B3:D5:54:60:00/36	Sensefar	Sensefarm AB
 70:B3:D5:54:70:00/36	CeLink	Ce Link Limited
 70:B3:D5:54:80:00/36	Digiverv	Digiverv Inc
 70:B3:D5:54:90:00/36	ProconAu	Procon automatic systems GmbH
+70:B3:D5:54:B0:00/36	BrakelsI	Brakels IT
 70:B3:D5:54:C0:00/36	HustyMSt	Husty M.Styczen J.Hupert Sp.J.
 70:B3:D5:54:D0:00/36	QingdaoH	Qingdao Haitian Weiye Automation Control System Co., Ltd
 70:B3:D5:54:E0:00/36	RflElect	RFL Electronics, Inc.
@@ -24228,6 +25069,7 @@
 70:B3:D5:55:00:00/36	MertenGm	Merten GmbH&CoKG
 70:B3:D5:55:10:00/36	Infrachi	infrachip
 70:B3:D5:55:40:00/36	Teletype	Teletypes Manufacturing Plant
+70:B3:D5:55:50:00/36	Softlab-	SoftLab-NSK
 70:B3:D5:55:70:00/36	Heitec	Heitec Ag
 70:B3:D5:55:90:00/36	EagleMou	Eagle Mountain Technology
 70:B3:D5:55:A0:00/36	Sontay	Sontay Ltd.
@@ -24238,9 +25080,11 @@
 70:B3:D5:56:30:00/36	Zhejiang	Zhejiang Hao Teng Electronic Technology Co., Ltd.
 70:B3:D5:56:40:00/36	Christma	christmann informationstechnik + medien GmbH & Co. KG
 70:B3:D5:56:60:00/36	DataInfo	Data Informs LLC
+70:B3:D5:56:A0:00/36	HarvardT	Harvard Technology Ltd
 70:B3:D5:56:B0:00/36	SEI	S.E.I. Co.,Ltd.
 70:B3:D5:57:00:00/36	BayernEn	Bayern Engineering GmbH & Co. KG
 70:B3:D5:57:20:00/36	Crde
+70:B3:D5:57:60:00/36	Shandong	Shandong Hospot IOT Technology Co.,Ltd.
 70:B3:D5:57:80:00/36	ImageTec	Image Tech Co.,Ltd
 70:B3:D5:57:90:00/36	ChelseaT	Chelsea Technologies Group Ltd
 70:B3:D5:57:B0:00/36	Elamakat	ELAMAKATO GmbH
@@ -24270,6 +25114,7 @@
 70:B3:D5:5A:00:00/36	AsconTec	Ascon Tecnologic S.r.l.
 70:B3:D5:5A:20:00/36	WallnerA	Wallner Automation GmbH
 70:B3:D5:5A:30:00/36	Ct	CT Company
+70:B3:D5:5A:50:00/36	Rehwork	Rehwork GmbH
 70:B3:D5:5A:80:00/36	Farmobil	Farmobile
 70:B3:D5:5A:90:00/36	BunkaShu	Bunka Shutter Co., Ltd.
 70:B3:D5:5A:A0:00/36	ChugokuE	Chugoku Electric Manufacturing Co.,Inc
@@ -24289,13 +25134,16 @@
 70:B3:D5:5C:A0:00/36	AcdElekr	ACD Elekronik GmbH
 70:B3:D5:5C:C0:00/36	AkseSrl	Akse srl
 70:B3:D5:5C:D0:00/36	MvtVideo	MVT Video Technologies R + H Maedler GbR
+70:B3:D5:5C:F0:00/36	ProelTsi	PROEL TSI s.r.l.
 70:B3:D5:5D:10:00/36	Software	Software Motor Corp
 70:B3:D5:5D:30:00/36	Supracon	Supracon AG
 70:B3:D5:5D:50:00/36	Ct	CT Company
 70:B3:D5:5D:60:00/36	BmtMesst	BMT Messtechnik Gmbh
 70:B3:D5:5D:80:00/36	LynxTech	LYNX Technik AG
+70:B3:D5:5D:A0:00/36	ValkWeld	Valk Welding B.V.
 70:B3:D5:5D:B0:00/36	MovicomL	Movicom LLC
 70:B3:D5:5D:C0:00/36	Factoryl	FactoryLab B.V.
+70:B3:D5:5D:E0:00/36	Hangzhou	Hangzhou AwareTec Technology Co., Ltd
 70:B3:D5:5E:00:00/36	HexagonM	Hexagon Metrology SAS
 70:B3:D5:5E:20:00/36	Grossenb	Grossenbacher Systeme AG
 70:B3:D5:5E:30:00/36	ImeconEn	Imecon Engineering SrL
@@ -24307,16 +25155,21 @@
 70:B3:D5:5E:A0:00/36	Kys	Kys,Inc
 70:B3:D5:5E:D0:00/36	EaElektr	EA Elektroautomatik GmbH & Co. KG
 70:B3:D5:5E:E0:00/36	Mikrotro	Mikrotron Mikrocomputer, Digital- und Analogtechnik GmbH
+70:B3:D5:5E:F0:00/36	StarInte	Star Systems International
 70:B3:D5:5F:00:00/36	Managee	managee GmbH & Co KG
 70:B3:D5:5F:10:00/36	FaterRas	Fater Rasa Noor
+70:B3:D5:5F:20:00/36	Invisibl	Invisible Systems Limited
 70:B3:D5:5F:30:00/36	Rtone
 70:B3:D5:5F:40:00/36	Fdstimin	FDSTiming
 70:B3:D5:5F:60:00/36	Freeflig	FreeFlight Systems
+70:B3:D5:5F:90:00/36	MbConnec	MB connect line GmbH Fernwartungssysteme
+70:B3:D5:5F:A0:00/36	TexCompu	Tex Computer Srl
 70:B3:D5:5F:B0:00/36	Teleplat	Teleplatforms
 70:B3:D5:5F:C0:00/36	Surtec
 70:B3:D5:5F:D0:00/36	WindarPh	Windar Photonics
 70:B3:D5:5F:F0:00/36	VaisalaO	Vaisala Oyj
 70:B3:D5:60:00:00/36	Stellwer	Stellwerk GmbH
+70:B3:D5:60:20:00/36	QuantumO	Quantum Opus, LLC
 70:B3:D5:60:50:00/36	AplexTec	Aplex Technology Inc.
 70:B3:D5:60:70:00/36	Ateme
 70:B3:D5:60:80:00/36	EiitSa	Eiit Sa
@@ -24329,6 +25182,7 @@
 70:B3:D5:60:F0:00/36	TanakaIn	Tanaka Information System, LLC.
 70:B3:D5:61:00:00/36	Polvisio	Polvision
 70:B3:D5:61:10:00/36	Avionica
+70:B3:D5:61:30:00/36	SuprockT	Suprock Technologies
 70:B3:D5:61:50:00/36	JscOtzvu	Jsc Otzvuk
 70:B3:D5:61:60:00/36	AxxessId	Axxess Identification Ltd
 70:B3:D5:61:80:00/36	MotecPty	Motec Pty Ltd
@@ -24336,14 +25190,17 @@
 70:B3:D5:61:B0:00/36	Nubewell	Nubewell Networks Pvt Ltd
 70:B3:D5:61:C0:00/36	EarthWor	Earth Works
 70:B3:D5:61:D0:00/36	TelonicB	Telonic Berkeley Inc
+70:B3:D5:61:E0:00/36	PkeElect	PKE Electronics AG
 70:B3:D5:61:F0:00/36	Labotect	Labotect Labor-Technik-Göttingen GmbH
+70:B3:D5:62:30:00/36	BeijingH	Beijing HuaLian Technology Co, Ltd.
 70:B3:D5:62:50:00/36	VxInstru	VX Instruments GmbH
 70:B3:D5:62:80:00/36	MectSRL	Mect S.R.L.
 70:B3:D5:62:B0:00/36	Silicann	Silicann Systems GmbH
 70:B3:D5:63:00:00/36	Lge
-70:B3:D5:63:10:00/36	Senso2me	SENSO2ME bvba
+70:B3:D5:63:10:00/36	Senso2me
 70:B3:D5:63:40:00/36	Idaqs	idaqs Co.,Ltd.
 70:B3:D5:63:50:00/36	CosylabD	Cosylab d.d.
+70:B3:D5:63:60:00/36	Globalco	Globalcom Engineering SPA
 70:B3:D5:63:70:00/36	Ineo-Sen	INEO-SENSE
 70:B3:D5:63:A0:00/36	DaveSrl	Dave Srl
 70:B3:D5:63:B0:00/36	LazerSaf	Lazer Safe Pty Ltd
@@ -24358,12 +25215,16 @@
 70:B3:D5:64:70:00/36	Kzta
 70:B3:D5:64:90:00/36	Swissled	swissled technologies AG
 70:B3:D5:64:A0:00/36	NetbricT	Netbric Technology Co.,Ltd.
+70:B3:D5:64:B0:00/36	Kalfire
 70:B3:D5:64:C0:00/36	AcemisFr	Acemis France
+70:B3:D5:64:E0:00/36	Bigstuff	BigStuff3, Inc.
 70:B3:D5:65:00:00/36	Gifas-El	GIFAS-ELECTRIC GmbH
+70:B3:D5:65:10:00/36	Roxford
 70:B3:D5:65:20:00/36	RobertBo	Robert Bosch, LLC
 70:B3:D5:65:30:00/36	LuxarTec	Luxar Tech, Inc.
 70:B3:D5:65:40:00/36	Emac	EMAC, Inc.
 70:B3:D5:65:50:00/36	AotSyste	AOT System GmbH
+70:B3:D5:65:60:00/36	Sonosoun	SonoSound ApS
 70:B3:D5:65:80:00/36	EmperorB	emperor brands
 70:B3:D5:65:90:00/36	E2gSrl	E2G srl
 70:B3:D5:65:A0:00/36	AplexTec	Aplex Technology Inc.
@@ -24375,16 +25236,23 @@
 70:B3:D5:66:40:00/36	SankyoIn	Sankyo Intec co.,ltd
 70:B3:D5:66:50:00/36	Certusus	CertUsus GmbH
 70:B3:D5:66:60:00/36	AplexTec	Aplex Technology Inc.
+70:B3:D5:66:A0:00/36	Private
 70:B3:D5:66:B0:00/36	Innitive	Innitive B.V.
 70:B3:D5:67:00:00/36	Particle	Particle sizing systems
 70:B3:D5:67:10:00/36	SeaShell	Sea Shell Corporation
 70:B3:D5:67:20:00/36	KleiberI	KLEIBER Infrared GmbH
+70:B3:D5:67:30:00/36	AcdElekr	ACD Elekronik GmbH
 70:B3:D5:67:40:00/36	Fortress	Fortress Cyber Security
+70:B3:D5:67:50:00/36	Alfamati	alfamation spa
+70:B3:D5:67:60:00/36	Samwooel	samwooeleco
 70:B3:D5:67:70:00/36	Fraunhof	Fraunhofer-Institut IIS
 70:B3:D5:67:80:00/36	DiniGrou	The Dini Group, La Jolla inc.
 70:B3:D5:67:90:00/36	Emac	EMAC, Inc.
 70:B3:D5:67:B0:00/36	Stesalit	Stesalit Systems Ltd
+70:B3:D5:67:D0:00/36	Acrodea	Acrodea, Inc.
+70:B3:D5:68:00:00/36	Basf	BASF Corporation
 70:B3:D5:68:20:00/36	Rosslare	Rosslare Enterprises Limited
+70:B3:D5:68:80:00/36	MgSRL	MG s.r.l.
 70:B3:D5:68:90:00/36	PrismaTe	Prisma Telecom Testing Srl
 70:B3:D5:68:C0:00/36	NdMeter	Nd Meter
 70:B3:D5:68:D0:00/36	Meta-Chr	Meta-chrom Co. Ltd.
@@ -24395,6 +25263,7 @@
 70:B3:D5:69:40:00/36	Movither	MoviTHERM
 70:B3:D5:69:60:00/36	OpenGrow	Open Grow
 70:B3:D5:69:70:00/36	AlazarTe	Alazar Technologies Inc.
+70:B3:D5:69:C0:00/36	Keepen
 70:B3:D5:69:E0:00/36	Ptype	PTYPE Co., LTD.
 70:B3:D5:69:F0:00/36	T+AElekt	T+A elektroakustik GmbH & Co.KG
 70:B3:D5:6A:00:00/36	ActiveRe	Active Research Limited
@@ -24411,17 +25280,23 @@
 70:B3:D5:6B:30:00/36	Duracomm	DuraComm Corporation
 70:B3:D5:6B:50:00/36	Art	Art Spa
 70:B3:D5:6B:60:00/36	Inradios	INRADIOS GmbH
+70:B3:D5:6B:70:00/36	Grossenb	Grossenbacher Systeme AG
+70:B3:D5:6B:80:00/36	Bt9
 70:B3:D5:6B:B0:00/36	Luceo
 70:B3:D5:6B:E0:00/36	VantageI	Vantage Integrated Security Solutions Pvt Ltd
 70:B3:D5:6B:F0:00/36	OttoBihl	Otto Bihler Maschinenfabrik GmbH & Co. KG
+70:B3:D5:6C:10:00/36	Labtroni	Labtronik s.r.l.
+70:B3:D5:6C:30:00/36	BeijingZ	Beijing Zgh Security Research Institute Co., Ltd
 70:B3:D5:6C:50:00/36	Cjsc«Rus	CJSC «Russian telecom equipment company» (CJSC RTEC)
 70:B3:D5:6C:70:00/36	BectonDi	Becton Dickinson
 70:B3:D5:6C:D0:00/36	Northbou	Northbound Networks Pty. Ltd.
 70:B3:D5:6C:F0:00/36	Private
 70:B3:D5:6D:00:00/36	CodeBlue	Code Blue Corporation
 70:B3:D5:6D:10:00/36	VisualEn	Visual Engineering Technologies Ltd
+70:B3:D5:6D:20:00/36	AhrensBi	Ahrens & Birner Company GmbH
 70:B3:D5:6D:30:00/36	Deuta-We	DEUTA-WERKE GmbH
 70:B3:D5:6D:60:00/36	Kmtronic	KMtronic Ltd.
+70:B3:D5:6D:80:00/36	Shanghai	Shanghai YuanAn Environmental Protection Technology Co.,Ltd
 70:B3:D5:6D:90:00/36	Vectare	VECTARE Inc
 70:B3:D5:6D:A0:00/36	Enovativ	Enovative Networks, Inc.
 70:B3:D5:6D:F0:00/36	MangoDsp	Mango DSP, Inc.
@@ -24441,17 +25316,24 @@
 70:B3:D5:6F:20:00/36	P&CMicro	P&C Micro's Pty Ltd
 70:B3:D5:6F:30:00/36	Iungo
 70:B3:D5:6F:60:00/36	AccoBran	Acco Brands Europe
+70:B3:D5:6F:70:00/36	EgiconSr	Egicon Srl
 70:B3:D5:6F:80:00/36	Senseon	SENSEON Corporation
 70:B3:D5:6F:90:00/36	Envitech	ENVItech s.r.o.
 70:B3:D5:6F:A0:00/36	Datafort	Dataforth Corporation
 70:B3:D5:6F:B0:00/36	Shachiha	Shachihata Inc.
+70:B3:D5:6F:C0:00/36	Mi	MI Inc.
 70:B3:D5:6F:D0:00/36	CoreAkıl	Core Akıllı Ev Sistemleri
 70:B3:D5:6F:F0:00/36	AkeoPlus	Akeo Plus
+70:B3:D5:70:00:00/36	Universi	University Of Groningen
 70:B3:D5:70:20:00/36	SensorHi	Sensor Highway Ltd
 70:B3:D5:70:30:00/36	Stromide	StromIdee GmbH
+70:B3:D5:70:40:00/36	MelecsEw	Melecs EWS GmbH
 70:B3:D5:70:50:00/36	DigitalM	Digital Matter Pty Ltd
+70:B3:D5:70:60:00/36	SmithMet	Smith Meter, Inc.
+70:B3:D5:70:70:00/36	KocoMoti	Koco Motion US LLC
 70:B3:D5:70:80:00/36	IbmResea	IBM Research GmbH
 70:B3:D5:70:90:00/36	Aml
+70:B3:D5:70:A0:00/36	PullnetT	PULLNET TECHNOLOGY, SA DE CV SSC1012302S73
 70:B3:D5:70:F0:00/36	AlionSci	Alion Science & Technology
 70:B3:D5:71:00:00/36	Guardian	Guardian Controls International Ltd
 70:B3:D5:71:10:00/36	X-LaserL	X-Laser LLC
@@ -24460,13 +25342,16 @@
 70:B3:D5:71:50:00/36	Riot
 70:B3:D5:71:60:00/36	LodeBv	Lode BV
 70:B3:D5:71:70:00/36	SecureSe	Secure Systems & Services
+70:B3:D5:71:80:00/36	PeekTraf	Peek Traffic
 70:B3:D5:71:B0:00/36	Elsys
 70:B3:D5:71:E0:00/36	MotecPty	Motec Pty Ltd
 70:B3:D5:72:00:00/36	Private
 70:B3:D5:72:10:00/36	ZoeMedic	Zoe Medical
+70:B3:D5:72:20:00/36	Uman
 70:B3:D5:72:30:00/36	LgElectr	LG Electronics
 70:B3:D5:72:40:00/36	QuanInte	Quan International Co., Ltd.
 70:B3:D5:72:70:00/36	LpTechno	LP Technologies Inc.
+70:B3:D5:72:80:00/36	BcdAudio	BCD Audio
 70:B3:D5:72:90:00/36	Emac	EMAC, Inc.
 70:B3:D5:72:C0:00/36	Nuri&GEn	NuRi&G Engineering co,.Ltd.
 70:B3:D5:72:D0:00/36	KronMedi	Kron Medidores
@@ -24478,6 +25363,8 @@
 70:B3:D5:73:40:00/36	MansionI	Mansion Industry Co., Ltd.
 70:B3:D5:73:50:00/36	SwissAud	Swiss Audio
 70:B3:D5:73:70:00/36	SdBiosen	SD Biosensor
+70:B3:D5:73:80:00/36	Private
+70:B3:D5:73:90:00/36	Zigencor	Zigencorp, Inc
 70:B3:D5:73:A0:00/36	Private
 70:B3:D5:73:B0:00/36	S-I-C
 70:B3:D5:73:D0:00/36	Netways	NETWAYS GmbH
@@ -24488,6 +25375,8 @@
 70:B3:D5:74:30:00/36	EaElektr	EA Elektroautomatik GmbH & Co. KG
 70:B3:D5:74:50:00/36	TmsiLlc	Tmsi Llc
 70:B3:D5:74:70:00/36	EvaAutom	Eva Automation
+70:B3:D5:74:80:00/36	Kdt
+70:B3:D5:74:90:00/36	GraniteR	Granite River Labs Inc
 70:B3:D5:74:A0:00/36	MettlerT	Mettler Toledo Hi Speed
 70:B3:D5:74:C0:00/36	KwantCon	Kwant Controls BV
 70:B3:D5:74:D0:00/36	SpeechTe	Speech Technology Center Limited
@@ -24497,21 +25386,28 @@
 70:B3:D5:75:10:00/36	Gnf
 70:B3:D5:75:30:00/36	HchKündi	HCH. Kündig & CIE. AG
 70:B3:D5:75:50:00/36	Landmark	LandmarkTech Systems Technology Co.,Ltd.
+70:B3:D5:75:80:00/36	Grossenb	Grossenbacher Systeme AG
+70:B3:D5:75:90:00/36	Aml
 70:B3:D5:75:A0:00/36	Standard	Standard Backhaul Communications
 70:B3:D5:75:B0:00/36	NetoolLl	Netool LLC
 70:B3:D5:75:C0:00/36	UpmTechn	UPM Technology, Inc
 70:B3:D5:75:D0:00/36	NanjingM	Nanjing Magewell Electronics Co., Ltd.
+70:B3:D5:75:E0:00/36	Cardinal	Cardinal Health
+70:B3:D5:75:F0:00/36	Vocality	Vocality international T/A Cubic
 70:B3:D5:76:00:00/36	Qualitte	Qualitteq Llc
 70:B3:D5:76:10:00/36	Critical	Critical Link LLC
 70:B3:D5:76:30:00/36	ATrapUsa	A Trap, USA
+70:B3:D5:76:40:00/36	SchmidEl	SCHMID electronic
 70:B3:D5:76:60:00/36	Tirasoft	Tirasoft Nederland
 70:B3:D5:76:70:00/36	Franklin	Franklin France
 70:B3:D5:76:80:00/36	KazanNet	Kazan Networks Corporation
 70:B3:D5:76:A0:00/36	Swiftnet	Swiftnet SOC Ltd
 70:B3:D5:76:B0:00/36	Empelor	EMPELOR GmbH
+70:B3:D5:76:C0:00/36	Aural	Aural Ltd
 70:B3:D5:76:D0:00/36	Trimble
 70:B3:D5:76:E0:00/36	GrupoEpe	Grupo Epelsa S.L.
 70:B3:D5:76:F0:00/36	Oti	Oti Ltd
+70:B3:D5:77:00:00/36	Strega
 70:B3:D5:77:10:00/36	ApatorMi	Apator Miitors ApS
 70:B3:D5:77:20:00/36	Enmodus
 70:B3:D5:77:30:00/36	RuggedSc	Rugged Science
@@ -24523,15 +25419,20 @@
 70:B3:D5:77:90:00/36	DrBridge	Dr.Bridge Aquatech
 70:B3:D5:77:B0:00/36	Aerovisi	AeroVision Avionics, Inc.
 70:B3:D5:77:C0:00/36	HustyMSt	HUSTY M.Styczen J.Hupert Sp.J.
+70:B3:D5:77:E0:00/36	BlueMarb	Blue Marble Communications, Inc.
 70:B3:D5:78:10:00/36	ProjectS	Project Service S.a.s.
 70:B3:D5:78:20:00/36	Thou&Tec	thou&tech
 70:B3:D5:78:40:00/36	Shenzhen	Shenzhen bayue software co. LTD
 70:B3:D5:78:50:00/36	Density	Density Inc.
 70:B3:D5:78:90:00/36	Semex-En	SEMEX-EngCon GmbH
+70:B3:D5:78:A0:00/36	HillsHea	Hills Health Solutions
 70:B3:D5:78:B0:00/36	JingtuPr	Jingtu Printing Systems Co., Ltd
 70:B3:D5:78:C0:00/36	Survalen	Survalent Technology Corporation
 70:B3:D5:78:E0:00/36	Effectas	effectas GmbH
+70:B3:D5:78:F0:00/36	Sofiha
+70:B3:D5:79:00:00/36	AviPty	AVI Pty Ltd
 70:B3:D5:79:10:00/36	RomteckA	Romteck Australia
+70:B3:D5:79:30:00/36	GastechA	Gastech Australia Pty Ltd
 70:B3:D5:79:40:00/36	ShadinAv	Shadin Avionics
 70:B3:D5:79:60:00/36	GamptMbh	GAMPT mbH
 70:B3:D5:79:90:00/36	VitecSys	Vitec System Engineering Inc.
@@ -24541,14 +25442,17 @@
 70:B3:D5:7A:00:00/36	Reactec	Reactec Ltd
 70:B3:D5:7A:10:00/36	Excelfor	Excelfore Corporation
 70:B3:D5:7A:20:00/36	AlphaEss	Alpha ESS Co., Ltd.
+70:B3:D5:7A:30:00/36	ImpulseA	Impulse Automation
 70:B3:D5:7A:40:00/36	PotterEl	Potter Electric Signal Co. LLC
+70:B3:D5:7A:50:00/36	TritonEl	Triton Electronics Ltd
 70:B3:D5:7A:60:00/36	Electrol	Electrolux
 70:B3:D5:7A:70:00/36	Symbicon	Symbicon Ltd
 70:B3:D5:7A:80:00/36	Dieentwi	dieEntwickler Elektronik GmbH
 70:B3:D5:7A:90:00/36	Adidas	adidas AG
 70:B3:D5:7A:A0:00/36	SadelSPA	Sadel S.p.A.
 70:B3:D5:7A:B0:00/36	Microgat	Microgate Srl
-70:B3:D5:7A:D0:00/36	Insitu	Insitu Inc
+70:B3:D5:7A:C0:00/36	VeritySt	Verity Studios AG
+70:B3:D5:7A:D0:00/36	Insitu	Insitu, Inc
 70:B3:D5:7A:E0:00/36	ExiFlowM	Exi Flow Measurement Ltd
 70:B3:D5:7A:F0:00/36	Hessware	Hessware GmbH
 70:B3:D5:7B:00:00/36	Medisafe	Medisafe International
@@ -24560,18 +25464,24 @@
 70:B3:D5:7B:80:00/36	Serenerg	SerEnergy A/S
 70:B3:D5:7B:90:00/36	QiagenIn	QIAGEN Instruments AG
 70:B3:D5:7B:F0:00/36	StoneThr	Stone Three
+70:B3:D5:7C:00:00/36	Torgovyy	Torgovyy Dom Tehnologiy Llc
 70:B3:D5:7C:10:00/36	DataScie	Data Sciences International
 70:B3:D5:7C:20:00/36	MorganSc	Morgan Schaffer Inc.
 70:B3:D5:7C:30:00/36	FleximSe	Flexim Security Oy
+70:B3:D5:7C:70:00/36	SiconSrl	Sicon srl
 70:B3:D5:7C:80:00/36	Crde
 70:B3:D5:7C:90:00/36	CouncilR	Council Rock
 70:B3:D5:7C:D0:00/36	Molekule	Molekuler Goruntuleme A.S.
 70:B3:D5:7C:E0:00/36	AplexTec	Aplex Technology Inc.
 70:B3:D5:7C:F0:00/36	OrcaTech	ORCA Technologies, LLC
+70:B3:D5:7D:00:00/36	Cubitech
 70:B3:D5:7D:10:00/36	Schneide	Schneider Electric Motion USA
 70:B3:D5:7D:20:00/36	SdkKrist	SDK Kristall
 70:B3:D5:7D:50:00/36	SicsSwed	SICS Swedish ICT
+70:B3:D5:7D:60:00/36	Yukilab
+70:B3:D5:7D:70:00/36	Gedomo	Gedomo GmbH
 70:B3:D5:7D:90:00/36	AtomGike	ATOM GIKEN Co.,Ltd.
+70:B3:D5:7D:C0:00/36	Software	Software Systems Plus
 70:B3:D5:7D:D0:00/36	ExcelMed	Excel Medical Electronics LLC
 70:B3:D5:7D:E0:00/36	Telaeris	Telaeris, Inc.
 70:B3:D5:7D:F0:00/36	Rdt	RDT Ltd
@@ -24588,14 +25498,16 @@
 70:B3:D5:7E:B0:00/36	XeroxInt	Xerox International Partners
 70:B3:D5:7E:C0:00/36	Gridsmar	GRIDSMART Technologies
 70:B3:D5:7E:D0:00/36	ThingsNe	The Things Network Foundation
+70:B3:D5:7E:E0:00/36	Adveez
 70:B3:D5:7E:F0:00/36	Cravis	Cravis Co., Limited
 70:B3:D5:7F:10:00/36	Aerovisi	AeroVision Avionics, Inc.
 70:B3:D5:7F:20:00/36	Tci
 70:B3:D5:7F:30:00/36	Shenzhen	Shenzhen Virtual Clusters Information Technology Co.,Ltd.
 70:B3:D5:7F:40:00/36	KstTechn	KST technology
+70:B3:D5:7F:50:00/36	Incusens	Incusense
 70:B3:D5:7F:70:00/36	JascoApp	JASCO Applied Sciences Canada Ltd
 70:B3:D5:7F:80:00/36	SolveraL	Solvera Lynx d.d.
-70:B3:D5:7F:90:00/36	Css	CSS Inc.
+70:B3:D5:7F:90:00/36	Communic	Communication Systems Solutions
 70:B3:D5:7F:B0:00/36	DbBroadc	db Broadcast Products Ltd
 70:B3:D5:7F:D0:00/36	SysTecEl	SYS TEC electronic GmbH
 70:B3:D5:7F:E0:00/36	RchItali	RCH Italia SpA
@@ -24607,6 +25519,7 @@
 70:B3:D5:80:B0:00/36	FischerB	Fischer Block, Inc.
 70:B3:D5:80:D0:00/36	DataPhys	Data Physics Corporation
 70:B3:D5:80:F0:00/36	Quickwar	Quickware Eng & Des LLC
+70:B3:D5:81:00:00/36	Advice
 70:B3:D5:81:10:00/36	Cjsc«Int	CJSC «INTERSET»
 70:B3:D5:81:30:00/36	WavemedS	Wavemed srl
 70:B3:D5:81:40:00/36	Ingenieu	Ingenieurbuero SOMTRONIK
@@ -24625,10 +25538,12 @@
 70:B3:D5:82:70:00/36	Metromat	Metromatics Pty Ltd
 70:B3:D5:82:80:00/36	Xacti	Xacti Corporation
 70:B3:D5:82:C0:00/36	Nels	NELS Ltd.
+70:B3:D5:82:D0:00/36	Elektron	Elektronik Art S.C.
 70:B3:D5:82:E0:00/36	Playaliv	PlayAlive A/S
 70:B3:D5:83:10:00/36	ArnouseD	Arnouse Digital Devices Corp
 70:B3:D5:83:30:00/36	AlpiqInt	Alpiq InTec Management AG
 70:B3:D5:83:50:00/36	CommboxP	CommBox P/L
+70:B3:D5:83:70:00/36	Hides	HiDes, Inc.
 70:B3:D5:83:80:00/36	Tofino
 70:B3:D5:83:90:00/36	Rockwell	Rockwell Collins Canada
 70:B3:D5:83:B0:00/36	Telefoni	Telefonix Incorporated
@@ -24640,8 +25555,10 @@
 70:B3:D5:84:40:00/36	SansfilT	SANSFIL Technologies
 70:B3:D5:84:50:00/36	Harborsi	Harborside Technology
 70:B3:D5:84:70:00/36	Ai-Lynx
+70:B3:D5:84:80:00/36	Aldridge	Aldridge Electrical Industries
 70:B3:D5:84:90:00/36	Rf-Tuote	RF-Tuote Oy
 70:B3:D5:84:A0:00/36	MogLabor	MOG Laboratories Pty Ltd
+70:B3:D5:84:C0:00/36	Corekine	CoreKinect
 70:B3:D5:84:D0:00/36	QuantumD	Quantum Design Inc.
 70:B3:D5:84:E0:00/36	Chromalo	Chromalox, Inc.
 70:B3:D5:85:00:00/36	Reo	Reo Ag
@@ -24649,13 +25566,17 @@
 70:B3:D5:85:30:00/36	HghSyste	Hgh Systemes Infrarouges
 70:B3:D5:85:40:00/36	AdimecAd	Adimec Advanced Image Systems
 70:B3:D5:85:50:00/36	Crde
+70:B3:D5:85:70:00/36	RchItali	RCH Italia SpA
 70:B3:D5:85:A0:00/36	Brushies
 70:B3:D5:85:B0:00/36	Tsubakim	Tsubakimoto Chain Co.
 70:B3:D5:85:C0:00/36	RobotPub	Robot Pub Group
 70:B3:D5:85:D0:00/36	Athreya	Athreya Inc
 70:B3:D5:85:E0:00/36	XlogicSr	XLOGIC srl
+70:B3:D5:85:F0:00/36	YuyamaMf	YUYAMA MFG Co.,Ltd
 70:B3:D5:86:10:00/36	KstTechn	KST technology
+70:B3:D5:86:20:00/36	Tripleor	TripleOre
 70:B3:D5:86:60:00/36	MepsReal	MEPS Realtime
+70:B3:D5:86:80:00/36	U-JinMes	U-JIN Mesco Co., Ltd.
 70:B3:D5:86:C0:00/36	Eeas	eeas gmbh
 70:B3:D5:86:D0:00/36	CensusDi	Census Digital Incorporated
 70:B3:D5:86:E0:00/36	Profcon	Profcon AB
@@ -24663,11 +25584,15 @@
 70:B3:D5:87:10:00/36	OsoTechn	Oso Technologies
 70:B3:D5:87:30:00/36	VishayNo	Vishay Nobel AB
 70:B3:D5:87:50:00/36	PeekTraf	Peek Traffic
+70:B3:D5:87:60:00/36	Ionetech
 70:B3:D5:87:70:00/36	PolynetT	Polynet Telecommunications Consulting and Contractor Ltd.
 70:B3:D5:87:80:00/36	PackageG	Package Guard, Inc
 70:B3:D5:87:90:00/36	Zigpos	ZIGPOS GmbH
 70:B3:D5:87:B0:00/36	LiquidIn	Liquid Instruments Pty Ltd
+70:B3:D5:87:C0:00/36	Nautel	Nautel Limited
+70:B3:D5:87:D0:00/36	Invixium	Invixium Access Inc.
 70:B3:D5:87:E0:00/36	Septentr	Septentrio NV
+70:B3:D5:87:F0:00/36	NacPlann	NAC Planning Co., Ltd.
 70:B3:D5:88:00:00/36	SkopeiBV	Skopei B.V.
 70:B3:D5:88:10:00/36	TattileS	Tattile Srl
 70:B3:D5:88:20:00/36	SimonTec	Simon Tech, S.L.
@@ -24678,6 +25603,7 @@
 70:B3:D5:88:B0:00/36	WuhanEas	WUHAN EASYLINKIN TECHNOLOGY co.,LTD
 70:B3:D5:88:D0:00/36	LgElectr	LG Electronics
 70:B3:D5:88:F0:00/36	QuaestaI	Quaesta Instruments, LLC
+70:B3:D5:89:00:00/36	EidosSRL	EIDOS s.r.l.
 70:B3:D5:89:10:00/36	Neocontr	neocontrol soluções em automação
 70:B3:D5:89:20:00/36	Abb
 70:B3:D5:89:30:00/36	Cubitech
@@ -24687,7 +25613,9 @@
 70:B3:D5:89:70:00/36	EfgCzSpo	EFG CZ spol. s r.o.
 70:B3:D5:89:B0:00/36	Controlw	ControlWorks, Inc.
 70:B3:D5:8A:00:00/36	DmRadioc	Dm Radiocom
+70:B3:D5:8A:20:00/36	WinnersD	Winners Digital Corporation
 70:B3:D5:8A:40:00/36	PhytonMi	Phyton, Inc. Microsystems and Development Tools
+70:B3:D5:8A:50:00/36	KstTechn	KST technology
 70:B3:D5:8A:60:00/36	Crde
 70:B3:D5:8A:80:00/36	MegatecE	megatec electronic GmbH
 70:B3:D5:8A:B0:00/36	Emac	EMAC, Inc.
@@ -24697,24 +25625,33 @@
 70:B3:D5:8B:10:00/36	M-TechIn	M-Tech Innovations Limited
 70:B3:D5:8B:20:00/36	NpfModem	NPF Modem, LLC
 70:B3:D5:8B:30:00/36	FireflyR	Firefly RFID Solutions
+70:B3:D5:8B:40:00/36	Scenario	Scenario Automation
+70:B3:D5:8B:70:00/36	ContecDt	Contec DTx
 70:B3:D5:8B:90:00/36	Toptech	Toptech Systems, Inc.
 70:B3:D5:8B:E0:00/36	Connoise	Connoiseur Electronics Private Limited
 70:B3:D5:8C:10:00/36	Rievtech	Rievtech Electronic Co.,Ltd
 70:B3:D5:8C:20:00/36	F-Domain	F-domain corporation
 70:B3:D5:8C:30:00/36	Wyebot	Wyebot, Inc.
 70:B3:D5:8C:50:00/36	Hmicro	HMicro Inc
+70:B3:D5:8C:60:00/36	Onosokki	Onosokki Co.,Ltd
 70:B3:D5:8C:80:00/36	Kronotec	Kronotech Srl
 70:B3:D5:8C:A0:00/36	AlliedDa	Allied Data Systems
 70:B3:D5:8C:B0:00/36	Welt	WELT Corporation
 70:B3:D5:8C:E0:00/36	Cores	CORES Corporation
 70:B3:D5:8C:F0:00/36	Dainichi	Dainichi Denshi　Co.,LTD
+70:B3:D5:8D:00:00/36	RaftTech	Raft Technologies
 70:B3:D5:8D:30:00/36	Performa	Performance Controls, Inc.
+70:B3:D5:8D:70:00/36	Schneide	Schneider Electric Motion USA
 70:B3:D5:8D:80:00/36	Vng	VNG Corporation
+70:B3:D5:8D:90:00/36	MbConnec	MB connect line GmbH Fernwartungssysteme
+70:B3:D5:8D:A0:00/36	Microele	MicroElectronics System Co.Ltd
 70:B3:D5:8D:B0:00/36	KratosAn	Kratos Analytical Ltd
 70:B3:D5:8D:C0:00/36	NiveoInt	Niveo International BV
 70:B3:D5:8E:00:00/36	SoudaxEq	Soudax Equipements
 70:B3:D5:8E:10:00/36	Woka-Ele	WoKa-Elektronik GmbH
+70:B3:D5:8E:30:00/36	DorletSa	Dorlet Sau
 70:B3:D5:8E:40:00/36	AplexTec	Aplex Technology Inc.
+70:B3:D5:8E:B0:00/36	ProconEl	Procon Electronics Pty Ltd
 70:B3:D5:8E:C0:00/36	RudyTell	Rudy Tellert
 70:B3:D5:8E:E0:00/36	NetworkA	Network Additions
 70:B3:D5:8E:F0:00/36	BeeperCo	Beeper Communications Ltd.
@@ -24725,16 +25662,20 @@
 70:B3:D5:8F:60:00/36	Dofuntec	Dofuntech Co.,LTD.
 70:B3:D5:8F:70:00/36	IESevkoA	I.E. Sevko A.V.
 70:B3:D5:8F:80:00/36	Wi6labs
+70:B3:D5:8F:A0:00/36	DeaSyste	Dea System Spa
 70:B3:D5:8F:F0:00/36	Imst	IMST GmbH
 70:B3:D5:90:10:00/36	Ats-Conv	ATS-CONVERS
 70:B3:D5:90:20:00/36	Unlimite	Unlimiterhear co.,ltd. taiwan branch
 70:B3:D5:90:30:00/36	Cymtec	Cymtec Ltd
+70:B3:D5:90:40:00/36	PhbEletr	PHB Eletronica Ltda.
 70:B3:D5:90:60:00/36	AplexTec	Aplex Technology Inc.
+70:B3:D5:90:70:00/36	NingboCr	Ningbo Crrc Times Transducer Technology Co., Ltd
 70:B3:D5:90:80:00/36	Accusoni	Accusonic
 70:B3:D5:90:A0:00/36	Hangzhou	Hangzhou SunTown Intelligent Science & Technology Co.,Ltd.
 70:B3:D5:90:B0:00/36	MatrixSw	Matrix Switch Corporation
 70:B3:D5:90:C0:00/36	Antek	ANTEK GmbH
 70:B3:D5:90:D0:00/36	Modtroni	Modtronix Engineering
+70:B3:D5:90:E0:00/36	Private
 70:B3:D5:90:F0:00/36	DtronCom	DTRON Communications (Pty) Ltd
 70:B3:D5:91:00:00/36	Eginity	Eginity, Inc.
 70:B3:D5:91:10:00/36	Equatel
@@ -24746,6 +25687,7 @@
 70:B3:D5:91:B0:00/36	Dolotron	Dolotron d.o.o.
 70:B3:D5:91:E0:00/36	Creotech	Creotech Instruments S.A.
 70:B3:D5:91:F0:00/36	JscInfor	JSC InformInvestGroup
+70:B3:D5:92:00:00/36	Slat
 70:B3:D5:92:30:00/36	EumigInd	eumig industrie-tv GmbH
 70:B3:D5:92:40:00/36	Meridian	Meridian Technologies Inc
 70:B3:D5:92:50:00/36	Diamante	Diamante Lighting Srl
@@ -24753,23 +25695,29 @@
 70:B3:D5:92:90:00/36	Outsys
 70:B3:D5:92:A0:00/36	Miravue
 70:B3:D5:92:B0:00/36	EntecEle	ENTEC Electric & Electronic Co., LTD.
+70:B3:D5:92:E0:00/36	MedicalM	Medical Monitoring Center OOD
+70:B3:D5:92:F0:00/36	Sifive
 70:B3:D5:93:00:00/36	Institut	The Institute of Mine Seismology
 70:B3:D5:93:20:00/36	Rohde&Sc	Rohde&Schwarz Topex SA
 70:B3:D5:93:30:00/36	SarlS@Ti	SARL S@TIS
 70:B3:D5:93:40:00/36	RbsNetko	RBS Netkom GmbH
 70:B3:D5:93:50:00/36	SensorDe	Sensor Developments
 70:B3:D5:93:60:00/36	FaroTech	Faro Technologies, Inc.
+70:B3:D5:93:70:00/36	TattileS	Tattile Srl
 70:B3:D5:93:80:00/36	JetiTech	JETI Technische Instrumente GmbH
 70:B3:D5:93:90:00/36	Invertek	Invertek Drives Ltd
+70:B3:D5:93:E0:00/36	WithInte	Systems With Intelligence Inc.
 70:B3:D5:94:00:00/36	Paradigm	Paradigm Technology Services B.V.
 70:B3:D5:94:10:00/36	Triax	Triax A/S
 70:B3:D5:94:20:00/36	TruteqDe	TruTeq Devices (Pty) Ltd
 70:B3:D5:94:30:00/36	AbbottMe	Abbott Medical Optics Inc.
 70:B3:D5:94:50:00/36	Symbotic	Symboticware Incorporated
 70:B3:D5:94:70:00/36	Checkbil	Checkbill Co,Ltd.
+70:B3:D5:94:80:00/36	VisionAu	VISION SYSTEMS AURTOMOTIVE (SAFETY TECH)
 70:B3:D5:94:A0:00/36	Shenzhen	Shenzhen Wisewing Internet Technology Co.,Ltd
 70:B3:D5:94:D0:00/36	SeasonDe	Season Design Technology
 70:B3:D5:94:F0:00/36	MartNetw	Mart Network Solutions Ltd
+70:B3:D5:95:00:00/36	CmtMedic	CMT Medical technologies
 70:B3:D5:95:20:00/36	Requea
 70:B3:D5:95:30:00/36	Spectrum	Spectrum Techniques, LLC
 70:B3:D5:95:40:00/36	DotSyste	Dot System S.r.l.
@@ -24782,8 +25730,12 @@
 70:B3:D5:95:B0:00/36	SrsGroup	SRS Group s.r.o.
 70:B3:D5:95:C0:00/36	WilsonEl	Wilson Electronics
 70:B3:D5:95:E0:00/36	BlocksiL	Blocksi Llc
+70:B3:D5:96:00:00/36	HorizonT	Horizon Telecom
+70:B3:D5:96:10:00/36	TaskSist	Task Sistemas De Computacao Ltda
 70:B3:D5:96:30:00/36	Triax	Triax A/S
+70:B3:D5:96:60:00/36	DaTomato	dA Tomato Limited
 70:B3:D5:96:70:00/36	TattileS	Tattile Srl
+70:B3:D5:96:80:00/36	LgmIngén	LGM Ingénierie
 70:B3:D5:96:90:00/36	EmtelSys	Emtel System Sp. z o.o.
 70:B3:D5:96:B0:00/36	Focal-Jm	FOCAL-JMLab
 70:B3:D5:96:D0:00/36	MsbElekt	MSB Elektronik und Gerätebau GmbH
@@ -24792,15 +25744,23 @@
 70:B3:D5:97:40:00/36	JirehInd	Jireh Industries Ltd.
 70:B3:D5:97:50:00/36	CoesterA	Coester Automação Ltda
 70:B3:D5:97:60:00/36	AtonarpM	Atonarp Micro-Systems India Pvt. Ltd.
+70:B3:D5:97:70:00/36	EngageTe	Engage Technologies
+70:B3:D5:97:80:00/36	SatixfyI	Satixfy Israel Ltd.
+70:B3:D5:97:A0:00/36	Orion	Orion Corporation
 70:B3:D5:97:C0:00/36	Nu-TekPo	Nu-Tek Power Controls and Automation
 70:B3:D5:97:F0:00/36	Bistos	BISTOS.,Co.,Ltd
+70:B3:D5:98:10:00/36	ZamirRec	Zamir Recognition Systems Ltd.
+70:B3:D5:98:40:00/36	SanminaI	Sanmina Israel
+70:B3:D5:98:50:00/36	BurkTech	Burk Technology
 70:B3:D5:98:60:00/36	AplexTec	Aplex Technology Inc.
 70:B3:D5:98:70:00/36	Axis	Axis Corporation
 70:B3:D5:98:90:00/36	Dcns
+70:B3:D5:98:B0:00/36	RichardP	Richard Paul Russell Ltd
 70:B3:D5:98:C0:00/36	Universi	University of Wisconsin Madison - Department of High Energy Physics
 70:B3:D5:98:E0:00/36	AutocomD	Autocom Diagnostic Partner AB
 70:B3:D5:98:F0:00/36	Spacefli	Spaceflight Industries
 70:B3:D5:99:10:00/36	Javaspar	Javasparrow Inc.
+70:B3:D5:99:30:00/36	Iothings
 70:B3:D5:99:40:00/36	KeffNetw	KeFF Networks
 70:B3:D5:99:50:00/36	Laytec	LayTec AG
 70:B3:D5:99:60:00/36	Xpertsea	XpertSea Solutions inc.
@@ -24813,11 +25773,14 @@
 70:B3:D5:9A:00:00/36	Eldes
 70:B3:D5:9A:10:00/36	ItsIndus	ITS Industrial Turbine Services GmbH
 70:B3:D5:9A:70:00/36	Honeywel	Honeywell
+70:B3:D5:9A:A0:00/36	TecsysDo	Tecsys do Brasil Industrial Ltda
+70:B3:D5:9A:B0:00/36	GroupePa	Groupe Paris-Turf
 70:B3:D5:9A:D0:00/36	FortunaI	Fortuna Impex Pvt ltd
 70:B3:D5:9A:E0:00/36	Volansys	Volansys technologies pvt ltd
 70:B3:D5:9B:10:00/36	AplexTec	Aplex Technology Inc.
 70:B3:D5:9B:20:00/36	Continen	CONTINENT, Ltd
 70:B3:D5:9B:30:00/36	K&JSchmi	K&J Schmittschneider AG
+70:B3:D5:9B:40:00/36	Myoungsu	MyoungSung System
 70:B3:D5:9B:50:00/36	Ideetron	Ideetron b.v.
 70:B3:D5:9B:60:00/36	Intercom	Intercomp S.p.A.
 70:B3:D5:9B:80:00/36	Loma	Loma Systems
@@ -24833,6 +25796,7 @@
 70:B3:D5:9C:B0:00/36	Alligato	Alligator Communications
 70:B3:D5:9C:E0:00/36	Terragen	Terragene S.A
 70:B3:D5:9D:00:00/36	Rj45Tech	RJ45 Technologies
+70:B3:D5:9D:10:00/36	Os42UgHa	OS42 UG (haftungsbeschraenkt)
 70:B3:D5:9D:20:00/36	AcsMotio	Acs Motion Control
 70:B3:D5:9D:30:00/36	Communic	Communication Technology Ltd.
 70:B3:D5:9D:40:00/36	TransasM	Transas Marine Limited
@@ -24843,8 +25807,10 @@
 70:B3:D5:9D:C0:00/36	Shanghai	Shanghai Daorech Industry Developmnet Co.,Ltd
 70:B3:D5:9D:D0:00/36	Humaneye	HumanEyes Technologies Ltd.
 70:B3:D5:9D:E0:00/36	System11	System 11 Sp. z o.o.
+70:B3:D5:9D:F0:00/36	DobeComp	DOBE Computing
 70:B3:D5:9E:00:00/36	EsIndust	ES Industrial Systems Co., Ltd.
 70:B3:D5:9E:20:00/36	OfilUsa	Ofil USA
+70:B3:D5:9E:30:00/36	LgElectr	LG Electronics
 70:B3:D5:9E:60:00/36	BlocksiL	Blocksi Llc
 70:B3:D5:9E:70:00/36	XiamenMa	Xiamen Maxincom Technologies Co., Ltd.
 70:B3:D5:9E:B0:00/36	PrestonI	Preston Industries dba PolyScience
@@ -24859,6 +25825,7 @@
 70:B3:D5:9F:50:00/36	VickersE	Vickers Electronics Ltd
 70:B3:D5:9F:60:00/36	Edgeware	Edgeware AB
 70:B3:D5:9F:80:00/36	Asymmetr	Asymmetric Technologies
+70:B3:D5:9F:90:00/36	FluidCom	Fluid Components Intl
 70:B3:D5:9F:A0:00/36	IdeasSrl	Ideas srl
 70:B3:D5:9F:B0:00/36	UnicomGl	Unicom Global, Inc.
 70:B3:D5:A0:00:00/36	AtxNetwo	Atx Networks Ltd
@@ -24869,11 +25836,15 @@
 70:B3:D5:A0:60:00/36	KopisMob	Kopis Mobile LLC
 70:B3:D5:A0:70:00/36	IotrekTe	IoTrek Technology Private Limited
 70:B3:D5:A0:80:00/36	Biobusin	BioBusiness
+70:B3:D5:A0:A0:00/36	Capsys
 70:B3:D5:A0:B0:00/36	Ambihome	ambiHome GmbH
+70:B3:D5:A0:D0:00/36	Globalco	Globalcom Engineering SPA
 70:B3:D5:A0:E0:00/36	Vetaphon	Vetaphone A/S
 70:B3:D5:A1:00:00/36	W-Tec	w-tec AG
 70:B3:D5:A1:20:00/36	QuercusT	Quercus Technologies, S.L.
+70:B3:D5:A1:30:00/36	Uplevel	Uplevel Systems Inc
 70:B3:D5:A1:50:00/36	Intercor	Intercore GmbH
+70:B3:D5:A1:70:00/36	Tunstall	Tunstall A/S
 70:B3:D5:A1:80:00/36	Embedded	Embedded Systems Lukasz Panasiuk
 70:B3:D5:A1:90:00/36	Qualitro	Qualitronix Madrass Pvt Ltd
 70:B3:D5:A1:B0:00/36	PotterEl	Potter Electric Signal Co. LLC
@@ -24896,6 +25867,7 @@
 70:B3:D5:A3:30:00/36	Tiama
 70:B3:D5:A3:50:00/36	SiconSrl	Sicon srl
 70:B3:D5:A3:60:00/36	BeijingD	Beijing DamingWuzhou Science&Technology Co., Ltd.
+70:B3:D5:A3:70:00/36	Mitsubis	Mitsubishi Heavy Industries Thermal Systems, Ltd.
 70:B3:D5:A3:A0:00/36	Epsoft	EPSOFT Co., Ltd
 70:B3:D5:A3:B0:00/36	GraceDes	Grace Design/Lunatec LLC
 70:B3:D5:A3:C0:00/36	WaveMusi	Wave Music Ltd
@@ -24903,6 +25875,7 @@
 70:B3:D5:A4:00:00/36	StrackLi	STRACK LIFT AUTOMATION GmbH
 70:B3:D5:A4:30:00/36	Oledcomm
 70:B3:D5:A4:40:00/36	Fsr	FSR Inc
+70:B3:D5:A4:60:00/36	Foxconn4	Foxconn 4Tech
 70:B3:D5:A4:70:00/36	Kanoa	Kanoa Inc
 70:B3:D5:A4:80:00/36	AppliedS	Applied Satellite Engineering
 70:B3:D5:A4:A0:00/36	BeijingA	Beijing Arrow SEED Technology Co,.Ltd.
@@ -24913,6 +25886,7 @@
 70:B3:D5:A5:00:00/36	Lecip	Lecip Corporation
 70:B3:D5:A5:10:00/36	RfCode	RF Code
 70:B3:D5:A5:30:00/36	GsIndust	GS Industrie-Elektronik GmbH
+70:B3:D5:A5:40:00/36	Provedo
 70:B3:D5:A5:50:00/36	EmbestTe	Embest Technology Co., Ltd
 70:B3:D5:A5:60:00/36	DorletSa	Dorlet Sau
 70:B3:D5:A5:70:00/36	Pcsc
@@ -24922,36 +25896,49 @@
 70:B3:D5:A5:B0:00/36	ChristEl	Christ Elektronik GmbH
 70:B3:D5:A5:C0:00/36	Molekule
 70:B3:D5:A5:E0:00/36	Conectai	ConectaIP Tecnologia S.L.
+70:B3:D5:A5:F0:00/36	Daatrics	Daatrics LTD
 70:B3:D5:A6:20:00/36	Environe	Environexus
+70:B3:D5:A6:40:00/36	Newshine
 70:B3:D5:A6:60:00/36	TrapezeS	Trapeze Software Group Inc
 70:B3:D5:A6:90:00/36	Leviatha	Leviathan Solutions Ltd.
 70:B3:D5:A6:D0:00/36	MetekMet	Metek Meteorologische Messtechnik GmbH
 70:B3:D5:A6:E0:00/36	JscElect	JSC Electrical Equipment Factory
 70:B3:D5:A6:F0:00/36	8cups
+70:B3:D5:A7:10:00/36	SamwellI	Samwell International Inc
 70:B3:D5:A7:20:00/36	Business	Business Marketers Group, Inc.
 70:B3:D5:A7:30:00/36	Mobiprom	MobiPromo
+70:B3:D5:A7:60:00/36	PietroFi	Pietro Fiorentini
 70:B3:D5:A7:80:00/36	Bionics	Bionics co.,ltd.
 70:B3:D5:A7:A0:00/36	FluidMan	Fluid Management Technology
 70:B3:D5:A7:C0:00/36	Transele	Transelektronik Messgeräte GmbH
 70:B3:D5:A7:E0:00/36	QuiccoSo	QUICCO SOUND Corporation
 70:B3:D5:A8:10:00/36	SiendaNe	Sienda New Media Technologies GmbH
+70:B3:D5:A8:20:00/36	Telefran	Telefrank GmbH
 70:B3:D5:A8:50:00/36	ExceetEl	exceet electronics GesmbH
+70:B3:D5:A8:60:00/36	Divigrap	Divigraph (Pty) LTD
+70:B3:D5:A8:70:00/36	TornadoM	Tornado Modular Systems
 70:B3:D5:A8:80:00/36	Shangdon	Shangdong Bosure Automation Technology Ltd
 70:B3:D5:A8:90:00/36	GbsCommu	Gbs Communications, Llc
 70:B3:D5:A8:B0:00/36	GiantPow	Giant Power Technology Biomedical Corporation
+70:B3:D5:A8:D0:00/36	CodeBlue	Code Blue Corporation
 70:B3:D5:A8:E0:00/36	OmeshCit	Omesh City Group
+70:B3:D5:A9:00:00/36	EraAS	ERA a.s.
 70:B3:D5:A9:10:00/36	IdealInd	IDEAL INDUSTRIES Ltd t/a Casella
 70:B3:D5:A9:20:00/36	Grossenb	Grossenbacher Systeme AG
 70:B3:D5:A9:30:00/36	MesCommu	Mes Communication Co., Ltd
+70:B3:D5:A9:40:00/36	EtaTechn	ETA Technology Pvt Ltd
 70:B3:D5:A9:50:00/36	Deuta-We	DEUTA-WERKE GmbH
 70:B3:D5:A9:60:00/36	ÖstlingM	Östling Marking Systems GmbH
 70:B3:D5:A9:70:00/36	Bizwerks	Bizwerks, LLC
 70:B3:D5:A9:90:00/36	Bandelin	Bandelin electronic GmbH & Co. KG
 70:B3:D5:A9:A0:00/36	Amphenol	Amphenol Advanced Sensors
+70:B3:D5:A9:C0:00/36	VeoTechn	Veo Technologies
 70:B3:D5:A9:D0:00/36	VitecMul	Vitec Multimedia
+70:B3:D5:A9:E0:00/36	ArgonSt	Argon ST
 70:B3:D5:A9:F0:00/36	Private
 70:B3:D5:AA:00:00/36	SimpleWo	Simple Works, Inc.
 70:B3:D5:AA:10:00/36	Shenzhen	Shenzhen Weema TV Technology Co.,Ltd.
+70:B3:D5:AA:20:00/36	EumigInd	eumig industrie-TV GmbH.
 70:B3:D5:AA:30:00/36	LineageP	Lineage Power Pvt Ltd.,
 70:B3:D5:AA:40:00/36	PullnetT	Pullnet Technology,S.L.
 70:B3:D5:AA:60:00/36	Proximus
@@ -24961,7 +25948,9 @@
 70:B3:D5:AA:C0:00/36	Sensotec	SensoTec GmbH
 70:B3:D5:AA:D0:00/36	Bartec	Bartec GmbH
 70:B3:D5:AA:E0:00/36	NuvizOy	Nuviz Oy
+70:B3:D5:AA:F0:00/36	ExiFlowM	Exi Flow Measurement Ltd
 70:B3:D5:AB:00:00/36	OsrR&DIs	OSR R&D ISRAEL LTD
+70:B3:D5:AB:30:00/36	Micas	Micas Ag
 70:B3:D5:AB:40:00/36	SysTecEl	SYS TEC electronic GmbH
 70:B3:D5:AB:50:00/36	Broadsof	BroadSoft Inc
 70:B3:D5:AB:70:00/36	Siglead	Siglead Inc
@@ -24973,18 +25962,23 @@
 70:B3:D5:AB:F0:00/36	AgrInter	AGR International
 70:B3:D5:AC:10:00/36	AemSinga	AEM Singapore Pte. Ltd.
 70:B3:D5:AC:30:00/36	Novoptel	Novoptel GmbH
+70:B3:D5:AC:40:00/36	LexiDevi	Lexi Devices, Inc.
 70:B3:D5:AC:50:00/36	AtomGike	ATOM GIKEN Co.,Ltd.
 70:B3:D5:AC:60:00/36	Smtc	SMTC Corporation
 70:B3:D5:AC:70:00/36	Vivamos
 70:B3:D5:AC:80:00/36	Heartlan	Heartland.Data Inc.
 70:B3:D5:AC:90:00/36	TrinityS	Trinity Solutions LLC
+70:B3:D5:AC:B0:00/36	TattileS	Tattile Srl
 70:B3:D5:AC:D0:00/36	Crde
+70:B3:D5:AC:F0:00/36	ApgCashD	APG Cash Drawer, LLC
 70:B3:D5:AD:10:00/36	SensileT	Sensile Technologies SA
 70:B3:D5:AD:20:00/36	Wart-Ele	Wart-Elektronik
 70:B3:D5:AD:50:00/36	Birdland	Birdland Audio
 70:B3:D5:AD:60:00/36	Lemonade	Lemonade Lab Inc
+70:B3:D5:AD:80:00/36	EuklisBy	Euklis by GSG International
 70:B3:D5:AD:A0:00/36	Private
 70:B3:D5:AD:B0:00/36	RfCode	RF Code
+70:B3:D5:AD:C0:00/36	Sodaq
 70:B3:D5:AD:D0:00/36	GhlBerha	GHL Systems Berhad
 70:B3:D5:AD:E0:00/36	IsacSrl	Isac Srl
 70:B3:D5:AD:F0:00/36	Seraphim	Seraphim Optronics Ltd
@@ -24993,9 +25987,11 @@
 70:B3:D5:AE:20:00/36	TransasM	Transas Marine Limited
 70:B3:D5:AE:30:00/36	Zhejiang	Zhejiang Wellsun Electric Meter Co.,Ltd
 70:B3:D5:AE:50:00/36	Beatcraf	BeatCraft, Inc.
+70:B3:D5:AE:60:00/36	YaBathoT	Ya Batho Trading (Pty) Ltd
 70:B3:D5:AE:70:00/36	E-T-AEle	E-T-A Elektrotechnische Apparate GmbH
 70:B3:D5:AE:90:00/36	CariElec	Cari Electronic
 70:B3:D5:AE:A0:00/36	BbrVerke	BBR Verkehrstechnik GmbH
+70:B3:D5:AE:B0:00/36	Associat	Association Romandix
 70:B3:D5:AE:E0:00/36	DitestFa	DiTEST Fahrzeugdiagnose GmbH
 70:B3:D5:AE:F0:00/36	Baumtec	Baumtec GmbH
 70:B3:D5:AF:00:00/36	SeasonDe	Season Design Technology
@@ -25006,6 +26002,7 @@
 70:B3:D5:AF:50:00/36	NetAndPr	Net And Print Inc.
 70:B3:D5:AF:60:00/36	SCESrl	S.C.E. srl
 70:B3:D5:AF:70:00/36	Dimosyst	DimoSystems BV
+70:B3:D5:AF:80:00/36	Boekel
 70:B3:D5:AF:90:00/36	Critical	Critical Link LLC
 70:B3:D5:AF:A0:00/36	PowerSec	Power Security Systems Ltd.
 70:B3:D5:AF:B0:00/36	Shanghai	Shanghai Tianhe Automation Instrumentation Co., Ltd.
@@ -25017,7 +26014,9 @@
 70:B3:D5:B0:70:00/36	Arrowval	Arrowvale Electronics
 70:B3:D5:B0:80:00/36	Secuinfo	Secuinfo Co. Ltd
 70:B3:D5:B0:90:00/36	FirstLig	First Light Imaging
+70:B3:D5:B0:B0:00/36	Internet	Internet Protocolo Logica Sl
 70:B3:D5:B0:C0:00/36	Vigilate	Vigilate srl
+70:B3:D5:B0:F0:00/36	MerkurFu	merkur Funksysteme AG
 70:B3:D5:B1:10:00/36	CabSRL	Cab S.R.L.
 70:B3:D5:B1:30:00/36	Omwave
 70:B3:D5:B1:50:00/36	EtaBetaS	Eta Beta Srl
@@ -25026,6 +26025,8 @@
 70:B3:D5:B1:80:00/36	AbbasAS	Abbas, a.s.
 70:B3:D5:B1:A0:00/36	Aaronia	Aaronia AG
 70:B3:D5:B1:D0:00/36	SafeletB	Safelet BV
+70:B3:D5:B1:E0:00/36	Fen	Fen Systems Ltd
+70:B3:D5:B1:F0:00/36	Tecnowat	Tecnowatt
 70:B3:D5:B2:10:00/36	TattileS	Tattile Srl
 70:B3:D5:B2:30:00/36	Supervis	Supervision Test et Pilotage
 70:B3:D5:B2:40:00/36	DatasatD	Datasat Digital Entertainment
@@ -25041,16 +26042,22 @@
 70:B3:D5:B3:40:00/36	Medtroni	Medtronic
 70:B3:D5:B3:50:00/36	Rexxam	Rexxam Co.,Ltd.
 70:B3:D5:B3:70:00/36	Codec	CODEC Co., Ltd.
-70:B3:D5:B3:90:00/36	MbConnec	MB Connect Line GmbH
+70:B3:D5:B3:80:00/36	Gotrusti	GoTrustID Inc.
+70:B3:D5:B3:90:00/36	MbConnec	MB connect line GmbH Fernwartungssysteme
 70:B3:D5:B3:A0:00/36	Adigital	Adigitalmedia
+70:B3:D5:B3:B0:00/36	Insitu	Insitu, Inc
 70:B3:D5:B3:C0:00/36	DorletSa	Dorlet Sau
 70:B3:D5:B3:D0:00/36	Inras	Inras GmbH
 70:B3:D5:B3:E0:00/36	Paradigm	Paradigm Communication Systems Ltd
 70:B3:D5:B3:F0:00/36	OrbitInt	Orbit International
 70:B3:D5:B4:00:00/36	WuhanXin	Wuhan Xingtuxinke ELectronic Co.,Ltd
+70:B3:D5:B4:30:00/36	ZaoZeo	Zao Zeo
 70:B3:D5:B4:40:00/36	EntecEle	ENTEC Electric & Electronic Co., LTD.
 70:B3:D5:B4:70:00/36	DsitSolu	DSIT Solutions LTD
 70:B3:D5:B4:80:00/36	DwqInfor	DWQ Informatikai Tanacsado es Vezerlestechnikai KFT
+70:B3:D5:B4:90:00/36	Analogic	Analogics Tech India Ltd
+70:B3:D5:B4:A0:00/36	Medex
+70:B3:D5:B4:D0:00/36	Avidbots	Avidbots Corporation
 70:B3:D5:B5:10:00/36	Critical	Critical Link LLC
 70:B3:D5:B5:30:00/36	Revoluti	Revolution Retail Systems, LLC
 70:B3:D5:B5:50:00/36	Ctag-Esg	CTAG - ESG36871424
@@ -25058,17 +26065,23 @@
 70:B3:D5:B5:90:00/36	Futurete	FutureTechnologyLaboratories INC.
 70:B3:D5:B5:C0:00/36	ProzessT	Prozess Technologie
 70:B3:D5:B6:20:00/36	SakuraSe	Sakura Seiki Co.,Ltd.
+70:B3:D5:B6:40:00/36	OsungLst	Osung Lst Co.,Ltd.
+70:B3:D5:B6:60:00/36	SilentGl	Silent Gliss International Ltd
 70:B3:D5:B6:70:00/36	RedwaveL	RedWave Labs Ltd
 70:B3:D5:B6:A0:00/36	YuyamaMf	YUYAMA MFG Co.,Ltd
+70:B3:D5:B6:B0:00/36	Cambria	Cambria Corporation
 70:B3:D5:B6:C0:00/36	Ghm-Mess	GHM-Messtechnik GmbH (Standort IMTRON)
 70:B3:D5:B6:D0:00/36	Movis
+70:B3:D5:B7:10:00/36	Private
 70:B3:D5:B7:20:00/36	Ub330Net	UB330.net d.o.o.
+70:B3:D5:B7:40:00/36	Onyield	OnYield Inc Ltd
 70:B3:D5:B7:70:00/36	MotecPty	Motec Pty Ltd
 70:B3:D5:B7:80:00/36	Hoermann	HOERMANN GmbH
 70:B3:D5:B7:A0:00/36	Mahle
 70:B3:D5:B7:C0:00/36	Electron	Electronic Navigation Ltd
 70:B3:D5:B7:D0:00/36	LogixIts	LOGIX ITS Inc
 70:B3:D5:B7:E0:00/36	ElbitOfA	Elbit Systems of America - Fort Worth Operations
+70:B3:D5:B7:F0:00/36	JskSyste	JSK System
 70:B3:D5:B8:10:00/36	InstroPr	Instro Precision Limited
 70:B3:D5:B8:20:00/36	LookoutP	Lookout Portable Security
 70:B3:D5:B8:50:00/36	Fenotech	Fenotech Inc.
@@ -25078,39 +26091,52 @@
 70:B3:D5:B8:B0:00/36	Profound	Profound Medical Inc.
 70:B3:D5:B8:C0:00/36	EpointEm	ePOINT Embedded Computing Limited
 70:B3:D5:B8:D0:00/36	Jungwooe	JungwooEng Co., Ltd
+70:B3:D5:B8:E0:00/36	UrFogSRL	Ur Fog S.R.L.
 70:B3:D5:B8:F0:00/36	Assembly	Assembly Contracts Ltd
 70:B3:D5:B9:10:00/36	Dynetics	Dynetics, Inc.
 70:B3:D5:B9:30:00/36	Internet	Internet Protocolo Logica Sl
+70:B3:D5:B9:40:00/36	Cygnetic	Cygnetic Technologies (Pty) Ltd
 70:B3:D5:B9:70:00/36	CanamTec	Canam Technology, Inc.
 70:B3:D5:B9:80:00/36	GsfPte	GSF Corporation Pte Ltd
 70:B3:D5:B9:90:00/36	Domosafe	DomoSafety S.A.
 70:B3:D5:B9:B0:00/36	Elektron	Elektronik Art
+70:B3:D5:B9:C0:00/36	EdcoTech	EDCO Technology 1993 ltd
 70:B3:D5:B9:E0:00/36	Polsyste	Polsystem Si Sp. Z O.O., S.K.A.
 70:B3:D5:BA:10:00/36	Cathwell	Cathwell AS
 70:B3:D5:BA:20:00/36	Mamac	MAMAC Systems, Inc.
+70:B3:D5:BA:30:00/36	Tiama
 70:B3:D5:BA:40:00/36	EiwaGike	Eiwa Giken Inc.
 70:B3:D5:BA:70:00/36	DigitalY	Digital Yacht Ltd
 70:B3:D5:BA:90:00/36	Alma
 70:B3:D5:BA:A0:00/36	DeviceSo	Device Solutions Ltd
 70:B3:D5:BA:B0:00/36	AxotecTe	Axotec Technologies GmbH
+70:B3:D5:BA:C0:00/36	Adinte	AdInte, inc.
 70:B3:D5:BA:D0:00/36	TechnikD	Technik & Design GmbH
 70:B3:D5:BA:E0:00/36	Warecube	Warecube,Inc
+70:B3:D5:BA:F0:00/36	SysTecEl	SYS TEC electronic GmbH
 70:B3:D5:BB:20:00/36	MettlerT	Mettler Toledo Hi Speed
 70:B3:D5:BB:30:00/36	ApgCashD	APG Cash Drawer, LLC
 70:B3:D5:BB:40:00/36	Integrit	Integritech
 70:B3:D5:BB:70:00/36	Innoflig	Innoflight, Inc.
 70:B3:D5:BB:80:00/36	AlKamelS	Al Kamel Systems S.L.
+70:B3:D5:BB:90:00/36	Kosmek	KOSMEK.Ltd
 70:B3:D5:BB:D0:00/36	Providiu	Providius Corp
 70:B3:D5:BB:E0:00/36	SunriseE	Sunrise Systems Electronics Co. Inc.
 70:B3:D5:BB:F0:00/36	EnsysSrl	Ensys srl
+70:B3:D5:BC:10:00/36	Abionic
 70:B3:D5:BC:20:00/36	Dwewoong	DWEWOONG ELECTRIC Co., Ltd.
+70:B3:D5:BC:30:00/36	Ewireles	eWireless
 70:B3:D5:BC:60:00/36	Hattelan	Hatteland Display AS
 70:B3:D5:BC:A0:00/36	DeymedDi	Deymed Diagnostic
+70:B3:D5:BC:B0:00/36	SmartVis	Smart Vision Lights
 70:B3:D5:BC:C0:00/36	MbConnec	MB connect line GmbH Fernwartungssysteme
+70:B3:D5:BC:E0:00/36	YawataEl	Yawata Electric Industrial Co.,Ltd.
+70:B3:D5:BC:F0:00/36	ApgCashD	APG Cash Drawer, LLC
 70:B3:D5:BD:10:00/36	Cablelab	CableLabs
 70:B3:D5:BD:20:00/36	BurkTech	Burk Technology
 70:B3:D5:BD:30:00/36	FotonaDD	Fotona D.D.
 70:B3:D5:BD:50:00/36	Synics	Synics AG
+70:B3:D5:BD:80:00/36	MbConnec	MB connect line GmbH Fernwartungssysteme
 70:B3:D5:BD:90:00/36	Solwayte	SolwayTech
 70:B3:D5:BD:A0:00/36	5-D	5-D Systems, Inc.
 70:B3:D5:BD:D0:00/36	CdrSrl	Cdr Srl
@@ -25130,24 +26156,31 @@
 70:B3:D5:BF:30:00/36	Cg-Wirel	CG-WIRELESS
 70:B3:D5:BF:50:00/36	AcaciaRe	Acacia Research
 70:B3:D5:BF:60:00/36	Comtac	comtac AG
+70:B3:D5:BF:90:00/36	OkolabSr	Okolab Srl
 70:B3:D5:BF:A0:00/36	NesaSrl	Nesa Srl
 70:B3:D5:BF:B0:00/36	Sensor42	Sensor 42
 70:B3:D5:BF:E0:00/36	AplexTec	Aplex Technology Inc.
 70:B3:D5:C0:10:00/36	Smartgua	SmartGuard LLC
 70:B3:D5:C0:30:00/36	XaviTech	XAVi Technologies Corp.
+70:B3:D5:C0:50:00/36	KstTechn	KST technology
 70:B3:D5:C0:60:00/36	Xotonics	XotonicsMED GmbH
 70:B3:D5:C0:70:00/36	Areco
 70:B3:D5:C0:A0:00/36	Infosock	Infosocket Co., Ltd.
+70:B3:D5:C0:B0:00/36	Fstudio	Fstudio Co Ltd
 70:B3:D5:C0:C0:00/36	Tech4rac	Tech4Race
 70:B3:D5:C0:E0:00/36	SysdevSr	SYSDEV Srl
 70:B3:D5:C0:F0:00/36	Honeywel	Honeywell Safety Products USA, Inc
+70:B3:D5:C1:10:00/36	AristonT	Ariston Thermo s.p.a.
 70:B3:D5:C1:20:00/36	BeijingW	Beijing Wisetone Information Technology Co.,Ltd.
 70:B3:D5:C1:40:00/36	GrupoEpe	Grupo Epelsa S.L.
 70:B3:D5:C1:50:00/36	Sensobox	Sensobox GmbH
 70:B3:D5:C1:60:00/36	Southern	Southern Innovation
 70:B3:D5:C1:70:00/36	PotterEl	Potter Electric Signal Co. LLC
+70:B3:D5:C1:A0:00/36	Xylon
 70:B3:D5:C1:B0:00/36	Labinven	Labinvent JSC
+70:B3:D5:C1:C0:00/36	DEM	D.E.M. Spa
 70:B3:D5:C1:D0:00/36	KranzeTe	Kranze Technology Solutions
+70:B3:D5:C1:F0:00/36	BehrTech	Behr Technologies Inc
 70:B3:D5:C2:00:00/36	MipotSPA	Mipot S.p.a.
 70:B3:D5:C2:10:00/36	AplexTec	Aplex Technology Inc.
 70:B3:D5:C2:20:00/36	Skyriver	Skyriver Communications Inc.
@@ -25162,7 +26195,9 @@
 70:B3:D5:C3:20:00/36	Infrasaf	INFRASAFE/ ADVANTOR SYSTEMS
 70:B3:D5:C3:30:00/36	DandongD	Dandong Dongfang Measurement & Control Technology Co., Ltd.
 70:B3:D5:C3:40:00/36	Technica	Technical Panels Co. Ltd.
+70:B3:D5:C3:50:00/36	Vibratio	Vibrationmaster
 70:B3:D5:C3:70:00/36	Keycom	Keycom Corp.
+70:B3:D5:C3:80:00/36	Cresprit	Cresprit Inc.
 70:B3:D5:C3:90:00/36	Meshwork	MeshWorks Wireless Oy
 70:B3:D5:C3:B0:00/36	Vironova	Vironova AB
 70:B3:D5:C3:C0:00/36	PeekTraf	Peek Traffic
@@ -25174,6 +26209,7 @@
 70:B3:D5:C4:30:00/36	FutureSk	Future Skies
 70:B3:D5:C4:50:00/36	StiebelE	Stiebel Eltron GmbH
 70:B3:D5:C4:90:00/36	BtgInstr	BTG Instruments AB
+70:B3:D5:C4:A0:00/36	Tiama
 70:B3:D5:C4:B0:00/36	Anker-Ea	ANKER-EAST
 70:B3:D5:C4:D0:00/36	RadaElec	RADA Electronics Industries Ltd.
 70:B3:D5:C4:F0:00/36	AeVanDeV	AE Van de Vliet BVBA
@@ -25189,6 +26225,9 @@
 70:B3:D5:C6:10:00/36	JcHunter	Jc Hunter Technologies
 70:B3:D5:C6:20:00/36	Wiznova
 70:B3:D5:C6:30:00/36	XentechS	Xentech Solutions Limited
+70:B3:D5:C6:40:00/36	SysTecEl	SYS TEC electronic GmbH
+70:B3:D5:C6:50:00/36	PeekTraf	Peek Traffic
+70:B3:D5:C6:60:00/36	BlueAcce	Blue Access Inc
 70:B3:D5:C6:70:00/36	ColliniD	Collini Dienstleistungs GmbH
 70:B3:D5:C6:80:00/36	MiniSolu	Mini Solution Co. Ltd.
 70:B3:D5:C6:A0:00/36	Private
@@ -25201,6 +26240,7 @@
 70:B3:D5:C7:70:00/36	YönnetAk	Yönnet Akıllı Bina ve Otomasyon Sistemleri
 70:B3:D5:C7:80:00/36	NetaElek	NETA Elektronik AS
 70:B3:D5:C7:90:00/36	MbConnec	MB connect line GmbH Fernwartungssysteme
+70:B3:D5:C7:D0:00/36	Metatron	Metatronics B.V.
 70:B3:D5:C7:E0:00/36	BirddogA	BirdDog Australia
 70:B3:D5:C7:F0:00/36	TattileS	Tattile Srl
 70:B3:D5:C8:00:00/36	LinkCare	Link Care Services
@@ -25213,13 +26253,17 @@
 70:B3:D5:C8:B0:00/36	AsiaPaci	Asia Pacific Satellite Coummunication Inc.
 70:B3:D5:C8:C0:00/36	Rollogo	Rollogo Limited
 70:B3:D5:C8:D0:00/36	KstTechn	KST technology
+70:B3:D5:C8:F0:00/36	TridentI	Trident Infosol Pvt Ltd
 70:B3:D5:C9:10:00/36	Grossenb	Grossenbacher Systeme AG
 70:B3:D5:C9:20:00/36	UnitroFl	Unitro Fleischmann
 70:B3:D5:C9:60:00/36	UniDimen	Uni Dimenxi Sdn Bhd
 70:B3:D5:C9:70:00/36	Csinfote	Csinfotel
 70:B3:D5:C9:B0:00/36	TietoSwe	Tieto Sweden AB
-70:B3:D5:C9:D0:00/36	ApgCashD	APG Cash Drawer
+70:B3:D5:C9:D0:00/36	ApgCashD	APG Cash Drawer, LLC
+70:B3:D5:C9:E0:00/36	FukudaSa	Fukuda Sangyo Co., Ltd.
 70:B3:D5:C9:F0:00/36	Triax	Triax A/S
+70:B3:D5:CA:20:00/36	DeHaardt	De Haardt bv
+70:B3:D5:CA:30:00/36	Saankhya	Saankhya Labs Private Limited
 70:B3:D5:CA:40:00/36	Netemera	Netemera Sp. z o.o.
 70:B3:D5:CA:80:00/36	GrupoEpe	Grupo Epelsa S.L.
 70:B3:D5:CA:90:00/36	Nxcontro	Nxcontrol system Co., Ltd.
@@ -25236,23 +26280,29 @@
 70:B3:D5:CB:C0:00/36	ProconEl	Procon Electronics Pty Ltd
 70:B3:D5:CB:E0:00/36	EnsuraSo	Ensura Solutions BV
 70:B3:D5:CC:10:00/36	Beecube	BEEcube Inc.
+70:B3:D5:CC:20:00/36	LscLight	LSC Lighting Systems (Aust) Pty Ltd
 70:B3:D5:CC:30:00/36	FidaliaN	Fidalia Networks Inc
 70:B3:D5:CC:50:00/36	Intecom
 70:B3:D5:CC:80:00/36	ProfenCo	Profen Communications
 70:B3:D5:CC:90:00/36	Rapiscan	Rapiscan Systems
 70:B3:D5:CC:A0:00/36	SiemensA	Siemens As
+70:B3:D5:CC:B0:00/36	Reald
 70:B3:D5:CC:C0:00/36	AecSRL	AEC s.r.l.
 70:B3:D5:CC:D0:00/36	SuzhouPo	Suzhou PowerCore Technology Co.,Ltd.
 70:B3:D5:CC:E0:00/36	Proconex	Proconex 2010 Inc.
 70:B3:D5:CC:F0:00/36	Netberg
+70:B3:D5:CD:00:00/36	EllenexP	Ellenex Pty Ltd
 70:B3:D5:CD:10:00/36	CannexTe	Cannex Technology Inc.
 70:B3:D5:CD:20:00/36	HbhMicro	HBH Microwave GmbH
 70:B3:D5:CD:30:00/36	Controlr	Controlrad
 70:B3:D5:CD:50:00/36	ApantacL	Apantac LLC
 70:B3:D5:CD:60:00/36	Videoray	VideoRay LLC
 70:B3:D5:CD:90:00/36	PeterHub	Peter Huber Kaeltemaschinenbau GmbH
+70:B3:D5:CD:A0:00/36	Vitec
 70:B3:D5:CD:E0:00/36	Multipur	Multipure International
+70:B3:D5:CD:F0:00/36	3dPrinti	3D Printing Specialists
 70:B3:D5:CE:10:00/36	EaElektr	EA Elektroautomatik GmbH & Co. KG
+70:B3:D5:CE:20:00/36	Centero
 70:B3:D5:CE:30:00/36	DalcnetS	Dalcnet srl
 70:B3:D5:CE:50:00/36	Gridbrid	GridBridge Inc
 70:B3:D5:CE:70:00/36	JuneAuto	June Automation Singapore Pte. Ltd.
@@ -25271,6 +26321,7 @@
 70:B3:D5:D0:50:00/36	Colmek
 70:B3:D5:D0:70:00/36	Waversa	Waversa Systems
 70:B3:D5:D0:80:00/36	VeecoIns	Veeco Instruments
+70:B3:D5:D0:90:00/36	RishaadB	Rishaad Brown
 70:B3:D5:D0:A0:00/36	Private
 70:B3:D5:D0:C0:00/36	ConnorWi	Connor Winfield LTD
 70:B3:D5:D0:D0:00/36	Logiwast	Logiwaste AB
@@ -25284,11 +26335,13 @@
 70:B3:D5:D1:F0:00/36	Embsec	Embsec AB
 70:B3:D5:D2:00:00/36	Rheonics	Rheonics GmbH
 70:B3:D5:D2:20:00/36	DekTechn	DEK Technologies
+70:B3:D5:D2:40:00/36	Microtro	Microtronics Engineering GmbH
 70:B3:D5:D2:50:00/36	Engenesi	ENGenesis
 70:B3:D5:D2:60:00/36	Mi	MI Inc.
 70:B3:D5:D2:90:00/36	Sportzca	Sportzcast
 70:B3:D5:D2:B0:00/36	Streampl	StreamPlay Oy Ltd
 70:B3:D5:D2:D0:00/36	EvoluteP	Evolute Systems Private Limited
+70:B3:D5:D2:E0:00/36	CoherosO	Coheros Oy
 70:B3:D5:D2:F0:00/36	LIFESa	L.I.F.E. Corporation SA
 70:B3:D5:D3:20:00/36	EuklisBy	Euklis by GSG International
 70:B3:D5:D3:40:00/36	G-Philos	G-PHILOS CO.,LTD
@@ -25305,6 +26358,8 @@
 70:B3:D5:D4:60:00/36	Contineo	Contineo s.r.o.
 70:B3:D5:D4:70:00/36	Yotascop	YotaScope Technologies Co., Ltd.
 70:B3:D5:D4:80:00/36	Headroom	HEADROOM Broadcast GmbH
+70:B3:D5:D4:A0:00/36	OüElikoT	OÜ ELIKO Tehnoloogia Arenduskeskus
+70:B3:D5:D4:B0:00/36	HermannL	Hermann Lümmen GmbH
 70:B3:D5:D4:C0:00/36	ElystecT	Elystec Technology Co., Ltd
 70:B3:D5:D4:D0:00/36	Morey	The Morey Corporation
 70:B3:D5:D4:E0:00/36	Flsmidth
@@ -25317,16 +26372,24 @@
 70:B3:D5:D5:A0:00/36	Wyrestor	WyreStorm Technologies Ltd
 70:B3:D5:D5:B0:00/36	Wyrestor	WyreStorm Technologies Ltd
 70:B3:D5:D5:C0:00/36	Critical	Critical Link LLC
+70:B3:D5:D5:F0:00/36	CoreBala	Core Balance Co., Ltd.
 70:B3:D5:D6:00:00/36	Flintab	Flintab AB
 70:B3:D5:D6:10:00/36	Vitec
+70:B3:D5:D6:20:00/36	AndasisE	Andasis Elektronik San. ve Tic. A.Ş.
 70:B3:D5:D6:30:00/36	Crde
+70:B3:D5:D6:40:00/36	MettlerT	Mettler Toledo Hi Speed
 70:B3:D5:D6:50:00/36	Crde
 70:B3:D5:D6:60:00/36	Ascenden	Ascendent Technology Group
 70:B3:D5:D6:70:00/36	Alpha	ALPHA　Corporation
 70:B3:D5:D6:90:00/36	ThermoFi	Thermo Fisher Scientific
+70:B3:D5:D6:A0:00/36	Knowroam	KnowRoaming
 70:B3:D5:D6:B0:00/36	Uwinloc
 70:B3:D5:D6:C0:00/36	Gp	GP Systems GmbH
+70:B3:D5:D6:E0:00/36	ArdSa	ard sa
+70:B3:D5:D6:F0:00/36	X-Spex	X-SPEX GmbH
 70:B3:D5:D7:00:00/36	Rational	Rational Production srl Unipersonale
+70:B3:D5:D7:10:00/36	RzbRudol	RZB Rudolf Zimmermann, Bamberg GmbH
+70:B3:D5:D7:20:00/36	Onyield	OnYield Inc Ltd
 70:B3:D5:D7:30:00/36	Ermine	ERMINE Corporation
 70:B3:D5:D7:40:00/36	SandiaNa	Sandia National Laboratories
 70:B3:D5:D7:50:00/36	HyundaiM	Hyundai MNSOFT
@@ -25334,6 +26397,7 @@
 70:B3:D5:D7:90:00/36	GomaElet	GOMA ELETTRONICA SpA
 70:B3:D5:D7:A0:00/36	Speedifi	Speedifi Inc
 70:B3:D5:D7:B0:00/36	PeterHub	Peter Huber Kaeltemaschinenbau AG
+70:B3:D5:D7:C0:00/36	DTSIllum	D.T.S Illuminazione Srl
 70:B3:D5:D7:E0:00/36	Triax	Triax A/S
 70:B3:D5:D7:F0:00/36	Conectai	ConectaIP Tecnologia S.L.
 70:B3:D5:D8:00:00/36	Ammt	AMMT GmbH
@@ -25341,6 +26405,7 @@
 70:B3:D5:D8:40:00/36	Sentry36	Sentry360
 70:B3:D5:D8:60:00/36	WpgsysPt	WPGSYS Pte Ltd
 70:B3:D5:D8:70:00/36	Zigen	Zigen Corp
+70:B3:D5:D8:90:00/36	Resoluti	Resolution Systems
 70:B3:D5:D8:B0:00/36	LenoxiAu	Lenoxi Automation s.r.o.
 70:B3:D5:D8:C0:00/36	Damerell	Damerell Design Limited (DCL)
 70:B3:D5:D8:D0:00/36	PullnetT	Pullnet Technology,S.L.
@@ -25361,22 +26426,30 @@
 70:B3:D5:D9:E0:00/36	GrupoEpe	Grupo Epelsa S.L.
 70:B3:D5:DA:10:00/36	QprelSrl	Qprel srl
 70:B3:D5:DA:40:00/36	Crde
+70:B3:D5:DA:50:00/36	Roboteq
+70:B3:D5:DA:60:00/36	RedfishG	Redfish Group Pty Ltd
 70:B3:D5:DA:80:00/36	TagarnoA	Tagarno AS
+70:B3:D5:DA:A0:00/36	AmtoteAu	AmTote Australasia
 70:B3:D5:DA:D0:00/36	GdMissio	GD Mission Systems
 70:B3:D5:DB:00:00/36	ArnouseD	Arnouse Digital Devices Corp
+70:B3:D5:DB:10:00/36	Biovigil	Biovigil Hygiene Technologies
 70:B3:D5:DB:20:00/36	MicroEle	Micro Electroninc Products
 70:B3:D5:DB:40:00/36	YuyamaMf	YUYAMA MFG Co.,Ltd
 70:B3:D5:DB:50:00/36	XiamenPo	Xiamen Point Circle Technologh Co,ltd
+70:B3:D5:DB:60:00/36	Csintech
 70:B3:D5:DB:80:00/36	SistemSa	Sistem Sa
+70:B3:D5:DB:F0:00/36	InfodevE	Infodev Electronic Designers Intl.
 70:B3:D5:DC:00:00/36	Ateme
 70:B3:D5:DC:50:00/36	ExcelMed	Excel Medical Electronics LLC
 70:B3:D5:DC:60:00/36	Idem	Idem Inc.
+70:B3:D5:DC:80:00/36	EnertexB	Enertex Bayern GmbH
 70:B3:D5:DC:90:00/36	Sensoter	Sensoterra BV
 70:B3:D5:DC:A0:00/36	Dsan	DSan Corporation
 70:B3:D5:DC:C0:00/36	Eutron	Eutron SPA
 70:B3:D5:DC:E0:00/36	Stahl	Stahl GmbH
 70:B3:D5:DC:F0:00/36	KlsNethe	KLS Netherlands B.V.
 70:B3:D5:DD:10:00/36	Em-Tec	em-tec GmbH
+70:B3:D5:DD:50:00/36	Cooltera	Cooltera Limited
 70:B3:D5:DD:70:00/36	DetectAu	DETECT Australia
 70:B3:D5:DD:80:00/36	Emscan	EMSCAN Corp.
 70:B3:D5:DD:B0:00/36	Intra	Intra Corporation
@@ -25389,9 +26462,12 @@
 70:B3:D5:DE:60:00/36	MbConnec	MB connect line GmbH Fernwartungssysteme
 70:B3:D5:DE:70:00/36	Innomind	Innominds Software Private Limited
 70:B3:D5:DE:80:00/36	Nation-E	Nation-E Ltd.
+70:B3:D5:DE:90:00/36	Private
+70:B3:D5:DE:A0:00/36	Advanced	Advanced Ventilation Applications, Inc.
 70:B3:D5:DE:C0:00/36	Condev-A	Condev-Automation GmbH
 70:B3:D5:DE:E0:00/36	Crde
 70:B3:D5:DF:00:00/36	AstoziCo	astozi consulting Tomasz Zieba
+70:B3:D5:DF:10:00/36	Coxlab	CoXlab Inc.
 70:B3:D5:DF:20:00/36	Aml
 70:B3:D5:DF:30:00/36	SpcBiocl	SPC Bioclinicum
 70:B3:D5:DF:60:00/36	Tiab	Tiab Limited
@@ -25407,6 +26483,8 @@
 70:B3:D5:E0:70:00/36	BaaderPl	Baader Planetarium GmbH
 70:B3:D5:E0:80:00/36	Olssen
 70:B3:D5:E0:90:00/36	L-3Commu	L-3 communications ComCept Division
+70:B3:D5:E0:B0:00/36	EntecEle	ENTEC Electric & Electronic Co., LTD.
+70:B3:D5:E0:C0:00/36	Communic	Communication Systems Solutions
 70:B3:D5:E0:D0:00/36	SigmaCon	Sigma Connectivity AB
 70:B3:D5:E0:F0:00/36	VtronPty	Vtron Pty Ltd
 70:B3:D5:E1:60:00/36	ChinaEnt	China Entropy Co., Ltd.
@@ -25422,9 +26500,11 @@
 70:B3:D5:E2:60:00/36	Feitian	Feitian Co.,Ltd.
 70:B3:D5:E2:70:00/36	Woodside	Woodside Electronics
 70:B3:D5:E2:80:00/36	Iotec	iotec GmbH
+70:B3:D5:E2:B0:00/36	GuanShow	Guan Show Technologe Co., Ltd.
 70:B3:D5:E2:C0:00/36	FourthFr	Fourth Frontier Technologies Private Limited
 70:B3:D5:E2:E0:00/36	MerzSRO	Merz s.r.o.
 70:B3:D5:E3:00:00/36	Quiss	Quiss Ag
+70:B3:D5:E3:20:00/36	HerutuEl	Herutu Electronics Corporation
 70:B3:D5:E3:50:00/36	Nanospee	Nanospeed Technologies Limited
 70:B3:D5:E3:60:00/36	Guidance	Guidance Navigation Limited
 70:B3:D5:E3:90:00/36	Thinnect	Thinnect, Inc,
@@ -25433,6 +26513,7 @@
 70:B3:D5:E3:D0:00/36	LeoBodna	Leo Bodnar Electronics Ltd
 70:B3:D5:E3:E0:00/36	SolWeldi	Sol Welding srl
 70:B3:D5:E3:F0:00/36	Bestcode	Bestcode Llc
+70:B3:D5:E4:30:00/36	SlAudio	SL Audio A/S
 70:B3:D5:E4:50:00/36	Momentum	Momentum Data Systems
 70:B3:D5:E4:80:00/36	Tdi	TDI. Co., LTD
 70:B3:D5:E4:90:00/36	Kendrion	Kendrion Mechatronics Center GmbH
@@ -25442,12 +26523,15 @@
 70:B3:D5:E4:E0:00/36	Midfin	Midfin Systems
 70:B3:D5:E4:F0:00/36	RwsAutom	RWS Automation GmbH
 70:B3:D5:E5:00:00/36	Advanced	Advanced Vision Technology Ltd
+70:B3:D5:E5:20:00/36	Guangzho	Guangzhou Moblin Technology Co., Ltd.
 70:B3:D5:E5:30:00/36	Mi	Mi Inc.
 70:B3:D5:E5:50:00/36	BeltSRL	BELT S.r.l.
 70:B3:D5:E5:70:00/36	Iradimed
 70:B3:D5:E5:80:00/36	ThurlbyT	Thurlby Thandar Instruments LTD
 70:B3:D5:E5:90:00/36	Fracarro	Fracarro srl
+70:B3:D5:E5:D0:00/36	BoffinsT	Boffins Technologies AB
 70:B3:D5:E5:E0:00/36	Critical	Critical Link LLC
+70:B3:D5:E6:10:00/36	Adeli
 70:B3:D5:E6:70:00/36	AppliedP	Applied Processing
 70:B3:D5:E6:90:00/36	Fire4Uk	Fire4 Systems UK Ltd
 70:B3:D5:E6:C0:00/36	FusarTec	Fusar Technologies inc
@@ -25465,6 +26549,7 @@
 70:B3:D5:E7:D0:00/36	NanjingD	Nanjing Dandick Science&technology development co., LTD
 70:B3:D5:E7:E0:00/36	GroupeCi	Groupe Citypassenger Inc
 70:B3:D5:E8:20:00/36	RfTrack	RF Track
+70:B3:D5:E8:40:00/36	EntecEle	ENTEC Electric & Electronic Co., LTD.
 70:B3:D5:E8:50:00/36	Explorer	Explorer Inc.
 70:B3:D5:E8:60:00/36	YuyamaMf	YUYAMA MFG Co.,Ltd
 70:B3:D5:E8:80:00/36	BreasMed	Breas Medical AB
@@ -25474,6 +26559,7 @@
 70:B3:D5:E9:10:00/36	NasAustr	NAS Australia P/L
 70:B3:D5:E9:20:00/36	FujiData	Fuji Data System Co.,Ltd.
 70:B3:D5:E9:30:00/36	EconTech	ECON Technology Co.Ltd
+70:B3:D5:E9:40:00/36	Lumiplan	Lumiplan Duhamel
 70:B3:D5:E9:50:00/36	Broadsof	BroadSoft Inc
 70:B3:D5:E9:60:00/36	CellierD	Cellier Domesticus inc
 70:B3:D5:E9:80:00/36	JscKalug	JSC Kaluga Astral
@@ -25481,22 +26567,28 @@
 70:B3:D5:E9:A0:00/36	MetaComp	Meta Computing Services, Corp
 70:B3:D5:E9:B0:00/36	NumataR&	NUMATA R&D Co.,Ltd
 70:B3:D5:E9:C0:00/36	AtgUvTec	ATG UV Technology
+70:B3:D5:E9:E0:00/36	MsbElekt	MSB Elektronik und Gerätebau GmbH
 70:B3:D5:EA:00:00/36	Park24
 70:B3:D5:EA:20:00/36	Transpor	Transportal Solutions Ltd
 70:B3:D5:EA:30:00/36	Gridless	Gridless Power Corperation
 70:B3:D5:EA:40:00/36	GrupoEpe	Grupo Epelsa S.L.
 70:B3:D5:EA:60:00/36	Galios
 70:B3:D5:EA:70:00/36	SICESSrl	S.I.C.E.S. srl
+70:B3:D5:EA:80:00/36	Dia-Stro	Dia-Stron Limited
 70:B3:D5:EA:B0:00/36	ApenGrou	APEN GROUP SpA (VAT IT08767740155)
 70:B3:D5:EA:C0:00/36	KentechI	Kentech Instruments Limited
 70:B3:D5:EA:E0:00/36	OrlacoPr	Orlaco Products B.V.
 70:B3:D5:EB:00:00/36	NautelLi	Nautel Limted
 70:B3:D5:EB:10:00/36	CpContec	CP contech electronic GmbH
 70:B3:D5:EB:20:00/36	ShooterD	Shooter Detection Systems
+70:B3:D5:EB:30:00/36	Kws-Elec	KWS-Electronic GmbH
+70:B3:D5:EB:40:00/36	RoboticR	Robotic Research, LLC
 70:B3:D5:EB:50:00/36	Justek	Justek Inc
 70:B3:D5:EB:70:00/36	Skreens
 70:B3:D5:EB:90:00/36	ThielAud	Thiel Audio Products Company, LLC
+70:B3:D5:EB:A0:00/36	LastMile	Last Mile Gear
 70:B3:D5:EB:B0:00/36	BeijingW	Beijing Wing ICT Technology Co., Ltd.
+70:B3:D5:EB:C0:00/36	RefineTe	Refine Technology, LLC
 70:B3:D5:EB:D0:00/36	MidbitTe	midBit Technologies, LLC
 70:B3:D5:EB:E0:00/36	SierraPa	Sierra Pacific Innovations Corp
 70:B3:D5:EC:10:00/36	XafaxNed	Xafax Nederland bv
@@ -25508,8 +26600,10 @@
 70:B3:D5:EC:D0:00/36	Sbs-Fein	SBS-Feintechnik GmbH & Co. KG
 70:B3:D5:EC:E0:00/36	Comm-Con	COMM-connect A/S
 70:B3:D5:EC:F0:00/36	Ipitek
+70:B3:D5:ED:00:00/36	Shanghai	shanghai qiaoqi zhinengkeji
 70:B3:D5:ED:10:00/36	Przemysl	Przemyslowy Instytut Automatyki i Pomiarow
 70:B3:D5:ED:50:00/36	Hangzhou	hangzhou battle link technology Co.,Ltd
+70:B3:D5:ED:70:00/36	Wave
 70:B3:D5:ED:B0:00/36	NetfortS	Netfort Solutions
 70:B3:D5:ED:C0:00/36	JDKoftin	J.D. Koftinoff Software, Ltd.
 70:B3:D5:ED:D0:00/36	SolarNet	Solar Network & Partners
@@ -25518,11 +26612,16 @@
 70:B3:D5:EE:30:00/36	LitheTec	Lithe Technology, LLC
 70:B3:D5:EE:40:00/36	O-NetAut	O-Net Automation Technology (Shenzhen)Limited
 70:B3:D5:EE:50:00/36	BeijingH	Beijing Hzhytech Technology Co.Ltd
+70:B3:D5:EE:70:00/36	Blue-Sol	BLUE-SOLUTIONS CANADA INC.
 70:B3:D5:EE:A0:00/36	Dameca	Dameca a/s
+70:B3:D5:EE:C0:00/36	Impolux	Impolux GmbH
 70:B3:D5:EE:D0:00/36	Comm-Con	COMM-connect A/S
 70:B3:D5:EE:E0:00/36	Sociedad	SOCIEDAD IBERICA DE CONSTRUCCIONES ELECTRICAS, S.A. (SICE)
+70:B3:D5:EE:F0:00/36	TattileS	Tattile Srl
 70:B3:D5:EF:20:00/36	Kongsber	Kongsberg Intergrated Tactical Systems
 70:B3:D5:EF:30:00/36	Octoscop	octoScope
+70:B3:D5:EF:40:00/36	OrangeTr	Orange Tree Technologies Ltd
+70:B3:D5:EF:50:00/36	Deuta-We	DEUTA-WERKE GmbH
 70:B3:D5:EF:60:00/36	Chargeli	Chargelib
 70:B3:D5:EF:70:00/36	DaveSrl	Dave Srl
 70:B3:D5:EF:80:00/36	DksDiens	DKS Dienstl.ges. f. Komm.anl. d. Stadt- u. Reg.verk. mbH
@@ -25534,6 +26633,7 @@
 70:B3:D5:F0:10:00/36	Software	Software Systems Plus
 70:B3:D5:F0:30:00/36	Gmi	GMI Ltd
 70:B3:D5:F0:50:00/36	Motomuto	Motomuto Aps
+70:B3:D5:F0:60:00/36	Warecube	Warecube,Inc
 70:B3:D5:F0:70:00/36	DuvalMes	Duval Messien
 70:B3:D5:F0:80:00/36	SzaboSof	Szabo Software & Engineering UK Ltd
 70:B3:D5:F0:B0:00/36	RfIndust	RF Industries
@@ -25543,13 +26643,17 @@
 70:B3:D5:F1:10:00/36	Broadsof	BroadSoft Inc
 70:B3:D5:F1:20:00/36	IncoilIn	Incoil Induktion AB
 70:B3:D5:F1:30:00/36	MediamSp	MEDIAM Sp. z o.o.
+70:B3:D5:F1:40:00/36	SanyuSwi	Sanyu Switch Co., Ltd.
+70:B3:D5:F1:60:00/36	BrsSiste	BRS Sistemas Eletrônicos
 70:B3:D5:F1:70:00/36	Vitec
+70:B3:D5:F1:90:00/36	VitroTec	Vitro Technology Corporation
 70:B3:D5:F1:A0:00/36	SatorCon	Sator Controls s.r.o.
 70:B3:D5:F1:D0:00/36	Critical	Critical Link LLC
 70:B3:D5:F1:E0:00/36	AtxNetwo	Atx Networks Ltd
 70:B3:D5:F1:F0:00/36	Hkc	HKC Limited
 70:B3:D5:F2:40:00/36	Daavlin
 70:B3:D5:F2:50:00/36	Jsc“Scie	JSC “Scientific Industrial Enterprise Rubin
+70:B3:D5:F2:70:00/36	Nirit-Xi	NIRIT- Xinwei  Telecom Technology Co., Ltd.
 70:B3:D5:F2:A0:00/36	WibondIn	WIBOND Informationssysteme GmbH
 70:B3:D5:F2:B0:00/36	Sensys	SENSYS GmbH
 70:B3:D5:F2:C0:00/36	HengenTe	Hengen Technologies GmbH
@@ -25567,20 +26671,25 @@
 70:B3:D5:F4:20:00/36	Matsuhis	Matsuhisa Corporation
 70:B3:D5:F4:50:00/36	NorbitOd	Norbit ODM AS
 70:B3:D5:F4:C0:00/36	GlobalLi	Global Lightning Protection Services A(S
-70:B3:D5:F4:D0:00/36	Honeywel	Honeywell International Inc.
+70:B3:D5:F4:D0:00/36	Honeywel	Honeywell
 70:B3:D5:F4:F0:00/36	PowerEle	Power Electronics Espana, S.L.
+70:B3:D5:F5:10:00/36	IotRoute	IoT Routers Limited
+70:B3:D5:F5:20:00/36	AlereTec	Alere Technologies AS
 70:B3:D5:F5:40:00/36	Revoluti	Revolution Retail Systems
 70:B3:D5:F5:50:00/36	KohlerMi	Kohler Mira Ltd
 70:B3:D5:F5:60:00/36	Virtualh	VirtualHere Pty. Ltd.
 70:B3:D5:F5:70:00/36	AplexTec	Aplex Technology Inc.
+70:B3:D5:F5:80:00/36	CdrSrl	Cdr Srl
 70:B3:D5:F5:A0:00/36	Hameg	HAMEG GmbH
 70:B3:D5:F5:B0:00/36	AFMensah	A.F.Mensah, Inc
 70:B3:D5:F5:C0:00/36	NableCom	Nable Communications, Inc.
 70:B3:D5:F5:E0:00/36	SelexEs	Selex ES Inc.
+70:B3:D5:F5:F0:00/36	RfrainLl	RFRain LLC
 70:B3:D5:F6:10:00/36	PowerDia	Power Diagnostic Service
 70:B3:D5:F6:20:00/36	Frs	FRS GmbH & Co. KG
 70:B3:D5:F6:30:00/36	ArsProdu	Ars Products
 70:B3:D5:F6:50:00/36	MarkusLa	Markus Labs
+70:B3:D5:F6:70:00/36	Winsun	winsun AG
 70:B3:D5:F6:80:00/36	AlZajelM	Al Zajel Modern Telecomm
 70:B3:D5:F6:D0:00/36	Qowisio
 70:B3:D5:F6:E0:00/36	Streambo	Streambox Inc
@@ -25592,11 +26701,17 @@
 70:B3:D5:F7:70:00/36	Satcube	Satcube AB
 70:B3:D5:F7:80:00/36	ManvishE	Manvish eTech Pvt. Ltd.
 70:B3:D5:F7:90:00/36	Firehose	Firehose Labs, Inc.
+70:B3:D5:F7:A0:00/36	Senso2me
 70:B3:D5:F7:B0:00/36	KstTechn	KST technology
+70:B3:D5:F7:C0:00/36	Private
 70:B3:D5:F7:E0:00/36	AlphaEle	Alpha Elettronica s.r.l.
 70:B3:D5:F8:10:00/36	Littlemo	Littlemore Scientific
 70:B3:D5:F8:30:00/36	TataComm	Tata Communications Ltd.
+70:B3:D5:F8:40:00/36	Deuta-We	DEUTA-WERKE GmbH
 70:B3:D5:F8:50:00/36	Solystic
+70:B3:D5:F8:70:00/36	ShinwaIn	Shinwa Industries, Inc.
+70:B3:D5:F8:80:00/36	Odawarak	ODAWARAKIKI AUTO-MACHINE MFG.CO.,LTD
+70:B3:D5:F8:A0:00/36	Frs	FRS GmbH & Co. KG
 70:B3:D5:F8:B0:00/36	IoootaSr	IOOOTA Srl
 70:B3:D5:F8:C0:00/36	European	European Advanced Technologies
 70:B3:D5:F8:D0:00/36	Flextron	Flextronics Canafa Design Services
@@ -25606,6 +26721,7 @@
 70:B3:D5:F9:30:00/36	HellaGut	Hella Gutmann Solutions GmbH
 70:B3:D5:F9:50:00/36	GetSat	Get SAT
 70:B3:D5:F9:60:00/36	Ecologic	Ecologicsense
+70:B3:D5:F9:80:00/36	MetrumSw	Metrum Sweden AB
 70:B3:D5:F9:90:00/36	TexCompu	Tex Computer Srl
 70:B3:D5:F9:A0:00/36	Krabbenh	Krabbenhøft og Ingolfsson
 70:B3:D5:F9:C0:00/36	Sureflap	SureFlap Ltd
@@ -25615,6 +26731,7 @@
 70:B3:D5:FA:20:00/36	SarokalT	Sarokal Test Systems Oy
 70:B3:D5:FA:30:00/36	Elva-1Mi	ELVA-1 MICROWAVE HANDELSBOLAG
 70:B3:D5:FA:40:00/36	Energybo	Energybox Limited
+70:B3:D5:FA:50:00/36	Shenzhen	Shenzhen Hui Rui Tianyan Technology Co., Ltd.
 70:B3:D5:FA:60:00/36	RflElect	RFL Electronics, Inc.
 70:B3:D5:FA:70:00/36	Nordson	Nordson Corporation
 70:B3:D5:FA:A0:00/36	LogimSof	LogiM GmbH Software und Entwicklung
@@ -25625,16 +26742,19 @@
 70:B3:D5:FB:30:00/36	3ps	3PS Inc
 70:B3:D5:FB:50:00/36	OrangeTr	Orange Tree Technologies Ltd
 70:B3:D5:FB:60:00/36	Kronotec	Kronotech Srl
+70:B3:D5:FB:70:00/36	Saice
 70:B3:D5:FB:A0:00/36	ApogeeAp	Apogee Applied Research, Inc.
 70:B3:D5:FB:B0:00/36	VenaEngi	Vena Engineering Corporation
 70:B3:D5:FB:C0:00/36	TwowayCo	Twoway Communications, Inc.
 70:B3:D5:FB:D0:00/36	MbConnec	MB connect line GmbH Fernwartungssysteme
 70:B3:D5:FB:E0:00/36	HanbatNa	Hanbat National University
 70:B3:D5:FB:F0:00/36	SensysDe	SenSys (Design Electronics Ltd)
+70:B3:D5:FC:00:00/36	Codesyst	CODESYSTEM Co.,Ltd
 70:B3:D5:FC:10:00/36	Indicor
 70:B3:D5:FC:20:00/36	HunterLi	Hunter Liberty Corporation
 70:B3:D5:FC:50:00/36	Eltwin	Eltwin A/S
 70:B3:D5:FC:60:00/36	TecnintH	Tecnint HTE SRL
+70:B3:D5:FC:80:00/36	Moduware	Moduware PTY LTD
 70:B3:D5:FC:90:00/36	Shanghai	Shanghai EICT Global Service Co., Ltd
 70:B3:D5:FC:A0:00/36	M2mCyber	M2M Cybernetics Pvt Ltd
 70:B3:D5:FC:C0:00/36	Digsilen	DIgSILENT GmbH
@@ -25644,9 +26764,11 @@
 70:B3:D5:FD:20:00/36	DalianLe	Dalian Levear Electric Co., Ltd
 70:B3:D5:FD:30:00/36	AkisTech	AKIS technologies
 70:B3:D5:FD:60:00/36	VisualFa	Visual Fan
+70:B3:D5:FD:70:00/36	CentumAd	Centum Adetel Group
 70:B3:D5:FD:80:00/36	MbConnec	MB connect line GmbH Fernwartungssysteme
 70:B3:D5:FD:A0:00/36	AcdElekt	ACD Elektronik GmbH
 70:B3:D5:FD:B0:00/36	DesignSh	Design SHIFT
+70:B3:D5:FD:D0:00/36	LaserIma	Laser Imagineering Vertriebs GmbH
 70:B3:D5:FD:E0:00/36	Aeronaut	AERONAUTICAL & GENERAL INSTRUMENTS LTD.
 70:B3:D5:FD:F0:00/36	NaraCont	Nara Controls Inc.
 70:B3:D5:FE:20:00/36	GalileoT	Galileo Tıp Teknolojileri San. ve Tic. A.S.
@@ -25656,9 +26778,11 @@
 70:B3:D5:FE:70:00/36	Veilux	Veilux Inc.
 70:B3:D5:FE:80:00/36	Pcme	PCME Ltd.
 70:B3:D5:FE:90:00/36	CamsatPr	Camsat Przemysław Gralak
+70:B3:D5:FE:A0:00/36	HengDian	Heng Dian Technology Co., Ltd
 70:B3:D5:FE:B0:00/36	LesDistr	Les distributions Multi-Secure incorporee
 70:B3:D5:FE:C0:00/36	Finder	Finder SpA
 70:B3:D5:FE:F0:00/36	Hangzhou	Hangzhou Hualan Microelectronique Co.,Ltd
+70:B3:D5:FF:00:00/36	E-Metrot	E-MetroTel
 70:B3:D5:FF:10:00/36	DataStra	Data Strategy Limited
 70:B3:D5:FF:30:00/36	AplexTec	Aplex Technology Inc.
 70:B3:D5:FF:40:00/36	Serveron	Serveron Corporation
@@ -25670,15 +26794,21 @@
 70:B3:D5:FF:E0:00/36	Private
 70:B3:D5:FF:F0:00/36	Private
 70:B5:99	Embedded	Embedded Technologies s.r.o.
+70:B7:AA	VivoMobi	vivo Mobile Communication Co., Ltd.
 70:B7:E2	JiangsuM	Jiangsu Miter Technology Co.,Ltd.
 70:B9:21	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 70:BA:EF	Hangzhou	Hangzhou H3C Technologies Co., Limited
+70:BB:E9	XiaomiCo	Xiaomi Communications Co Ltd
 70:BF:3E	CharlesR	Charles River Laboratories
 70:C6:AC	BoschAut	Bosch Automotive Aftermarket
 70:C7:6F	InnoS	Inno S
+70:C8:33	WirepasO	Wirepas Oy
+70:C9:4E	LiteonTe	Liteon Technology Corporation
 70:CA:4D	Shenzhen	Shenzhen lnovance Technology Co.,Ltd.
 70:CA:9B	Cisco	Cisco Systems, Inc
 70:CD:60	Apple	Apple, Inc.
+70:D0:81	BeijingN	Beijing Netpower Technologies Inc.
+70:D3:13	HuaweiTe	Huawei Technologies Co.,Ltd
 70:D3:79	Cisco	Cisco Systems, Inc
 70:D4:F2	Rim
 70:D5:7E	Scalar	Scalar Corporation
@@ -25734,12 +26864,15 @@
 70:F9:27	SamsungE	Samsung Electronics Co.,Ltd
 70:F9:6D	Hangzhou	Hangzhou H3C Technologies Co., Limited
 70:FC:8C	Oneacces	OneAccess SA
+70:FD:46	SamsungE	Samsung Electronics Co.,Ltd
 70:FF:5C	Cheerzin	Cheerzing Communication(Xiamen)Technology Co.,Ltd
 70:FF:76	TexasIns	Texas Instruments
 74:03:BD	Buffalo	Buffalo.Inc
 74:04:2B	LenovoMo	Lenovo Mobile Communication (Wuhan) Company Limited
+74:05:A5	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 74:0A:BC	Lightwav	LightwaveRF Technology Ltd
 74:0E:DB	Optowiz	Optowiz Co., Ltd
+74:12:BB	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 74:14:89	SrtWirel	SRT Wireless
 74:15:E2	Tri-Sen	Tri-Sen Systems Corporation
 74:18:65	Shanghai	Shanghai DareGlobal Technologies Co.,Ltd
@@ -25780,6 +26913,7 @@
 74:1C:27	ItelMobi	Itel Mobile Limited
 74:1E:93	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 74:1F:4A	Hangzhou	Hangzhou H3C Technologies Co., Limited
+74:1F:79	Youngkoo	Youngkook Electronics Co.,Ltd
 74:23:44	XiaomiCo	Xiaomi Communications Co Ltd
 74:25:8A	Hangzhou	Hangzhou H3C Technologies Co., Limited
 74:26:AC	Cisco	Cisco Systems, Inc
@@ -25794,6 +26928,7 @@
 74:2F:68	Azurewav	AzureWave Technology Inc.
 74:31:70	Arcadyan	Arcadyan Technology Corporation
 74:32:56	Nt-WareS	NT-ware Systemprg GmbH
+74:34:00	Mtg	MTG Co., Ltd.
 74:37:2F	Tongfang	Tongfang Shenzhen Cloudcomputing Technology Co.,Ltd
 74:37:3B	Uninet	UNINET Co.,Ltd.
 74:38:89	AnnaxAnz	ANNAX Anzeigesysteme GmbH
@@ -25813,11 +26948,13 @@
 74:54:7D	CiscoSpv	Cisco SPVTG
 74:56:12	ArrisGro	ARRIS Group, Inc.
 74:57:98	TrumpfLa	TRUMPF Laser GmbH + Co. KG
+74:59:33	DanalEnt	Danal Entertainment
 74:5A:AA	HuaweiTe	Huawei Technologies Co.,Ltd
 74:5C:4B	GnAudio	GN Audio A/S
 74:5C:9F	TctMobil	TCT mobile ltd
 74:5E:1C	Pioneer	Pioneer Corporation
 74:5F:00	SamsungS	Samsung Semiconductor Inc.
+74:5F:90	LamTechn	LAM Technologies
 74:5F:AE	TslPpl	Tsl Ppl
 74:61:4B	Chongqin	Chongqing Huijiatong Information Technology Co., Ltd.
 74:63:DF	Vts	VTS GmbH
@@ -25828,10 +26965,13 @@
 74:6A:89	Rezolt	Rezolt Corporation
 74:6A:8F	VsVision	VS Vision Systems GmbH
 74:6B:82	Movek
+74:6B:AB	Guangdon	Guangdong Enok Communication Co., Ltd
 74:6E:E4	AsiaVita	Asia Vital Components Co.,Ltd.
 74:6F:19	Icarvisi	ICARVISIONS (SHENZHEN) TECHNOLOGY CO., LTD.
 74:6F:3D	Contec	Contec GmbH
 74:6F:F7	WistronN	Wistron Neweb Corporation
+74:70:FD	IntelCor	Intel Corporate
+74:72:1E	EdisonLa	Edison Labs Inc.
 74:72:B0	Guangzho	Guangzhou Shiyuan Electronics Co., Ltd.
 74:72:F2	ChipsipT	Chipsip Technology Co., Ltd.
 74:73:36	Microdig	MICRODIGTAL Inc
@@ -25844,11 +26984,13 @@
 74:7E:2D	BeijingT	Beijing Thomson CITIC Digital Technology Co. LTD.
 74:81:14	Apple	Apple, Inc.
 74:81:9A	PtHarton	PT. Hartono Istana Teknologi
+74:83:C2	Ubiquiti	Ubiquiti Networks Inc.
 74:83:EF	AristaNe	Arista Networks
 74:85:2A	Pegatron	Pegatron Corporation
 74:86:0B	Cisco	Cisco Systems, Inc
 74:86:7A	Dell	Dell Inc.
 74:87:A9	OctTechn	OCT Technology Co., Ltd.
+74:87:BB	Ciena	Ciena Corporation
 74:88:2A	HuaweiTe	Huawei Technologies Co.,Ltd
 74:88:8B	AdbBroad	ADB Broadband Italia
 74:8A:69	KoreaIma	Korea Image Technology Co., Ltd
@@ -25868,8 +27010,10 @@
 74:99:75	Ibm	IBM Corporation
 74:9C:52	HuizhouD	Huizhou Desay SV Automotive Co., Ltd.
 74:9C:E3	Kodaclou	KodaCloud Canada, Inc
+74:9D:79	Sercomm	Sercomm Corporation.
 74:9D:8F	HuaweiTe	Huawei Technologies Co.,Ltd
 74:9D:DC	2wire	2Wire Inc
+74:9E:AF	Apple	Apple, Inc.
 74:A0:2F	Cisco	Cisco Systems, Inc
 74:A0:63	HuaweiTe	Huawei Technologies Co.,Ltd
 74:A2:E6	Cisco	Cisco Systems, Inc
@@ -25885,12 +27029,17 @@
 74:B0:0C	NetworkV	Network Video Technologies, Inc
 74:B4:72	Ciesse
 74:B5:7E	Zte	zte corporation
+74:B5:87	Apple	Apple, Inc.
+74:B9:1E	NanjingB	Nanjing Bestway Automation System Co., Ltd
 74:B9:EB	Jinqianm	JinQianMao Technology Co.,Ltd.
 74:BA:DB	Longconn	Longconn Electornics(shenzhen)Co.,Ltd
 74:BB:D3	Shenzhen	Shenzhen xeme Communication Co., Ltd.
 74:BE:08	AtekProd	ATEK Products, LLC
 74:BF:A1	Hyunteck
 74:BF:B7	Nusoft	Nusoft Corporation
+74:BF:C0	Canon	Canon Inc.
+74:C1:4F	HuaweiTe	Huawei Technologies Co.,Ltd
+74:C1:7D	InfinixM	Infinix mobility limited
 74:C2:46	AmazonTe	Amazon Technologies Inc.
 74:C3:30	Shenzhen	Shenzhen Fast Technologies Co.,Ltd
 74:C6:21	Zhejiang	Zhejiang Hite Renewable Energy Co.,LTD
@@ -25951,6 +27100,8 @@
 74:EA:C8	NewH3cTe	New H3C Technologies Co., Ltd
 74:EA:CB	NewH3cTe	New H3C Technologies Co., Ltd
 74:EA:E8	ArrisGro	ARRIS Group, Inc.
+74:EB:80	SamsungE	Samsung Electronics Co.,Ltd
+74:EC:42	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 74:EC:F1	Acumen
 74:F0:6D	Azurewav	AzureWave Technology Inc.
 74:F0:7D	Bncom	BnCOM Co.,Ltd
@@ -25972,7 +27123,7 @@
 74:F8:DB:70:00:00/28	WuhanTia	Wuhan Tianyu Information Industry Co., Ltd.
 74:F8:DB:80:00:00/28	SongamSy	Songam Syscom Co. LTD.
 74:F8:DB:90:00:00/28	Avantree	Avantree Corporation
-74:F8:DB:A0:00:00/28	BallardT	Ballard Technology Inc.
+74:F8:DB:A0:00:00/28	BallardT	Ballard Technology, Inc,
 74:F8:DB:B0:00:00/28	CapwaveT	Capwave Technologies Inc
 74:F8:DB:C0:00:00/28	Tbm	Tbm Co., Ltd.
 74:F8:DB:D0:00:00/28	SimonEle	Simon Electric (China) Co.,ltd
@@ -25988,10 +27139,14 @@
 78:02:B1	Cisco	Cisco Systems, Inc
 78:02:B7	Shenzhen	ShenZhen Ultra Easy Technology CO.,LTD
 78:02:F8	XiaomiCo	Xiaomi Communications Co Ltd
+78:04:73	TexasIns	Texas Instruments
 78:05:41	Queclink	Queclink Wireless Solutions Co., Ltd
+78:05:5F	Shenzhen	Shenzhen WYC Technology Co., Ltd.
 78:07:38	ZUKElzab	Z.U.K. Elzab S.A.
 78:0A:C7	BaofengT	Baofeng TV Co., Ltd.
 78:0C:B8	IntelCor	Intel Corporate
+78:0C:F0	Cisco	Cisco Systems, Inc
+78:0F:77	Hangzhou	HangZhou Gubei Electronics Technology Co.,Ltd
 78:11:85	NbsPayme	NBS Payment Solutions Inc.
 78:11:DC	XiaomiEl	XIAOMI Electronics,CO.,LTD
 78:12:B8	Orantek	Orantek Limited
@@ -25999,26 +27154,33 @@
 78:19:2E	NascentT	NASCENT Technology
 78:19:F7	JuniperN	Juniper Networks
 78:1C:5A	Sharp	SHARP Corporation
+78:1D:4A	Zte	zte corporation
 78:1D:BA	HuaweiTe	Huawei Technologies Co.,Ltd
 78:1D:FD	Jabil	Jabil Inc
 78:1F:DB	SamsungE	Samsung Electronics Co.,Ltd
 78:20:79	IdTech	ID Tech
 78:22:3D	Affirmed	Affirmed Networks
+78:23:27	SamsungE	Samsung Electronics Co.,Ltd
 78:23:AE	ArrisGro	ARRIS Group, Inc.
 78:24:AF	AsustekC	ASUSTek COMPUTER INC.
 78:25:44	Omnima	Omnima Limited
+78:25:7A	LeoInnov	LEO Innovation Lab
 78:25:AD	SamsungE	Samsung Electronics Co.,Ltd
 78:28:CA	Sonos	Sonos, Inc.
+78:29:ED	AskeyCom	Askey Computer Corp
 78:2B:CB	Dell	Dell Inc.
 78:2D:7E	Trendnet	TRENDnet, Inc.
 78:2E:EF	Nokia	Nokia Corporation
+78:2F:17	Xlab	Xlab Co.,Ltd
 78:30:3B	StephenT	Stephen Technologies Co.,Limited
 78:30:E1	Ultracle	UltraClenz, LLC
 78:31:2B	Zte	zte corporation
 78:31:C1	Apple	Apple, Inc.
 78:32:1B	D-LinkIn	D-Link International
 78:32:4F	Millenni	Millennium Group, Inc.
+78:35:A0	ZurnIndu	Zurn Industries LLC
 78:36:90	YulongCo	Yulong Computer Telecommunication Scientific (Shenzhen) Co.,Ltd
+78:36:CC	Guangdon	Guangdong Oppo Mobile Telecommunications Corp.,Ltd
 78:3A:84	Apple	Apple, Inc.
 78:3C:E3	Kai-Ee
 78:3D:5B	TelnetRe	TELNET Redes Inteligentes S.A.
@@ -26033,6 +27195,7 @@
 78:45:C4	Dell	Dell Inc.
 78:46:C4	DaehapHy	DAEHAP HYPER-TECH
 78:47:1D	SamsungE	Samsung Electronics Co.,Ltd
+78:47:E3	SichuanT	Sichuan Tianyi Comheart Telecom Co.,Ltd
 78:48:59	HewlettP	Hewlett Packard
 78:49:1D	Will-Bur	The Will-Burt Company
 78:4B:08	FRobotic	f.robotics acquisitions ltd
@@ -26040,6 +27203,7 @@
 78:4F:43	Apple	Apple, Inc.
 78:51:0C	Liveu	LiveU Ltd.
 78:52:1A	SamsungE	Samsung Electronics Co.,Ltd
+78:52:4A	Ensenso	Ensenso GmbH
 78:52:62	Shenzhen	Shenzhen Hojy Software Co., Ltd.
 78:53:64	Shift	SHIFT GmbH
 78:53:F2	Roxton	ROXTON Ltd.
@@ -26064,9 +27228,12 @@
 78:6A:89	HuaweiTe	Huawei Technologies Co.,Ltd
 78:6C:1C	Apple	Apple, Inc.
 78:6D:94	PaloAlto	Palo Alto Networks
+78:70:52	Welotec	Welotec GmbH
 78:71:9C	ArrisGro	ARRIS Group, Inc.
+78:72:5D	Cisco	Cisco Systems, Inc
 78:7B:8A	Apple	Apple, Inc.
 78:7D:48	ItelMobi	Itel Mobile Limited
+78:7D:53	Aerohive	Aerohive Networks Inc.
 78:7E:61	Apple	Apple, Inc.
 78:7F:62	GikMbh	GiK mbH
 78:80:38	FunaiEle	Funai Electric Co., Ltd.
@@ -26081,7 +27248,7 @@
 78:8A:20	Ubiquiti	Ubiquiti Networks Inc.
 78:8B:77	StandarT	Standar Telecom
 78:8C:4D	IndymeSo	Indyme Solutions, LLC
-78:8C:54	EltekTec	Eltek Technologies LTD
+78:8C:54	PingComm	Ping Communication
 78:8D:F7	HitronTe	Hitron Technologies. Inc
 78:8E:33	JiangsuS	Jiangsu SEUIC Technology Co.,Ltd
 78:92:3E	Nokia	Nokia Corporation
@@ -26118,11 +27285,13 @@
 78:AC:C0	HewlettP	Hewlett Packard
 78:AE:0C	FarSouth	Far South Networks
 78:AF:58	GimasiSa	Gimasi Sa
+78:AF:E4	ComauSPA	Comau S.p.A
 78:B2:8D	BeijingT	Beijing Tengling Technology CO.Ltd
 78:B3:B9	Shanghai	ShangHai sunup lighting CO.,LTD
 78:B3:CE	EloTouch	Elo touch solutions
 78:B5:D2	EverTrea	Ever Treasure Industrial Limited
 78:B6:C1	AoboTele	AOBO Telecom Co.,Ltd
+78:B6:EC	ScufGami	Scuf Gaming International LLC
 78:B8:1A	InterSal	INTER SALES A/S
 78:B8:4B	SichuanT	Sichuan Tianyi Comheart Telecomco.,Ltd
 78:BA:D0	Shinybow	Shinybow Technology Co. Ltd.
@@ -26178,6 +27347,7 @@
 78:CD:8E	SmcNetwo	SMC Networks Inc
 78:D0:04	NeousysT	Neousys Technology Inc.
 78:D1:29	Vicos
+78:D2:94	Netgear
 78:D3:4F	Pace-O-M	Pace-O-Matic, Inc.
 78:D3:8D	Hongkong	Hongkong Yunlink Technology Limited
 78:D5:B5	Navielek	Navielektro Ky
@@ -26203,6 +27373,7 @@
 78:D8:00:D0:00:00/28	KoreaMic	Korea Micro Wireless Co.,Ltd.
 78:D8:00:E0:00:00/28	ClIntern	CL International
 78:D9:9F	NucomHk	NuCom HK Ltd.
+78:DA:07	Zhejiang	Zhejiang Tmall Technology Co., Ltd.
 78:DA:6E	Cisco	Cisco Systems, Inc
 78:DA:B3	GboTechn	GBO Technology
 78:DD:08	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
@@ -26228,6 +27399,7 @@
 78:F7:D0	Silverbr	Silverbrook Research
 78:F8:82	LgElectr	LG Electronics (Mobile Communications)
 78:F9:44	Private
+78:F9:B4	Nokia
 78:FC:14	FamilyZo	Family Zone Cyber Safety Ltd
 78:FD:94	Apple	Apple, Inc.
 78:FE:3D	JuniperN	Juniper Networks
@@ -26243,6 +27415,7 @@
 7C:01:91	Apple	Apple, Inc.
 7C:02:BC	HansungE	Hansung Electronics Co. LTD
 7C:03:4C	Sagemcom	Sagemcom Broadband SAS
+7C:03:AB	XiaomiCo	Xiaomi Communications Co Ltd
 7C:03:C9	Shenzhen	Shenzhen YOUHUA Technology Co., Ltd
 7C:03:D8	Sagemcom	Sagemcom Broadband SAS
 7C:04:D0	Apple	Apple, Inc.
@@ -26253,6 +27426,7 @@
 7C:09:2B	Bekey	Bekey A/S
 7C:0A:50	J-Mex	J-MEX Inc.
 7C:0B:C6	SamsungE	Samsung Electronics Co.,Ltd
+7C:0C:F6	Guangdon	Guangdong Huiwei High-tech Co., Ltd.
 7C:0E:CE	Cisco	Cisco Systems, Inc
 7C:10:15	Brillian	Brilliant Home Technology, Inc.
 7C:11:BE	Apple	Apple, Inc.
@@ -26271,12 +27445,16 @@
 7C:1E:B3	2nTeleko	2N TELEKOMUNIKACE a.s.
 7C:20:48	Koamtac
 7C:20:64	Alcatel-	Alcatel-Lucent IPD
+7C:24:0C	Telechip	Telechips, Inc.
+7C:25:86	JuniperN	Juniper Networks
 7C:25:87	Chaowifi	chaowifi.com
 7C:26:34	ArrisGro	ARRIS Group, Inc.
 7C:26:64	Sagemcom	Sagemcom Broadband SAS
+7C:2A:31	IntelCor	Intel Corporate
 7C:2B:E1	Shenzhen	Shenzhen Ferex Electrical Co.,Ltd
 7C:2C:F3	SecureEl	Secure Electrans Ltd
 7C:2E:0D	Blackmag	Blackmagic Design
+7C:2E:BD	Google	Google, Inc.
 7C:2E:DD	SamsungE	Samsung Electronics Co.,Ltd
 7C:2F:80	GigasetC	Gigaset Communications GmbH
 7C:33:6E	MegElect	MEG Electronics Inc.
@@ -26288,6 +27466,7 @@
 7C:3B:D5	ImagoGro	Imago Group
 7C:3C:B6	Shenzhen	Shenzhen Homecare Technology Co.,Ltd.
 7C:3E:9D	Patech
+7C:41:A2	Nokia
 7C:43:8F	E-BandCo	E-Band Communications Corp.
 7C:44:4C	Entertai	Entertainment Solutions, S.L.
 7C:46:85	Motorola	Motorola (Wuhan) Mobility Technologies Communication Co., Ltd.
@@ -26308,6 +27487,7 @@
 7C:47:7C:D0:00:00/28	Speedifi	Speedifi Inc
 7C:47:7C:E0:00:00/28	I-Conver	I-Convergence.com
 7C:49:B9	PlexusMa	Plexus Manufacturing Sdn Bhd
+7C:49:EB	XiaomiEl	XIAOMI Electronics,CO.,LTD
 7C:4A:82	Portsmit	Portsmith LLC
 7C:4A:A8	Mindtree	MindTree Wireless PVT Ltd
 7C:4B:78	RedSunSy	Red Sun Synthesis Pte Ltd
@@ -26327,6 +27507,7 @@
 7C:64:56	SamsungE	Samsung Electronics Co.,Ltd
 7C:66:9D	TexasIns	Texas Instruments
 7C:67:A2	IntelCor	Intel Corporate
+7C:69:6B	AtmosicT	Atmosic Technologies
 7C:69:F6	Cisco	Cisco Systems, Inc
 7C:6A:B3	IbcTechn	Ibc Technologies Inc.
 7C:6A:C3	Gatesair	GatesAir, Inc
@@ -26334,10 +27515,12 @@
 7C:6A:F3	Integrat	Integrated Device Technology (Malaysia) Sdn. Bhd.
 7C:6B:33	TenyuTec	Tenyu Tech Co. Ltd.
 7C:6B:52	TigaroWi	Tigaro Wireless
+7C:6B:9C	Guangdon	Guangdong Oppo Mobile Telecommunications Corp.,Ltd
 7C:6B:F7	Nti	NTI co., ltd.
 7C:6C:39	PixsysSr	Pixsys Srl
 7C:6C:8F	AmsNeve	Ams Neve Ltd
 7C:6D:62	Apple	Apple, Inc.
+7C:6D:A6	Superwav	Superwave Group LLC
 7C:6D:F8	Apple	Apple, Inc.
 7C:6F:06	Caterpil	Caterpillar Trimble Control Technologies
 7C:6F:F8	Shenzhen	ShenZhen ACTO Digital Video Technology Co.,Ltd.
@@ -26363,6 +27546,7 @@
 7C:73:8B	CocoonAl	Cocoon Alarm Ltd
 7C:76:30	Shenzhen	Shenzhen YOUHUA Technology Co., Ltd
 7C:76:35	IntelCor	Intel Corporate
+7C:76:68	HuaweiTe	Huawei Technologies Co.,Ltd
 7C:76:73	Enmas	ENMAS GmbH
 7C:78:7E	SamsungE	Samsung Electronics Co.,Ltd
 7C:79:E8	Payrange	PayRange Inc.
@@ -26375,6 +27559,7 @@
 7C:82:2D	Nortec
 7C:82:74	Shenzhen	Shenzhen Hikeen Technology CO.,LTD
 7C:83:06	GlenDimp	Glen Dimplex Nordic as
+7C:8B:B5	SamsungE	Samsung Electronics Co.,Ltd
 7C:8B:CA	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 7C:8D:91	Shanghai	Shanghai Hongzhuo Information Technology co.,LTD
 7C:8E:E4	TexasIns	Texas Instruments
@@ -26382,9 +27567,12 @@
 7C:94:B2	PhilipsH	Philips Healthcare PCCI
 7C:95:B1	Aerohive	Aerohive Networks Inc.
 7C:95:F3	Cisco	Cisco Systems, Inc
+7C:96:D2	Fihonest	Fihonest communication co.,Ltd
 7C:97:63	Openmati	Openmatics s.r.o.
+7C:9A:54	Technico	Technicolor CH USA Inc.
 7C:9A:9B	VseValen	VSE valencia smart energy
 7C:A1:5D	GnResoun	GN ReSound A/S
+7C:A1:77	HuaweiTe	Huawei Technologies Co.,Ltd
 7C:A2:37	KingSlid	King Slide Technology CO., LTD.
 7C:A2:3E	HuaweiTe	Huawei Technologies Co.,Ltd
 7C:A2:9B	DSignt	D.SignT GmbH & Co. KG
@@ -26425,6 +27613,7 @@
 7C:BD:06	AeRefuso	AE REFUsol
 7C:BF:88	Mobilico	Mobilicom LTD
 7C:BF:B1	ArrisGro	ARRIS Group, Inc.
+7C:C3:85	HuaweiTe	Huawei Technologies Co.,Ltd
 7C:C3:A1	Apple	Apple, Inc.
 7C:C4:EF	Devialet
 7C:C5:37	Apple	Apple, Inc.
@@ -26457,7 +27646,7 @@
 7C:CD:3C	Guangzho	Guangzhou Juzing Technology Co., Ltd
 7C:CF:CF	Shanghai	Shanghai SEARI Intelligent System Co., Ltd
 7C:D1:C3	Apple	Apple, Inc.
-7C:D3:0A	Inventec	INVENTEC Corporation
+7C:D3:0A	Inventec	Inventec Corporation
 7C:D7:62	Freestyl	Freestyle Technology Pty Ltd
 7C:D8:44	Enmotus	Enmotus Inc
 7C:D9:FE	NewCosmo	New Cosmos Electric Co., Ltd.
@@ -26493,12 +27682,15 @@
 7C:FE:28	Salutron	Salutron Inc.
 7C:FE:4E	Shenzhen	Shenzhen Safe vision Technology Co.,LTD
 7C:FE:90	Mellanox	Mellanox Technologies, Inc.
+7C:FF:4D	AvmAudio	AVM Audiovisuelles Marketing und Computersysteme GmbH
 7C:FF:62	HuizhouS	Huizhou Super Electron Technology Co.,Ltd.
 80:00:0B	IntelCor	Intel Corporate
 80:00:10	At&T[Mis	AT&T [misrepresented as 080010? One source claims this is correct]
 80:00:6E	Apple	Apple, Inc.
 80:01:84	Htc	HTC Corporation
+80:02:9C	GemtekTe	Gemtek Technology Co., Ltd.
 80:02:DF	Ora	ORA Inc.
+80:05:88	RuijieNe	Ruijie Networks Co.,LTD
 80:05:DF	MontageT	Montage Technology Group Limited
 80:07:A2	EssonTec	Esson Technology Inc.
 80:09:02	Keysight	Keysight Technologies, Inc.
@@ -26539,7 +27731,9 @@
 80:2E:14	AzetiNet	azeti Networks AG
 80:2F:DE	ZurichIn	Zurich Instruments AG
 80:30:DC	TexasIns	Texas Instruments
+80:30:E0	HewlettP	Hewlett Packard Enterprise
 80:34:57	Ot	OT Systems Limited
+80:35:C1	XiaomiCo	Xiaomi Communications Co Ltd
 80:37:73	Netgear
 80:38:96	Sharp	SHARP Corporation
 80:38:BC	HuaweiTe	Huawei Technologies Co.,Ltd
@@ -26547,6 +27741,7 @@
 80:39:E5	Patlite	Patlite Corporation
 80:3A:0A	Integrat	Integrated Device Technology (Malaysia) Sdn. Bhd.
 80:3A:59	At&T
+80:3A:F4	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 80:3B:2A	AbbXiame	ABB Xiamen Low Voltage Equipment Co.,Ltd.
 80:3B:9A	Ghe-CesE	ghe-ces electronic ag
 80:3B:F6	LookEasy	Look Easy International Limited
@@ -26564,6 +27759,7 @@
 80:4F:58	Thinkeco	ThinkEco, Inc.
 80:50:1B	Nokia	Nokia Corporation
 80:50:67	WDTechno	W & D TECHNOLOGY CORPORATION
+80:50:F6	ItelMobi	Itel Mobile Limited
 80:56:F2	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 80:57:19	SamsungE	Samsung Electronics Co.,Ltd
 80:58:C5	NovatecK	NovaTec Kommunikationstechnik GmbH
@@ -26571,6 +27767,7 @@
 80:59:FD	Noviga
 80:5A:04	LgElectr	LG Electronics (Mobile Communications)
 80:5E:0C	YealinkX	YEALINK(XIAMEN) NETWORK TECHNOLOGY CO.,LTD.
+80:5E:4F	Fn-LinkT	FN-LINK TECHNOLOGY LIMITED
 80:5E:C0	YealinkX	YEALINK(XIAMEN) NETWORK TECHNOLOGY CO.,LTD.
 80:60:07	Rim
 80:61:5F	BeijingS	Beijing Sinead Technology Co., Ltd.
@@ -26579,10 +27776,13 @@
 80:65:6D	SamsungE	Samsung Electronics Co.,Ltd
 80:65:E9	Benq	BenQ Corporation
 80:66:29	Prescope	Prescope Technologies CO.,LTD.
+80:69:33	HuaweiTe	Huawei Technologies Co.,Ltd
+80:69:40	Lexar	Lexar Co.,Limited
 80:6A:B0	Shenzhen	Shenzhen TINNO Mobile Technology Corp.
 80:6C:1B	Motorola	Motorola Mobility LLC, a Lenovo Company
 80:6C:8B	KaeserKo	Kaeser Kompressoren Ag
 80:6C:BC	NetNewEl	NET New Electronic Technology GmbH
+80:6F:B0	TexasIns	Texas Instruments
 80:71:1F	JuniperN	Juniper Networks
 80:71:7A	HuaweiTe	Huawei Technologies Co.,Ltd
 80:73:9F	Kyocera	Kyocera Corporation
@@ -26609,9 +27809,11 @@
 80:7B:85:D0:00:00/28	KaynesTe	Kaynes Technology India Pvt Ltd
 80:7B:85:E0:00:00/28	Mersen
 80:7B:85:F0:00:00/28	Private
+80:7D:14	HuaweiTe	Huawei Technologies Co.,Ltd
 80:7D:1B	Neosyste	Neosystem Co. Ltd.
 80:7D:E3	Chongqin	Chongqing Sichuan Instrument Microcircuit Co.LTD.
 80:81:A5	Tongqing	TONGQING COMMUNICATION EQUIPMENT (SHENZHEN) Co.,Ltd
+80:82:23	Apple	Apple, Inc.
 80:82:87	AtcomTec	ATCOM Technology Co.Ltd.
 80:86:98	Netronic	Netronics Technologies Inc.
 80:86:F2	IntelCor	Intel Corporate
@@ -26624,6 +27826,7 @@
 80:92:9F	Apple	Apple, Inc.
 80:93:93	Xapt	Xapt GmbH
 80:94:6C	TokyoRad	Tokyo Radar Corporation
+80:96:21	Lenovo
 80:96:B1	ArrisGro	ARRIS Group, Inc.
 80:96:CA	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 80:97:1B	Altenerg	Altenergy Power System,Inc.
@@ -26633,16 +27836,20 @@
 80:A1:AB	Intellis	Intellisis
 80:A1:D7	Shanghai	Shanghai DareGlobal Technologies Co.,Ltd
 80:A5:89	Azurewav	AzureWave Technology Inc.
+80:A7:96	Neurotek	Neurotek LLC
 80:A8:5D	Osterhou	Osterhout Design Group
 80:AA:A4	Usag
 80:AC:AC	JuniperN	Juniper Networks
 80:AD:00	CnetTech	CNET Technology Inc. (Probably an error, see instead 0080AD)
+80:AD:16	XiaomiCo	Xiaomi Communications Co Ltd
 80:AD:67	KasdaNet	Kasda Networks Inc
 80:B0:3D	Apple	Apple, Inc.
 80:B2:19	Elektron	Elektron Technology Uk Limited
 80:B2:34	Technico	Technicolor CH USA Inc.
 80:B2:89	Forworld	Forworld Electronics Ltd.
-80:B3:2A	AlstomGr	Alstom Grid
+80:B3:2A	UkGridSo	UK Grid Solutions Ltd
+80:B5:75	HuaweiTe	Huawei Technologies Co.,Ltd
+80:B6:24	Ivs
 80:B6:86	HuaweiTe	Huawei Technologies Co.,Ltd
 80:B7:08	BlueDanu	Blue Danube Systems, Inc
 80:B7:09	Viptela	Viptela, Inc
@@ -26659,11 +27866,14 @@
 80:C6:AB	Technico	Technicolor CH USA Inc.
 80:C6:CA	EndianSR	Endian s.r.l.
 80:C7:55	Panasoni	Panasonic Appliances Company
+80:C7:C5	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 80:C8:62	Openpeak	Openpeak, Inc
 80:CE:62	HewlettP	Hewlett Packard
 80:CE:B1	Theissen	Theissen Training Systems GmbH
+80:CE:B9	SamsungE	Samsung Electronics Co.,Ltd
 80:CF:41	LenovoMo	Lenovo Mobile Communication Technology Ltd.
 80:D0:19	Embed	Embed, Inc
+80:D0:65	Cks	CKS Corporation
 80:D0:9B	HuaweiTe	Huawei Technologies Co.,Ltd
 80:D1:60	Integrat	Integrated Device Technology (Malaysia) Sdn. Bhd.
 80:D1:8B	Hangzhou	Hangzhou I'converge Technology Co.,Ltd
@@ -26706,18 +27916,21 @@
 80:F8:EB	Raytight
 80:FA:5B	Clevo	Clevo Co.
 80:FB:06	HuaweiTe	Huawei Technologies Co.,Ltd
+80:FB:F0	QuectelW	Quectel Wireless Solutions Co., Ltd.
 80:FF:A8	Unidis
 84:00:2D	Pegatron	Pegatron Corporation
-84:00:D2	SonyMobi	Sony Mobile Communications AB
+84:00:D2	SonyMobi	Sony Mobile Communications Inc
 84:01:A7	Greyware	Greyware Automation Products, Inc
 84:04:D2	KiraleTe	Kirale Technologies SL
 84:0B:2D	SamsungE	Samsung Electro Mechanics Co., Ltd.
+84:0D:8E	Espressi	Espressif Inc.
 84:0F:45	Shanghai	Shanghai GMT Digital Technologies Co., Ltd
 84:10:0D	Motorola	Motorola Mobility LLC, a Lenovo Company
 84:11:9E	SamsungE	Samsung Electronics Co.,Ltd
 84:16:F9	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 84:17:15	GpElectr	GP Electronics (HK) Ltd.
-84:17:66	WeifangG	Weifang GoerTek Technology Co.,Ltd.
+84:17:66	WeifangG	Weifang Goertek Electronics Co.,Ltd
+84:17:EF	Technico	Technicolor CH USA Inc.
 84:18:26	Osram	Osram GmbH
 84:18:3A	RuckusWi	Ruckus Wireless
 84:18:88	JuniperN	Juniper Networks
@@ -26746,6 +27959,7 @@
 84:2E:27	SamsungE	Samsung Electronics Co.,Ltd
 84:2F:75	InnokasG	Innokas Group
 84:30:E5	Skyhawke	SkyHawke Technologies, LLC
+84:32:6F	Guangzho	Guangzhou Ava Electronics Technology Co.,Ltd
 84:32:EA	AnhuiWan	ANHUI WANZTEN P&T CO., LTD
 84:34:97	HewlettP	Hewlett Packard
 84:36:11	Hyungseu	hyungseul publishing networks
@@ -26790,6 +28004,8 @@
 84:62:A6	EurocbPh	EuroCB (Phils), Inc.
 84:63:D6	Microsof	Microsoft Corporation
 84:68:3E	IntelCor	Intel Corporate
+84:68:78	Apple	Apple, Inc.
+84:6A:66	Sumitomo	Sumitomo Kizai  Co.,Ltd.
 84:6A:ED	Wireless	Wireless Tsukamoto.,co.LTD
 84:6E:B1	ParkAssi	Park Assist LLC
 84:72:07	I&CTechn	I&C Technology
@@ -26806,6 +28022,7 @@
 84:7B:EB	Dell	Dell Inc.
 84:7D:50	HolleyMe	Holley Metering Limited
 84:7E:40	TexasIns	Texas Instruments
+84:7F:3D	Integrat	Integrated Device Technology (Malaysia) Sdn. Bhd.
 84:80:2D	Cisco	Cisco Systems, Inc
 84:82:F4	BeijingH	Beijing Huasun Unicreate Technology Co., Ltd
 84:83:19	Hangzhou	Hangzhou Zero Zero Technology Co., Ltd.
@@ -26816,11 +28033,28 @@
 84:85:0A	HellaSon	Hella Sonnen- und Wetterschutztechnik GmbH
 84:86:F3	Greenvit	Greenvity Communications
 84:89:AD	Apple	Apple, Inc.
+84:89:EC	IeeeRegi	IEEE Registration Authority
+84:89:EC:00:00:00/28	Smartgia	SmartGiant Technology
+84:89:EC:10:00:00/28	Research	Research Electronics International, LLC.
+84:89:EC:20:00:00/28	Thousand	thousand star tech LTD.
+84:89:EC:30:00:00/28	Aerionic	Aerionics Inc.
+84:89:EC:40:00:00/28	VayyarIm	Vayyar Imaging Ltd.
+84:89:EC:50:00:00/28	ZephyrEn	Zephyr Engineering, Inc.
+84:89:EC:60:00:00/28	PoctBiot	POCT biotechnology
+84:89:EC:70:00:00/28	Byda	BYDA Co. Ltd.,
+84:89:EC:80:00:00/28	ArtsDigi	Arts Digital Technology (HK) Ltd.
+84:89:EC:90:00:00/28	Shenzhen	Shenzhen Xtooltech Co., Ltd
+84:89:EC:A0:00:00/28	NewellBr	Newell Brands
+84:89:EC:B0:00:00/28	EpsaElek	EPSa Elektronik & Präzisionsbau Saalfeld GmbH
+84:89:EC:C0:00:00/28	Shinkawa	Shinkawa Ltd.
+84:89:EC:D0:00:00/28	PriceInd	Price Industries Limited
+84:89:EC:E0:00:00/28	Shenzhen	Shenzhen Intellifusion Technologies Co., Ltd.
+84:8A:8D	Cisco	Cisco Systems, Inc
 84:8D:84	Rajant	Rajant Corporation
 84:8D:C7	CiscoSpv	Cisco SPVTG
 84:8E:0C	Apple	Apple, Inc.
 84:8E:96	Embertec	Embertec Pty Ltd
-84:8E:DF	SonyMobi	Sony Mobile Communications AB
+84:8E:DF	SonyMobi	Sony Mobile Communications Inc
 84:8F:69	Dell	Dell Inc.
 84:90:00	ArnoldRi	Arnold & Richter Cine Technik
 84:93:0C	IncoaxNe	InCoax Networks Europe AB
@@ -26835,6 +28069,7 @@
 84:9F:B5	HuaweiTe	Huawei Technologies Co.,Ltd
 84:A1:34	Apple	Apple, Inc.
 84:A1:D1	Sagemcom	Sagemcom Broadband SAS
+84:A2:4D	BirdsEye	Birds Eye Systems Private Limited
 84:A4:23	Sagemcom	Sagemcom Broadband SAS
 84:A4:66	SamsungE	Samsung Electronics Co.,Ltd
 84:A6:C8	IntelCor	Intel Corporate
@@ -26851,6 +28086,7 @@
 84:AF:EC	Buffalo	Buffalo.Inc
 84:B1:53	Apple	Apple, Inc.
 84:B2:61	Cisco	Cisco Systems, Inc
+84:B3:1B	Kinexon	Kinexon GmbH
 84:B5:17	Cisco	Cisco Systems, Inc
 84:B5:41	SamsungE	Samsung Electronics Co.,Ltd
 84:B5:9C	JuniperN	Juniper Networks
@@ -26863,9 +28099,10 @@
 84:C3:E8	Vaillant	Vaillant GmbH
 84:C7:27	Gnodal	Gnodal Ltd
 84:C7:A9	C3poSA	C3PO S.A.
-84:C7:EA	SonyMobi	Sony Mobile Communications AB
+84:C7:EA	SonyMobi	Sony Mobile Communications Inc
 84:C8:B1	Incognit	Incognito Software Systems Inc.
 84:C9:B2	D-LinkIn	D-Link International
+84:C9:C6	Shenzhen	Shenzhen Gongjin Electronics Co.,Lt
 84:CD:62	Shenzhen	ShenZhen IDWELL Technology CO.,Ltd
 84:CF:BF	Fairphon	Fairphone
 84:D3:2A	Ieee1905	IEEE 1905.1
@@ -26875,6 +28112,7 @@
 84:D9:31	Hangzhou	Hangzhou H3C Technologies Co., Limited
 84:D9:C8	Unipatte	Unipattern Co.,
 84:DB:2F	SierraWi	Sierra Wireless Inc
+84:DB:9E	Aifloo	Aifloo AB
 84:DB:AC	HuaweiTe	Huawei Technologies Co.,Ltd
 84:DB:FC	Nokia
 84:DD:20	TexasIns	Texas Instruments
@@ -26902,6 +28140,7 @@
 84:E3:23	GreenWav	Green Wave Telecommunication SDN BHD
 84:E3:27	TailynTe	Tailyn Technologies Inc
 84:E4:D9	Shenzhen	Shenzhen NEED technology Ltd.
+84:E5:D8	Guangdon	Guangdong UNIPOE IoT Technology Co.,Ltd.
 84:E6:29	BluwanSa	Bluwan SA
 84:E7:14	LiangHer	Liang Herng Enterprise,Co.Ltd.
 84:EA:99	Vieworks
@@ -26909,6 +28148,7 @@
 84:ED:33	Bbmc	BBMC Co.,Ltd
 84:EF:18	IntelCor	Intel Corporate
 84:F1:29	Metrasca	Metrascale Inc.
+84:F3:EB	Espressi	Espressif Inc.
 84:F4:93	OmsSpolS	OMS spol. s.r.o.
 84:F6:4C	CrossPoi	Cross Point BV
 84:F6:FA	Miovisio	Miovision Technologies Incorporated
@@ -26916,18 +28156,24 @@
 84:FC:FE	Apple	Apple, Inc.
 84:FE:9E	RtcIndus	RTC Industries, Inc.
 84:FE:DC	BorqsBei	Borqs Beijing Ltd.
+88:01:18	Blt	BLT Co
 88:01:F2	VitecSys	Vitec System Engineering Inc.
 88:03:55	Arcadyan	Arcadyan Technology Corporation
 88:07:4B	LgElectr	LG Electronics (Mobile Communications)
 88:09:05	Mtmcommu	MTMCommunications
+88:09:07	MktSyste	MKT Systemtechnik GmbH & Co. KG
 88:09:AF	Masimo	Masimo Corporation
 88:0F:10	HuamiInf	Huami Information Technology Co.,Ltd.
 88:0F:B6	JabilCir	Jabil Circuits India Pvt Ltd,-EHTP unit
 88:10:36	PanodicS	Panodic(ShenZhen) Electronics Limted
+88:10:8F	HuaweiTe	Huawei Technologies Co.,Ltd
+88:11:96	HuaweiTe	Huawei Technologies Co.,Ltd
 88:12:4E	Qualcomm	Qualcomm Inc.
 88:14:2B	Protonic	Protonic Holland
 88:15:44	CiscoMer	Cisco Meraki
+88:17:A3	Integrat	Integrated Device Technology (Malaysia) Sdn. Bhd.
 88:18:AE	Tamron	Tamron Co., Ltd
+88:19:08	Apple	Apple, Inc.
 88:1B:99	Shenzhen	Shenzhen Xin Fei Jia Electronic Co. Ltd.
 88:1D:FC	Cisco	Cisco Systems, Inc
 88:1F:A1	Apple	Apple, Inc.
@@ -26938,20 +28184,25 @@
 88:25:2C	Arcadyan	Arcadyan Technology Corporation
 88:25:93	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 88:28:B3	HuaweiTe	Huawei Technologies Co.,Ltd
-88:29:50	DalianNe	Dalian Netmoon Tech Develop Co.,Ltd
+88:29:50	NetmoonT	Netmoon Technology Co., Ltd
 88:2B:D7	Addénerg	ADDÉNERGIE  TECHNOLOGIES
+88:2D:53	BaiduOnl	Baidu Online Network Technology (Beijing) Co., Ltd.
 88:2E:5A	Storone
 88:30:8A	MurataMa	Murata Manufacturing Co., Ltd.
 88:32:9B	SamsungE	SAMSUNG ELECTRO-MECHANICS(THAILAND)
 88:33:14	TexasIns	Texas Instruments
 88:33:BE	Ivenix	Ivenix, Inc.
+88:34:FE	BoschAut	Bosch Automotive Products (Suzhou) Co. Ltd
 88:35:4C	Transics
+88:35:C1	OiElectr	Oi Electric Co.,Ltd
 88:36:12	SrcCompu	SRC Computers, LLC
 88:36:5F	LgElectr	LG Electronics (Mobile Communications)
 88:36:6C	EfmNetwo	EFM Networks
 88:3B:8B	Cheering	Cheering Connection Co. Ltd.
 88:3C:1C	Mercury	Mercury Corporation
 88:3D:24	Google	Google, Inc.
+88:3F:4A	TexasIns	Texas Instruments
+88:3F:99	Siemens	Siemens AG
 88:3F:D3	HuaweiTe	Huawei Technologies Co.,Ltd
 88:41:57	Shenzhen	Shenzhen Atsmart Technology Co.,Ltd.
 88:41:C1	OrbisatD	Orbisat Da Amazonia Ind E Aerol Sa
@@ -26991,6 +28242,22 @@
 88:5D:90:E0:00:00/28	UnitacTe	Unitac Technology Limited
 88:5D:90:F0:00:00/28	Private
 88:5D:FB	Zte	zte corporation
+88:5F:E8	IeeeRegi	IEEE Registration Authority
+88:5F:E8:00:00:00/28	Junghein	Jungheinrich Norderstedt AG & Co. KG
+88:5F:E8:10:00:00/28	ApoideaT	Apoidea Technology Co., Ltd.
+88:5F:E8:20:00:00/28	OptoEngi	Opto Engineering
+88:5F:E8:30:00:00/28	SonnetLa	Sonnet Labs Inc.
+88:5F:E8:40:00:00/28	BeijingL	Beijing laiwei Technology  Co.,Ltd
+88:5F:E8:50:00:00/28	HauchBac	Hauch & Bach ApS
+88:5F:E8:60:00:00/28	Shenzhen	Shenzhen Xin Kingbrand Enterprises Co.,Ltd
+88:5F:E8:70:00:00/28	RedTechn	Red Technologies, LLC.
+88:5F:E8:80:00:00/28	Changsha	Changsha Xiangji-Haidun Technology Co., Ltd
+88:5F:E8:90:00:00/28	Sowee
+88:5F:E8:A0:00:00/28	LisleDes	Lisle Design Ltd
+88:5F:E8:B0:00:00/28	Shenzhen	Shenzhen ORVIBO Technology Co., Ltd
+88:5F:E8:C0:00:00/28	InorProc	Inor Process AB
+88:5F:E8:D0:00:00/28	Zhejiang	zhejiang yuanwang communication technolgy co.,ltd
+88:5F:E8:E0:00:00/28	UnicomGl	Unicom Global, Inc.
 88:61:5A	SianoMob	Siano Mobile Silicon Ltd.
 88:63:DF	Apple	Apple, Inc.
 88:66:39	HuaweiTe	Huawei Technologies Co.,Ltd
@@ -27005,6 +28272,7 @@
 88:70:33	Hangzhou	Hangzhou Silan Microelectronic Inc
 88:70:8C	LenovoMo	Lenovo Mobile Communication Technology Ltd.
 88:70:EF	ScProfes	SC Professional Trading Co., Ltd.
+88:71:B1	ArrisGro	ARRIS Group, Inc.
 88:71:E5	AmazonTe	Amazon Technologies Inc.
 88:73:84	Toshiba
 88:73:98	K2eTekpo	K2E Tekpoint
@@ -27035,13 +28303,16 @@
 88:94:7E	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 88:94:F9	GemicomT	Gemicom Technology, Inc.
 88:95:B9	UnifiedP	Unified Packet Systems Crop
+88:96:4E	ArrisGro	ARRIS Group, Inc.
 88:96:76	TtcMarco	TTC MARCONI s.r.o.
 88:96:B6	GlobalFi	Global Fire Equipment S.A.
 88:96:F2	ValeoSch	Valeo Schalter und Sensoren GmbH
+88:97:65	Exands
 88:97:DF	Entrypas	Entrypass Corporation Sdn. Bhd.
 88:98:21	Teraon
 88:9B:39	SamsungE	Samsung Electronics Co.,Ltd
 88:9C:A6	BtbKorea	BTB Korea INC
+88:9F:6F	SamsungE	Samsung Electronics Co.,Ltd
 88:9F:FA	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 88:A0:84	Formatio	Formation Data Systems
 88:A2:5E	JuniperN	Juniper Networks
@@ -27050,9 +28321,26 @@
 88:A5:BD	Qpcom	Qpcom Inc.
 88:A6:C6	Sagemcom	Sagemcom Broadband SAS
 88:A7:3C	Ragentek	Ragentek Technology Group
+88:A9:A7	IeeeRegi	IEEE Registration Authority
+88:A9:A7:00:00:00/28	Shenzhen	Shenzhenshi kechuangzhixian technology Co.LTD
+88:A9:A7:10:00:00/28	Solaredg	Solaredge LTD.
+88:A9:A7:20:00:00/28	Honeywel	Honeywell spol. s.r.o. HTS CZ o.z.
+88:A9:A7:30:00:00/28	Mikroele	Mikroelektronika
+88:A9:A7:40:00:00/28	ThomasDa	Thomas & Darden, Inc
+88:A9:A7:50:00:00/28	Volterma	Volterman Inc.
+88:A9:A7:60:00:00/28	SieperLü	Sieper Lüdenscheid GmbH & Co. KG
+88:A9:A7:70:00:00/28	KimuraGi	kimura giken corporation
+88:A9:A7:80:00:00/28	PsbIntra	psb intralogistics GmbH
+88:A9:A7:90:00:00/28	Flashfor	FlashForge Corporation
+88:A9:A7:A0:00:00/28	Zhejiang	Zhejiang Haoteng Electronic Technology Co.,Ltd.
+88:A9:A7:B0:00:00/28	Twk-Elek	TWK-ELEKTRONIK
+88:A9:A7:C0:00:00/28	Androvid	AndroVideo Inc.
+88:A9:A7:D0:00:00/28	AvlinkIn	Avlink Industrial Co., Ltd
+88:A9:A7:E0:00:00/28	ImpactDi	Impact Distribution
 88:AC:C1	Generito	Generiton Co., Ltd.
 88:AD:43	Pegatron	Pegatron Corporation
 88:AD:D2	SamsungE	Samsung Electronics Co.,Ltd
+88:AE:07	Apple	Apple, Inc.
 88:AE:1D	CompalIn	COMPAL INFORMATION (KUNSHAN) CO., LTD.
 88:B1:11	IntelCor	Intel Corporate
 88:B1:68	DeltaCon	Delta Control GmbH
@@ -27060,12 +28348,14 @@
 88:B3:62	NokiaSha	Nokia Shanghai Bell Co. Ltd.）
 88:B4:A6	Motorola	Motorola Mobility LLC, a Lenovo Company
 88:B6:27	GembirdE	Gembird Europe BV
+88:B6:6B	Easynetw	easynetworks
 88:B6:EE	DishTech	Dish Technologies Corp
 88:B8:D0	Dongguan	Dongguan Koppo Electronic Co.,Ltd
 88:BA:7F	Qfiednet	Qfiednet Co., Ltd.
 88:BD:45	SamsungE	Samsung Electronics Co.,Ltd
 88:BD:78	Flaircom	Flaircomm Microelectronics,Inc.
 88:BF:D5	SimpleAu	Simple Audio Ltd
+88:BF:E4	HuaweiTe	Huawei Technologies Co.,Ltd
 88:C2:42	Poynt	Poynt Co.
 88:C2:55	TexasIns	Texas Instruments
 88:C3:6E	BeijingE	Beijing Ereneben lnformation Technology Limited
@@ -27081,15 +28371,19 @@
 88:D0:39	TclTechn	TCL Technoly Electronics(Huizhou).,Ltd
 88:D1:71	Beghelli	Beghelli S.P.A
 88:D2:74	Zte	zte corporation
+88:D2:BF	GermanAu	German Autolabs
 88:D3:7B	FirmtekL	FirmTek, LLC
 88:D5:0C	Guangdon	Guangdong Oppo Mobile Telecommunications Corp.,Ltd
+88:D6:52	Amergint	AMERGINT Technologies
 88:D7:BC	Dep	DEP Company
 88:D7:F6	AsustekC	ASUSTek COMPUTER INC.
 88:D9:62	CanopusU	Canopus Systems US LLC
 88:DA:1A	RedpineS	Redpine Signals, Inc.
 88:DC:96	SenaoNet	SENAO Networks, Inc.
 88:DD:79	Voltaire
+88:DE:7C	AskeyCom	Askey Computer Corp.
 88:DE:A9	Roku	Roku, Inc.
+88:DF:9E	NewH3cTe	New H3C Technologies Co., Ltd
 88:E0:A0	Shenzhen	Shenzhen VisionSTOR Technologies Co., Ltd
 88:E0:F3	JuniperN	Juniper Networks
 88:E1:61	ArtBeiji	Art Beijing Science and Technology Development Co., Ltd.
@@ -27100,12 +28394,15 @@
 88:E7:A6	Iknowled	iKnowledge Integration Corp.
 88:E8:7F	Apple	Apple, Inc.
 88:E8:F8	YongTaiE	YONG TAI ELECTRONIC (DONGGUAN) LTD.
+88:E9:0F	Innomdle	innomdlelab
 88:E9:17	Tamaggo
+88:E9:FE	Apple	Apple, Inc.
 88:ED:1C	CudoComm	Cudo Communication Co., Ltd.
 88:F0:31	Cisco	Cisco Systems, Inc
 88:F0:77	Cisco	Cisco Systems, Inc
 88:F4:88	CellonCo	cellon communications technology(shenzhen)Co.,Ltd.
 88:F4:90	Jetmobil	Jetmobile Pte Ltd
+88:F7:BF	VivoMobi	vivo Mobile Communication Co., Ltd.
 88:F7:C7	Technico	Technicolor CH USA Inc.
 88:FD:15	Lineeye	Lineeye Co., Ltd
 88:FE:D6	Shanghai	ShangHai WangYong Software Co., Ltd.
@@ -27114,7 +28411,7 @@
 8A:A5:C1	RanovusU	Ranovus USA
 8A:B3:DA	Homeplug	HomePlug Powerline Alliance, Inc.
 8A:C7:2E	Roku	Roku, Inc.
-8A:CB:A4	Honeywel	Honeywell HSG
+8A:CB:A4	Resideo
 8A:DA:26	Eleven	Eleven Inc.
 8C:00:6D	Apple	Apple, Inc.
 8C:04:FF	Technico	Technicolor CH USA Inc.
@@ -27146,6 +28443,8 @@
 8C:14:7D:C0:00:00/28	Reynaers	Reynaers Aluminium
 8C:14:7D:D0:00:00/28	Shenzhen	Shenzhen  Lanxus  technology Co. Ltd.
 8C:14:7D:E0:00:00/28	Electric	Electrical & Automation Larsen & Toubro Limited
+8C:14:B4	Zte	zte corporation
+8C:15:C7	HuaweiTe	Huawei Technologies Co.,Ltd
 8C:16:45	LcfcHefe	LCFC(HeFei) Electronics Technology co., ltd
 8C:18:D9	Shenzhen	Shenzhen RF Technology Co., Ltd
 8C:19:2D	IeeeRegi	IEEE Registration Authority
@@ -27165,6 +28464,22 @@
 8C:19:2D:D0:00:00/28	PyrasTec	Pyras Technology Inc.
 8C:19:2D:E0:00:00/28	Elcon	Elcon AB
 8C:1A:BF	SamsungE	Samsung Electronics Co.,Ltd
+8C:1C:DA	IeeeRegi	IEEE Registration Authority
+8C:1C:DA:00:00:00/28	CeosPty	CEOS Pty Ltd
+8C:1C:DA:10:00:00/28	Gesas	GESAS GmbH
+8C:1C:DA:20:00:00/28	Geomc
+8C:1C:DA:30:00:00/28	Structur	Structura Technology & Innovation
+8C:1C:DA:40:00:00/28	Anntec（B	Anntec （Beijing） Technology Co.,Ltd.
+8C:1C:DA:50:00:00/28	Septentr	Septentrio NV
+8C:1C:DA:60:00:00/28	Locolabs	LocoLabs LLC
+8C:1C:DA:70:00:00/28	KTechnol	K Technology Corporation
+8C:1C:DA:80:00:00/28	AtolLlc	Atol Llc
+8C:1C:DA:90:00:00/28	RaychemR	Raychem RPG PVT. LTD.
+8C:1C:DA:A0:00:00/28	ChinaPot	China Potevio Co., Ltd
+8C:1C:DA:B0:00:00/28	T+AElekt	T+A elektroakustik GmbH & Co.KG
+8C:1C:DA:C0:00:00/28	Alcidae	Alcidae Inc
+8C:1C:DA:D0:00:00/28	RieglLas	Riegl Laser Measurement Systems GmbH
+8C:1C:DA:E0:00:00/28	Electron	Electronic Controlled Systems, Inc.
 8C:1F:94	RfSurgic	RF Surgical System Inc.
 8C:21:0A	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 8C:25:05	HuaweiTe	Huawei Technologies Co.,Ltd
@@ -27177,12 +28492,14 @@
 8C:33:30	Emfirst	EmFirst Co., Ltd.
 8C:33:57	Hitevisi	HiteVision Digital Media Technology Co.,Ltd.
 8C:34:FD	HuaweiTe	Huawei Technologies Co.,Ltd
+8C:35:79	QdiqoSpZ	QDIQO Sp. z o.o.
 8C:39:5C	Bit4idSr	Bit4id Srl
 8C:3A:E3	LgElectr	LG Electronics (Mobile Communications)
 8C:3B:AD	Netgear
 8C:3C:07	SkivaTec	Skiva Technologies, Inc.
 8C:3C:4A	Nakayo	NAKAYO Inc
 8C:41:F2	RdaTechn	RDA Technologies Ltd.
+8C:41:F4	Ipmotion	IPmotion GmbH
 8C:44:35	Shanghai	Shanghai BroadMobi Communication Technology Co., Ltd.
 8C:45:00	MurataMa	Murata Manufacturing Co., Ltd.
 8C:4A:EE	GigaTms	Giga Tms Inc
@@ -27211,11 +28528,13 @@
 8C:60:4F	Cisco	Cisco Systems, Inc
 8C:60:E7	Mpgio	Mpgio Co.,Ltd
 8C:61:02	BeijingB	Beijing Baofengmojing Technologies Co., Ltd
+8C:61:A3	ArrisGro	ARRIS Group, Inc.
 8C:64:0B	BeyondDe	Beyond Devices d.o.o.
-8C:64:22	SonyMobi	Sony Mobile Communications AB
+8C:64:22	SonyMobi	Sony Mobile Communications Inc
 8C:68:78	Nortek-A	Nortek-AS
 8C:6A:E4	Viogem	Viogem Limited
 8C:6D:50	Shenzhen	Shenzhen Mtc Co Ltd
+8C:6D:77	HuaweiTe	Huawei Technologies Co.,Ltd
 8C:70:5A	IntelCor	Intel Corporate
 8C:71:F8	SamsungE	Samsung Electronics Co.,Ltd
 8C:73:6E	Fujitsu	Fujitsu Limited
@@ -27225,16 +28544,20 @@
 8C:78:D7	Shenzhen	Shenzhen Fast Technologies Co.,Ltd
 8C:79:67	Zte	zte corporation
 8C:7B:9D	Apple	Apple, Inc.
+8C:7B:F0	XufengDe	Xufeng Development Limited
 8C:7C:92	Apple	Apple, Inc.
 8C:7C:B5	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 8C:7C:FF	BrocadeC	Brocade Communications Systems, Inc.
 8C:7E:B3	Lytro	Lytro, Inc.
 8C:7F:3B	ArrisGro	ARRIS Group, Inc.
+8C:81:26	Arcom
 8C:82:A8	InsigmaT	Insigma Technology Co.,Ltd
 8C:83:9D	Shenzhen	Shenzhen Xinyupeng Electronic Technology Co., Ltd
+8C:83:E1	SamsungE	Samsung Electronics Co.,Ltd
 8C:84:01	Private
 8C:85:80	SmartInn	Smart Innovation LLC
 8C:85:90	Apple	Apple, Inc.
+8C:85:E6	Cleondri	Cleondris GmbH
 8C:87:3B	LeicaCam	Leica Camera AG
 8C:89:7A	Augtek
 8C:89:A5	Micro-St	Micro-Star INT'L CO., LTD
@@ -27243,10 +28566,12 @@
 8C:8B:83	TexasIns	Texas Instruments
 8C:8E:76	Taskit	taskit GmbH
 8C:8E:F2	Apple	Apple, Inc.
+8C:8F:8B	ChinaMob	China Mobile Chongqing branch
 8C:8F:E9	Apple	Apple, Inc.
 8C:90:D3	Nokia
 8C:91:09	Toyoshim	Toyoshima Electric Technoeogy(Suzhou) Co.,Ltd.
 8C:92:36	AusLinxT	Aus.Linx Technology Co., Ltd.
+8C:92:46	Oerlikon	Oerlikon Textile Gmbh&Co.KG
 8C:93:51	Jigowatt	Jigowatts Inc.
 8C:94:CF	EncellTe	Encell Technology, Inc.
 8C:99:E6	TctMobil	TCT mobile ltd
@@ -27260,6 +28585,7 @@
 8C:AE:4C	Plugable	Plugable Technologies
 8C:AE:89	Y-CamSol	Y-cam Solutions Ltd
 8C:B0:94	AirtechI	Airtech I&C Co., Ltd
+8C:B0:E9	SamsungE	Samsung Electronics.,LTD
 8C:B6:4F	Cisco	Cisco Systems, Inc
 8C:B7:F7	Shenzhen	Shenzhen UniStrong Science & Technology Co., Ltd
 8C:B8:2C	IpitomyC	IPitomy Communications
@@ -27315,7 +28641,7 @@
 8C:EB:C6	HuaweiTe	Huawei Technologies Co.,Ltd
 8C:EC:4B	Dell	Dell Inc.
 8C:EE:C6	Precepsc	Precepscion Pty. Ltd.
-8C:F2:28	Shenzhen	Shenzhen Mercury Communication Technologies Co.,Ltd.
+8C:F2:28	MercuryC	Mercury Communication Technologies Co.,Ltd.
 8C:F5:A3	SamsungE	SAMSUNG ELECTRO-MECHANICS(THAILAND)
 8C:F7:10	AmpakTec	AMPAK Technology, Inc.
 8C:F7:73	Nokia
@@ -27324,7 +28650,10 @@
 8C:F9:57	Ruixingh	RuiXingHengFang Network (Shenzhen) Co.,Ltd
 8C:F9:C9	MesadaTe	MESADA Technology Co.,Ltd.
 8C:FA:BA	Apple	Apple, Inc.
+8C:FC:A0	Shenzhen	Shenzhen Smart Device Technology Co., LTD.
 8C:FD:F0	Qualcomm	Qualcomm Inc.
+8C:FE:57	Apple	Apple, Inc.
+8C:FE:74	RuckusWi	Ruckus Wireless
 8C:FE:B4	Vsoontec	Vsoontech Electronics Co., Limited
 90:00:4E	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 90:00:DB	SamsungE	Samsung Electronics Co.,Ltd
@@ -27332,6 +28661,7 @@
 90:02:8A	Shenzhen	Shenzhen Shidean Legrand Electronic Products Co.,Ltd
 90:02:A9	Zhejiang	Zhejiang Dahua Technology Co., Ltd.
 90:03:25	HuaweiTe	Huawei Technologies Co.,Ltd
+90:03:72	LongnanJ	Longnan Junya Digital Technology Co. Ltd.
 90:03:B7	ParrotSa	Parrot Sa
 90:06:28	SamsungE	Samsung Electronics Co.,Ltd
 90:09:17	Far-Sigh	Far-sighted mobile
@@ -27343,6 +28673,7 @@
 90:0D:66	Digimore	Digimore Electronics Co., Ltd
 90:0D:CB	ArrisGro	ARRIS Group, Inc.
 90:0E:83	MonicoMo	Monico Monitoring, Inc.
+90:0E:B3	Shenzhen	Shenzhen Amediatech Technology Co., Ltd.
 90:17:11	HagenukM	Hagenuk Marinekommunikation GmbH
 90:17:9B	Nanomega	Nanomegas
 90:17:AC	HuaweiTe	Huawei Technologies Co.,Ltd
@@ -27362,6 +28693,7 @@
 90:23:EC	Availink	Availink, Inc.
 90:27:E4	Apple	Apple, Inc.
 90:2B:34	Giga-Byt	GIGA-BYTE TECHNOLOGY CO.,LTD.
+90:2B:D2	HuaweiTe	Huawei Technologies Co.,Ltd
 90:2C:C7	C-MaxAsi	C-MAX Asia Limited
 90:2E:1C	IntelCor	Intel Corporate
 90:2E:87	Labjack
@@ -27378,6 +28710,7 @@
 90:3C:92	Apple	Apple, Inc.
 90:3C:AE	YunnanKs	Yunnan KSEC Digital Technology Co.,Ltd.
 90:3D:5A	Shenzhen	Shenzhen Wision Technology Holding Limited
+90:3D:68	G-Printe	G-Printec, Inc.
 90:3D:6B	ZiconTec	Zicon Technology Corp.
 90:3D:BD	SecureMe	Secure Meters Limited
 90:3E:AB	ArrisGro	ARRIS Group, Inc.
@@ -27387,6 +28720,7 @@
 90:47:16	Rorze	Rorze Corporation
 90:48:9A	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 90:49:FA	IntelCor	Intel Corporate
+90:4C:81	HewlettP	Hewlett Packard Enterprise
 90:4C:E5	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 90:4D:4A	Sagemcom	Sagemcom Broadband SAS
 90:4E:2B	HuaweiTe	Huawei Technologies Co.,Ltd
@@ -27421,6 +28755,7 @@
 90:60:F1	Apple	Apple, Inc.
 90:61:0C	FidaInte	Fida International (S) Pte Ltd
 90:61:AE	IntelCor	Intel Corporate
+90:63:3B	SamsungE	Samsung Electronics Co.,Ltd
 90:67:17	AlphionI	Alphion India Private Limited
 90:67:1C	HuaweiTe	Huawei Technologies Co.,Ltd
 90:67:B5	Alcatel-	Alcatel-Lucent
@@ -27435,6 +28770,7 @@
 90:70:65	TexasIns	Texas Instruments
 90:72:40	Apple	Apple, Inc.
 90:72:82	Sagemcom	Sagemcom Broadband SAS
+90:79:10	Integrat	Integrated Device Technology (Malaysia) Sdn. Bhd.
 90:79:90	Benchmar	Benchmark Electronics Romania SRL
 90:7A:0A	GebrBode	Gebr. Bode GmbH & Co KG
 90:7A:28	BeijingM	Beijing Morncloud Information And Technology Co. Ltd.
@@ -27442,6 +28778,7 @@
 90:7E:BA	UtekTech	UTEK TECHNOLOGY (SHENZHEN) CO.,LTD
 90:7F:61	ChiconyE	Chicony Electronics Co., Ltd.
 90:82:60	Ieee1904	IEEE 1904.1 Working Group
+90:83:4B	BeijingY	Beijing Yunyi Times Technology Co,.Ltd
 90:83:7A	GeneralE	General Electric Water & Process Technologies
 90:84:0D	Apple	Apple, Inc.
 90:84:2B	LegoSyst	LEGO System A/S
@@ -27458,6 +28795,7 @@
 90:90:3C	TrisonTe	Trison Technology Corporation
 90:90:60	RsiVideo	Rsi Video Technologies
 90:92:B4	DiehlBgt	Diehl BGT Defence GmbH & Co. KG
+90:94:97	HuaweiTe	Huawei Technologies Co.,Ltd
 90:94:E4	D-LinkIn	D-Link International
 90:97:D5	Espressi	Espressif Inc.
 90:97:F3	SamsungE	Samsung Electronics Co.,Ltd
@@ -27467,6 +28805,7 @@
 90:9D:E0	NewlandD	Newland Design + Assoc. Inc.
 90:9F:33	EfmNetwo	EFM Networks
 90:9F:43	Accutron	Accutron Instruments Inc.
+90:A1:37	BeijingS	Beijing Splendidtel Communication Technology Co,. Ltd
 90:A2:10	UnitedTe	United Telecoms Ltd
 90:A2:DA	GheoSa	Gheo Sa
 90:A3:65	HmdGloba	HMD Global Oy
@@ -27487,9 +28826,10 @@
 90:B8:D0	Joyent	Joyent, Inc.
 90:B9:31	Apple	Apple, Inc.
 90:B9:7D	JohnsonO	Johnson Outdoors Marine Electronics d/b/a Minnkota
-90:C1:15	SonyMobi	Sony Mobile Communications AB
+90:C1:15	SonyMobi	Sony Mobile Communications Inc
 90:C1:C6	Apple	Apple, Inc.
 90:C3:5F	NanjingJ	Nanjing Jiahao Technology Co., Ltd.
+90:C5:4A	VivoMobi	vivo Mobile Communication Co., Ltd.
 90:C6:82	IeeeRegi	IEEE Registration Authority
 90:C6:82:00:00:00/28	Shenzhen	Shenzhen Lencotion Technology Co.,Ltd
 90:C6:82:10:00:00/28	Shenzhen	Shenzhen Photon Broadband Technology CO., LTD
@@ -27509,7 +28849,7 @@
 90:C6:82:F0:00:00/28	Private
 90:C7:92	ArrisGro	ARRIS Group, Inc.
 90:C7:D8	Zte	zte corporation
-90:C9:9B	Recore	Recore Systems
+90:C9:9B	Tesorion	Tesorion Nederland B.V.
 90:CC:24	Synaptic	Synaptics, Inc
 90:CD:B6	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 90:CF:15	Nokia	Nokia Corporation
@@ -27525,11 +28865,14 @@
 90:DA:4E	Avanu
 90:DA:6A	FocusH&S	FOCUS H&S Co., Ltd.
 90:DB:46	E-LeadEl	E-LEAD ELECTRONIC CO., LTD
+90:DD:5D	Apple	Apple, Inc.
 90:DF:B7	SMSSmart	s.m.s smart microwave sensors GmbH
 90:DF:FB	Homeride	Homerider Systems
 90:E0:F0	Ieee1722	IEEE 1722a Working Group
+90:E1:7B	Apple	Apple, Inc.
 90:E2:BA	IntelCor	Intel Corporate
 90:E6:BA	AsustekC	ASUSTek COMPUTER INC.
+90:E7:10	NewH3cTe	New H3C Technologies Co., Ltd
 90:E7:C4	Htc	HTC Corporation
 90:EA:60	SpiLaser	SPI Lasers Ltd
 90:EC:50	COBO	C.O.B.O. Spa
@@ -27565,12 +28908,14 @@
 94:14:7A	VivoMobi	vivo Mobile Communication Co., Ltd.
 94:16:73	PointCor	Point Core SARL
 94:18:82	HewlettP	Hewlett Packard Enterprise
+94:19:3A	Elvaco	Elvaco AB
 94:1D:1C	TlabWest	TLab West Systems AB
 94:20:53	Nokia	Nokia Corporation
 94:21:97	Stalmart	Stalmart Technology Limited
 94:23:6E	Shenzhen	Shenzhen Junlan Electronic Ltd
 94:28:2E	NewH3cTe	New H3C Technologies Co., Ltd
 94:29:0C	Shenyang	Shenyang wisdom Foundation Technology Development Co., Ltd.
+94:29:8D	Shanghai	Shanghai AdaptComm Technology Co., Ltd.
 94:2A:3F	Diversey	Diversey Inc
 94:2C:B3	Humax	HUMAX Co., Ltd.
 94:2E:17	Schneide	Schneider Electric Canada Inc
@@ -27591,7 +28936,8 @@
 94:46:96	Baudtec	BaudTec Corporation
 94:49:96	Wisilica	WiSilica Inc
 94:4A:09	BitwiseC	BitWise Controls
-94:4A:0C	Sercomm	Sercomm Corporation
+94:4A:0C	Sercomm	Sercomm Corporation.
+94:4F:4C	SoundUni	Sound United LLC
 94:50:47	Rechnerb	Rechnerbetriebsgruppe
 94:50:89	Simonsvo	SimonsVoss Technologies GmbH
 94:51:03	SamsungE	Samsung Electronics Co.,Ltd
@@ -27611,6 +28957,7 @@
 94:65:2D	OneplusT	OnePlus Technology (Shenzhen) Co., Ltd
 94:65:9C	IntelCor	Intel Corporate
 94:66:E7	WomEngin	WOM Engineering
+94:6A:B0	Arcadyan	Arcadyan Corporation
 94:70:D2	WinfirmT	Winfirm Technology
 94:71:AC	TctMobil	TCT mobile ltd
 94:75:6E	QinetiqN	QinetiQ North America
@@ -27625,27 +28972,34 @@
 94:86:CD	SeoulEle	SEOUL ELECTRONICS&TELECOM
 94:86:D4	Surveill	Surveillance Pro Corporation
 94:87:7C	ArrisGro	ARRIS Group, Inc.
+94:87:E0	XiaomiCo	Xiaomi Communications Co Ltd
 94:88:15	Infiniqu	Infinique Worldwide Inc
 94:88:54	TexasIns	Texas Instruments
 94:88:5E	Surfilte	Surfilter Network Technology Co., Ltd.
 94:8B:03	EagetInn	EAGET Innovation and Technology Co., Ltd.
 94:8B:C1	SamsungE	Samsung Electronics Co.,Ltd
 94:8D:50	BeamexOy	Beamex Oy Ab
+94:8D:EF	OetikerS	Oetiker Schweiz AG
 94:8E:89	Industri	Industrias Unidas Sa De Cv
 94:8F:EE	VerizonT	Verizon Telematics
+94:91:7F	AskeyCom	Askey Computer Corp
 94:92:BC	SyntechH	SYNTECH(HK) TECHNOLOGY LIMITED
 94:94:26	Apple	Apple, Inc.
 94:95:A0	Google	Google, Inc.
 94:98:A2	Shanghai	Shanghai LISTEN TECH.LTD
 94:99:01	Shenzhen	Shenzhen YITOA Digital Appliance CO.,LTD
+94:99:90	VtcTelec	VTC Telecommunications
 94:9A:A9	Microsof	Microsoft Corporation
+94:9B:2C	ExtremeN	Extreme Networks, Inc.
 94:9B:FD	TransNew	Trans New Technology, Inc.
 94:9C:55	AltaData	Alta Data Technologies
+94:9D:57	Panasoni	Panasonic do Brasil Limitada
 94:9F:3E	Sonos	Sonos, Inc.
 94:9F:3F	OptekDig	Optek Digital Technology company limited
 94:9F:B4	ChengduJ	ChengDu JiaFaAnTai Technology Co.,Ltd
 94:A0:4E	BostexTe	Bostex Technology Co., LTD
 94:A1:A2	AmpakTec	AMPAK Technology, Inc.
+94:A3:CA	Konnecto	KonnectONE, LLC
 94:A7:B7	Zte	zte corporation
 94:A7:BC	Bodymedi	BodyMedia, Inc.
 94:AA:B8	JoviewBe	Joview(Beijing) Technology Co. Ltd.
@@ -27657,17 +29011,19 @@
 94:B2:CC	Pioneer	Pioneer Corporation
 94:B4:0F	ArubaNet	Aruba Networks
 94:B8:19	Nokia
+94:B8:6D	IntelCor	Intel Corporate
 94:B8:C5	Ruggedco	RuggedCom Inc.
 94:B9:B4	AptosTec	Aptos Technology
 94:BA:31	Visionte	Visiontec da Amazônia Ltda.
 94:BA:56	Shenzhen	Shenzhen Coship Electronics Co., Ltd.
 94:BB:AE	Husqvarn	Husqvarna AB
 94:BF:1E	Eflow/Sm	eflow Inc. / Smart Device Planning and Development Division
+94:BF:2D	Apple	Apple, Inc.
 94:BF:95	Shenzhen	Shenzhen Coship Electronics Co., Ltd
 94:C0:14	SorterSp	Sorter Sp. j. Konrad Grzeszczyk MichaA, Ziomek
 94:C0:38	TallacNe	Tallac Networks
 94:C1:50	2wire	2Wire Inc
-94:C3:E4	ScaSchuc	SCA Schucker Gmbh & Co KG
+94:C3:E4	AtlasCop	Atlas Copco IAS GmbH
 94:C4:E9	Powerlay	PowerLayer Microsystems HongKong Limited
 94:C6:91	Elitegro	EliteGroup Computer Systems Co., LTD
 94:C6:EB	NovaElec	NOVA electronics, Inc.
@@ -27677,7 +29033,7 @@
 94:CA:0F	Honeywel	Honeywell Analytics
 94:CC:B9	ArrisGro	ARRIS Group, Inc.
 94:CD:AC	Creowave	Creowave Oy
-94:CE:2C	SonyMobi	Sony Mobile Communications AB
+94:CE:2C	SonyMobi	Sony Mobile Communications Inc
 94:CE:31	Cts	CTS Limited
 94:D0:19	Cydle	Cydle Corp.
 94:D0:29	Guangdon	Guangdong Oppo Mobile Telecommunications Corp.,Ltd
@@ -27698,6 +29054,7 @@
 94:DF:4E	WistronI	Wistron InfoComm(Kunshan)Co.,Ltd.
 94:DF:58	IjElectr	IJ Electron CO.,Ltd.
 94:E0:D0	Healthst	HealthStream Taiwan Inc.
+94:E1:AC	Hangzhou	Hangzhou Hikvision Digital Technology Co.,Ltd.
 94:E2:26	DOrtizCo	D. ORtiz Consulting, LLC
 94:E2:FD	BogeKomp	Boge Kompressoren OTTO Boge GmbH & Co. KG
 94:E3:6D	TexasIns	Texas Instruments
@@ -27707,6 +29064,7 @@
 94:E9:6A	Apple	Apple, Inc.
 94:E9:79	LiteonTe	Liteon Technology Corporation
 94:E9:8C	Nokia
+94:EA:EA	Tellesco	Tellescom Industria E Comercio Em Telecomunicacao
 94:EB:2C	Google	Google, Inc.
 94:EB:CD	Blackber	BlackBerry RTS
 94:F1:28	HewlettP	Hewlett Packard Enterprise
@@ -27747,6 +29105,7 @@
 98:02:D8:D0:00:00/28	Promicon	Promicon Elektronik GmbH + Co.KG
 98:02:D8:E0:00:00/28	Private
 98:02:D8:F0:00:00/28	Private
+98:03:9B	Mellanox	Mellanox Technologies, Inc.
 98:03:A0	AbbNVPow	ABB n.v. Power Quality Products
 98:03:D8	Apple	Apple, Inc.
 98:07:2D	TexasIns	Texas Instruments
@@ -27757,7 +29116,9 @@
 98:10:94	Shenzhen	Shenzhen Vsun communication technology Co.,ltd
 98:10:E8	Apple	Apple, Inc.
 98:13:33	Zte	zte corporation
+98:14:D2	Avonic
 98:16:EC	IcIntrac	IC Intracom
+98:18:88	CiscoMer	Cisco Meraki
 98:1D:FA	SamsungE	Samsung Electronics Co.,Ltd
 98:1E:0F	JeelanSh	Jeelan (Shanghai Jeelan Technology Information Inc
 98:1F:B1	Shenzhen	Shenzhen Lemon Network Technology Co.,Ltd
@@ -27782,10 +29143,12 @@
 98:37:13	PtNavico	PT.Navicom Indonesia
 98:39:8E	SamsungE	Samsung Electronics Co.,Ltd
 98:3B:16	AmpakTec	AMPAK Technology, Inc.
+98:3B:8F	IntelCor	Intel Corporate
 98:3F:9F	ChinaSsj	China SSJ (Suzhou) Network Technology Inc.
 98:40:BB	Dell	Dell Inc.
 98:42:46	SolIndus	Sol Industry Pte., Ltd
 98:43:DA	Intertec	Intertech
+98:45:62	Shanghai	Shanghai Baud Data Communication Co.,Ltd.
 98:47:3C	Shanghai	Shanghai Sunmon Communication Technogy Co.,Ltd
 98:4A:47	ChgHospi	CHG Hospital Beds
 98:4B:4A	ArrisGro	ARRIS Group, Inc.
@@ -27803,6 +29166,7 @@
 98:5B:B0	Kmdata	Kmdata Inc.
 98:5C:93	SbgSas	SBG Systems SAS
 98:5D:46	Peoplene	PeopleNet Communication
+98:5D:82	AristaNe	Arista Networks
 98:5D:AD	TexasIns	Texas Instruments
 98:5E:1B	Conversd	ConversDigital Co., Ltd.
 98:5F:D3	Microsof	Microsoft Corporation
@@ -27847,6 +29211,7 @@
 98:8B:AD	Corintec	Corintech Ltd.
 98:8E:34	Zhejiang	Zhejiang Boxsam Electronic Co.,Ltd
 98:8E:4A	NoxusBei	NOXUS(BEIJING) TECHNOLOGY CO.,LTD
+98:8E:D4	ItelMobi	Itel Mobile Limited
 98:8E:DD	TeConnec	TE Connectivity Limerick
 98:90:80	Linkpowe	Linkpower Network System Inc Ltd.
 98:90:96	Dell	Dell Inc.
@@ -27855,6 +29220,7 @@
 98:97:D1	Mitrasta	MitraStar Technology Corp.
 98:9C:57	HuaweiTe	Huawei Technologies Co.,Ltd
 98:9E:63	Apple	Apple, Inc.
+98:A4:04	Ericsson	Ericsson AB
 98:A4:0E	Snap	Snap, Inc.
 98:A7:B0	McstZao	Mcst Zao
 98:AA:3C	WillI-Te	Will i-tech Co., Ltd.
@@ -27875,10 +29241,12 @@
 98:AA:FC:C0:00:00/28	Dots	dots Inc.
 98:AA:FC:D0:00:00/28	McsMicro	MCS Micronic Computer Systeme GmbH
 98:AA:FC:E0:00:00/28	ComarchS	Comarch S.A.
+98:AE:71	VvdnTech	VVDN Technologies Pvt Ltd
 98:B0:39	Nokia
 98:B6:E9	Nintendo	Nintendo Co.,Ltd
 98:B8:E3	Apple	Apple, Inc.
 98:BB:1E	BydPreci	BYD Precision Manufacture Company Ltd.
+98:BB:99	PhicommS	Phicomm (Sichuan) Co.,Ltd.
 98:BC:57	SvaTechn	Sva Technologies Co.Ltd
 98:BC:99	Edeltech	Edeltech Co.,Ltd.
 98:BE:94	Ibm
@@ -27892,9 +29260,11 @@
 98:D2:93	Google	Google, Inc.
 98:D3:31	Shenzhen	Shenzhen Bolutek Technology Co.,Ltd.
 98:D3:D2	MekraLan	MEKRA Lang GmbH & Co. KG
+98:D3:E7	NetafimL	Netafim L
 98:D6:86	ChyiLeeI	Chyi Lee industry Co., ltd.
 98:D6:BB	Apple	Apple, Inc.
 98:D6:F7	LgElectr	LG Electronics (Mobile Communications)
+98:D8:63	Shanghai	Shanghai High-Flying Electronics Technology Co., Ltd
 98:D8:8C	NortelNe	Nortel Networks
 98:DA:92	Vuzix	Vuzix Corporation
 98:DC:D9	Unitec	UNITEC Co., Ltd.
@@ -27908,6 +29278,7 @@
 98:E7:F5	HuaweiTe	Huawei Technologies Co.,Ltd
 98:E8:48	Axiim
 98:EC:65	CosesyAp	Cosesy ApS
+98:ED:5C	TeslaMot	Tesla Motors, Inc
 98:EE:CB	WistronI	Wistron Infocomm (Zhongshan) Corporation
 98:EF:9B	Ohsung
 98:F0:58	Lynxspri	Lynxspring, Incl.
@@ -27942,12 +29313,14 @@
 9C:04:EB	Apple	Apple, Inc.
 9C:06:1B	Hangzhou	Hangzhou H3C Technologies Co., Limited
 9C:06:6E	HyteraCo	Hytera Communications Corporation Limited
+9C:0C:DF	Guangdon	Guangdong Oppo Mobile Telecommunications Corp.,Ltd
 9C:0D:AC	Tymphany	Tymphany HK Limited
 9C:0E:4A	Shenzhen	Shenzhen Vastking Electronic Co.,Ltd.
 9C:13:AB	ChansonW	Chanson Water Co., Ltd.
 9C:14:65	EdataEle	Edata Elektronik San. ve Tic. A.Ş.
 9C:18:74	NokiaDan	Nokia Danmark A/S
 9C:1C:12	ArubaNet	Aruba Networks
+9C:1D:36	HuaweiTe	Huawei Technologies Co.,Ltd
 9C:1D:58	TexasIns	Texas Instruments
 9C:1E:95	Actionte	Actiontec Electronics, Inc
 9C:1F:DD	Accupix	Accupix Inc.
@@ -27960,6 +29333,8 @@
 9C:29:3F	Apple	Apple, Inc.
 9C:2A:70	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 9C:2A:83	SamsungE	Samsung Electronics Co.,Ltd
+9C:2E:A1	XiaomiCo	Xiaomi Communications Co Ltd
+9C:2F:73	Universa	Universal Tiancheng Technology (Beijing) Co., Ltd.
 9C:30:5B	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 9C:30:66	RweEffiz	RWE Effizienz GmbH
 9C:31:78	FoshanHu	Foshan Huadian Intelligent Communications Teachnologies Co.,Ltd
@@ -28009,10 +29384,11 @@
 9C:55:B4	ISESRL	I.S.E. S.r.l.
 9C:57:11	FeitianX	Feitian Xunda(Beijing) Aeronautical Information Technology Co., Ltd.
 9C:57:AD	Cisco	Cisco Systems, Inc
+9C:5A:44	CompalIn	COMPAL INFORMATION (KUNSHAN) CO., LTD.
 9C:5B:96	Nmr	NMR Corporation
 9C:5C:8D	FiremaxI	FIREMAX INDÚSTRIA E COMÉRCIO DE PRODUTOS ELETRÔNICOS  LTDA
 9C:5C:8E	AsustekC	ASUSTek COMPUTER INC.
-9C:5C:F9	SonyMobi	Sony Mobile Communications AB
+9C:5C:F9	SonyMobi	Sony Mobile Communications Inc
 9C:5D:12	Aerohive	Aerohive Networks Inc.
 9C:5D:95	VtcElect	VTC Electronics Corp.
 9C:5E:73	CalibreU	Calibre UK LTD
@@ -28029,6 +29405,7 @@
 9C:6A:BE	QeesAps	QEES ApS.
 9C:6C:15	Microsof	Microsoft Corporation
 9C:6F:52	Zte	zte corporation
+9C:71:3A	HuaweiTe	Huawei Technologies Co.,Ltd
 9C:74:1A	HuaweiTe	Huawei Technologies Co.,Ltd
 9C:75:14	WildixSr	Wildix srl
 9C:77:AA	Nadasnv
@@ -28036,6 +29413,7 @@
 9C:7A:03	Ciena	Ciena Corporation
 9C:7B:D2	NeolabCo	NEOLAB Convergence
 9C:7D:A3	HuaweiTe	Huawei Technologies Co.,Ltd
+9C:7F:57	UnicMemo	UNIC Memory Technology Co Ltd
 9C:80:7D	Syscable	SYSCABLE Korea Inc.
 9C:80:DF	Arcadyan	Arcadyan Technology Corporation
 9C:83:BF	Pro-Visi	PRO-VISION, Inc.
@@ -28065,10 +29443,13 @@
 9C:A1:34	Nike	Nike, Inc.
 9C:A3:A9	Guangzho	Guangzhou Juan Optical and Electronical Tech Joint Stock Co., Ltd
 9C:A3:BA	SakuraIn	SAKURA Internet Inc.
+9C:A5:25	Shandong	Shandong USR IOT Technology Limited
 9C:A5:77	OsornoEn	Osorno Enterprises Inc.
 9C:A5:C0	VivoMobi	vivo Mobile Communication Co., Ltd.
+9C:A6:15	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 9C:A6:9D	WhaleyTe	Whaley Technology Co.Ltd
 9C:A9:E4	Zte	zte corporation
+9C:AA:1B	Microsof	Microsoft Corporation
 9C:AC:6D	Universa	Universal Electronics, Inc.
 9C:AD:97	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 9C:AD:EF	ObihaiTe	Obihai Technology, Inc.
@@ -28091,6 +29472,8 @@
 9C:C7:A6	Avm	AVM GmbH
 9C:C7:D1	Sharp	SHARP Corporation
 9C:C8:AE	BectonDi	Becton, Dickinson  and Company
+9C:C8:FC	ArrisGro	ARRIS Group, Inc.
+9C:C9:50	Baumer	Baumer Holding
 9C:CA:D9	Nokia	Nokia Corporation
 9C:CC:83	JuniperN	Juniper Networks
 9C:CD:82	ChengUei	Cheng Uei Precision Industry Co.,Ltd
@@ -28115,8 +29498,11 @@
 9C:E3:3F	Apple	Apple, Inc.
 9C:E3:74	HuaweiTe	Huawei Technologies Co.,Ltd
 9C:E6:35	Nintendo	Nintendo Co., Ltd.
+9C:E6:5E	Apple	Apple, Inc.
 9C:E6:E7	SamsungE	Samsung Electronics Co.,Ltd
 9C:E7:BD	Windusko	Winduskorea co., Ltd
+9C:E8:2B	VivoMobi	vivo Mobile Communication Co., Ltd.
+9C:E8:95	NewH3cTe	New H3C Technologies Co., Ltd
 9C:E9:51	Shenzhen	Shenzhen Sang Fei Consumer Communications Ltd., Co.
 9C:EB:E8	BizlinkK	BizLink (Kunshan) Co.,Ltd
 9C:EF:D5	PandaWir	Panda Wireless, Inc.
@@ -28124,12 +29510,29 @@
 9C:F4:8E	Apple	Apple, Inc.
 9C:F6:1A	UtcFireA	UTC Fire and Security
 9C:F6:7D	RicardoP	Ricardo Prague, s.r.o.
+9C:F6:DD	IeeeRegi	IEEE Registration Authority
+9C:F6:DD:00:00:00/28	Annapurn	annapurnalabs
+9C:F6:DD:10:00:00/28	IthorIt	Ithor IT Co.,Ltd.
+9C:F6:DD:20:00:00/28	BeijingS	Beijing Sifang Automation Co., Ltd.
+9C:F6:DD:30:00:00/28	RyeexTec	RYEEX Technology Co.,Ltd.
+9C:F6:DD:40:00:00/28	CapitalE	Capital Engineering & Research Incorporation Ltd.
+9C:F6:DD:50:00:00/28	B8ta	b8ta Inc.
+9C:F6:DD:60:00:00/28	Shenzhen	Shenzhen Xtooltech Co., Ltd
+9C:F6:DD:70:00:00/28	KxtTechn	KXT Technology Co., Ltd.
+9C:F6:DD:80:00:00/28	Savari	Savari Inc
+9C:F6:DD:90:00:00/28	Cama（Luo	CAMA（Luoyang）Electronics Co.，Ltd
+9C:F6:DD:A0:00:00/28	AviPty	AVI Pty Ltd
+9C:F6:DD:B0:00:00/28	Guangzho	Guangzhou LANGO Electronics Technology Co., Ltd.
+9C:F6:DD:C0:00:00/28	Lighting	Lighting New Energy Technology Co., Ltd.
+9C:F6:DD:D0:00:00/28	FoshanSy	Foshan Synwit Technology Co.,Ltd.
+9C:F6:DD:E0:00:00/28	ShanxiZh	Shanxi ZhuoZhi fei High Electronic Technology Co. Ltd.
 9C:F8:DB	Shenzhen	shenzhen eyunmei technology co,.ltd
 9C:F9:38	ArevaNp	AREVA NP GmbH
 9C:FB:D5	VivoMobi	vivo Mobile Communication Co., Ltd.
 9C:FB:F1	Mesomati	MESOMATIC GmbH & Co.KG
 9C:FC:01	Apple	Apple, Inc.
 9C:FC:D1	Aetheris	Aetheris Technology (Shanghai) Co., Ltd.
+9C:FE:A1	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 9C:FF:BE	Otsl	OTSL Inc.
 A0:02:DC	AmazonTe	Amazon Technologies Inc.
 A0:03:63	RobertBo	Robert Bosch Healthcare GmbH
@@ -28154,6 +29557,22 @@ A0:16:5C	Triteka	Triteka LTD
 A0:18:28	Apple	Apple, Inc.
 A0:18:59	Shenzhen	Shenzhen Yidashi Electronics Co Ltd
 A0:19:17	BertelSP	Bertel S.p.a.
+A0:19:B2	IeeeRegi	IEEE Registration Authority
+A0:19:B2:00:00:00/28	VastProd	Vast Production Services
+A0:19:B2:10:00:00/28	ElSewedy	El Sewedy Electrometer Egypt S.A.E.
+A0:19:B2:20:00:00/28	BeijingD	Beijing Deephi Intelligent Technology Co., Ltd
+A0:19:B2:30:00:00/28	PowerDia	Power Diagnostic Service Co., LTD.
+A0:19:B2:40:00:00/28	Osatec
+A0:19:B2:50:00:00/28	SzbroadT	SZBROAD   TECHNOLOGY (HK) CO.,LTMITED
+A0:19:B2:60:00:00/28	GfgMbh	GfG mbH
+A0:19:B2:70:00:00/28	ArimaCom	ARIMA Communications Corp.
+A0:19:B2:80:00:00/28	MisIndus	MIS Industrie Systeme GmbH & Co. KG
+A0:19:B2:90:00:00/28	LonMicro	Lon Microsystems Inc.
+A0:19:B2:A0:00:00/28	Adomi
+A0:19:B2:B0:00:00/28	Hangzhou	HangZhou iMagic Technology Co., Ltd
+A0:19:B2:C0:00:00/28	LdaTechn	LDA Technologies
+A0:19:B2:D0:00:00/28	RydElect	RYD Electronic Technology Co.,Ltd.
+A0:19:B2:E0:00:00/28	AhgoraSi	Ahgora Sistemas SA
 A0:1B:29	Sagemcom	Sagemcom Broadband SAS
 A0:1C:05	NimaxTel	Nimax Telecom Co.,Ltd.
 A0:1D:48	HewlettP	Hewlett Packard
@@ -28163,6 +29582,22 @@ A0:21:95	SamsungE	Samsung Electronics Co.,Ltd
 A0:21:B7	Netgear
 A0:23:1B	Telecomp	TeleComp R&D Corp.
 A0:23:9F	Cisco	Cisco Systems, Inc
+A0:28:33	IeeeRegi	IEEE Registration Authority
+A0:28:33:00:00:00/28	Gersys	GERSYS GmbH
+A0:28:33:10:00:00/28	Ordercub	Ordercube GmbH
+A0:28:33:20:00:00/28	Shanghai	Shanghai Nohmi Secom Fire Protection  Equipment Co.,Ltd.
+A0:28:33:30:00:00/28	Shanghai	Shanghai Xuntai Information Technology Co.,Ltd.
+A0:28:33:40:00:00/28	FirmInfo	Firm INFORMTEST Ltd.
+A0:28:33:50:00:00/28	JgrOptic	JGR Optics Inc
+A0:28:33:60:00:00/28	XiamenCa	Xiamen Caimore Communication Technology Co.,Ltd.
+A0:28:33:70:00:00/28	KryptusI	Kryptus Information Security S/A
+A0:28:33:80:00:00/28	HzhyTech	Hzhy Technology
+A0:28:33:90:00:00/28	Imeshx	Imeshx Corporation Limited
+A0:28:33:A0:00:00/28	MedicalE	Medical Evolution Kft
+A0:28:33:B0:00:00/28	Flexlink	FlexLink AB
+A0:28:33:C0:00:00/28	KalraySA	Kalray S.A.
+A0:28:33:D0:00:00/28	Audix
+A0:28:33:E0:00:00/28	Precisio	Precision Planting, LLC.
 A0:2B:B8	HewlettP	Hewlett Packard
 A0:2C:36	Fn-LinkT	FN-LINK TECHNOLOGY LIMITED
 A0:2E:F3	UnitedIn	United Integrated Services Co., Led.
@@ -28171,6 +29606,7 @@ A0:34:1B	Trackr	TrackR, Inc
 A0:36:9F	IntelCor	Intel Corporate
 A0:36:F0	Comprehe	Comprehensive Power
 A0:36:FA	EttusRes	Ettus Research LLC
+A0:38:F8	OuraHeal	OURA Health Oy
 A0:39:EE	Sagemcom	Sagemcom Broadband SAS
 A0:39:F7	LgElectr	LG Electronics (Mobile Communications)
 A0:3A:75	PssBelgi	PSS Belgium N.V.
@@ -28212,6 +29648,8 @@ A0:51:C6	Avaya	Avaya Inc
 A0:55:4F	Cisco	Cisco Systems, Inc
 A0:55:DE	ArrisGro	ARRIS Group, Inc.
 A0:56:B2	Harman/B	Harman/Becker Automotive Systems GmbH
+A0:56:F3	Apple	Apple, Inc.
+A0:57:E3	HuaweiTe	Huawei Technologies Co.,Ltd
 A0:59:3A	VDSVideo	V.D.S. Video Display Systems srl
 A0:5A:A4	GrandPro	Grand Products Nevada, Inc.
 A0:5B:21	Envinet	ENVINET GmbH
@@ -28222,6 +29660,7 @@ A0:60:90	SamsungE	Samsung Electronics Co.,Ltd
 A0:63:91	Netgear
 A0:64:8F	AskeyCom	Askey Computer Corp
 A0:65:18	VnptTech	Vnpt Technology
+A0:66:10	Fujitsu	Fujitsu Limited
 A0:67:BE	SiconSrl	Sicon srl
 A0:69:86	WellavTe	Wellav Technologies Ltd
 A0:6A:00	Verilink	Verilink Corporation
@@ -28237,6 +29676,7 @@ A0:72:E4	NjSystem	Nj System Co.,Ltd
 A0:73:32	Cashmast	Cashmaster International Limited
 A0:73:FC	RancoreT	Rancore Technologies Private Limited
 A0:75:91	SamsungE	Samsung Electronics Co.,Ltd
+A0:75:EA	Boxlock	BoxLock, Inc.
 A0:77:71	VialisBv	Vialis BV
 A0:78:BA	Pantech	Pantech Co., Ltd.
 A0:82:1F	SamsungE	Samsung Electronics Co.,Ltd
@@ -28260,7 +29700,8 @@ A0:90:DE	VeedimsL	Veedims,Llc
 A0:91:69	LgElectr	LG Electronics (Mobile Communications)
 A0:91:C8	Zte	zte corporation
 A0:93:47	Guangdon	Guangdong Oppo Mobile Telecommunications Corp.,Ltd
-A0:95:0C	ChinaMob	China Mobile IOTCompany Limited
+A0:93:51	Cisco	Cisco Systems, Inc
+A0:95:0C	ChinaMob	China Mobile IOT Company Limited
 A0:98:05	OpenvoxC	OpenVox Communication Co Ltd
 A0:98:ED	Shandong	Shandong Intelligent Optical Communication Development Co., Ltd.
 A0:99:9B	Apple	Apple, Inc.
@@ -28274,6 +29715,7 @@ A0:A1:30	DliTaiwa	DLI Taiwan Branch office
 A0:A2:3C	Gpms
 A0:A3:3B	HuaweiTe	Huawei Technologies Co.,Ltd
 A0:A3:E2	Actionte	Actiontec Electronics, Inc
+A0:A4:C5	IntelCor	Intel Corporate
 A0:A6:5C	Supercom	Supercomputing Systems AG
 A0:A7:63	Polytron	Polytron Vertrieb GmbH
 A0:A8:CD	IntelCor	Intel Corporate
@@ -28281,10 +29723,12 @@ A0:AA:FD	Erathink	EraThink Technologies Corp.
 A0:AB:1B	D-LinkIn	D-Link International
 A0:AD:A1	JmrElect	JMR Electronics, Inc
 A0:AF:BD	IntelCor	Intel Corporate
+A0:B0:45	HalongMi	Halong Mining
 A0:B1:00	Shenzhen	ShenZhen Cando Electronics Co.,Ltd
 A0:B3:CC	HewlettP	Hewlett Packard
 A0:B4:37	GdMissio	GD Mission Systems
 A0:B4:A5	SamsungE	Samsung Electronics Co.,Ltd
+A0:B5:49	Arcadyan	Arcadyan Corporation
 A0:B5:DA	Hongkong	HongKong THTF Co., Ltd
 A0:B6:62	Acutvist	Acutvista Innovation Co., Ltd.
 A0:B8:F8	AmgenUSA	Amgen U.S.A. Inc.
@@ -28316,7 +29760,7 @@ A0:C4:A5	SygnHous	Sygn House Co.,Ltd
 A0:C5:62	ArrisGro	ARRIS Group, Inc.
 A0:C5:89	IntelCor	Intel Corporate
 A0:C5:F2	IeeeRegi	IEEE Registration Authority
-A0:C5:F2:00:00:00/28	Private
+A0:C5:F2:00:00:00/28	Quantlab	Quantlab Financial, LLC
 A0:C5:F2:10:00:00/28	KnsGroup	KNS Group LLC (YADRO Company)
 A0:C5:F2:20:00:00/28	Speedgoa	Speedgoat GmbH
 A0:C5:F2:30:00:00/28	Shenzhen	Shenzhen Feima Robotics Technology Co.,Ltd
@@ -28341,6 +29785,7 @@ A0:D1:2A	AxproTec	AXPRO Technology Inc.
 A0:D3:7A	IntelCor	Intel Corporate
 A0:D3:85	AumaRies	AUMA Riester GmbH & Co. KG
 A0:D3:C1	HewlettP	Hewlett Packard
+A0:D6:35	WbsTechn	WBS Technology
 A0:D7:95	Apple	Apple, Inc.
 A0:D8:6F	Private
 A0:DA:92	NanjingG	Nanjing Glarun Atten Technology Co. Ltd.
@@ -28352,10 +29797,11 @@ A0:E0:AF	Cisco	Cisco Systems, Inc
 A0:E2:01	AvtraceC	AVTrace Ltd.(China)
 A0:E2:5A	AmicusSk	Amicus SK, s.r.o.
 A0:E2:95	DatSyste	DAT System Co.,Ltd
-A0:E4:53	SonyMobi	Sony Mobile Communications AB
+A0:E4:53	SonyMobi	Sony Mobile Communications Inc
 A0:E4:CB	ZyxelCom	Zyxel Communications Corporation
 A0:E5:34	StratecB	Stratec Biomedical AG
 A0:E5:E9	Enimai	enimai Inc
+A0:E6:17	Matis
 A0:E6:F8	TexasIns	Texas Instruments
 A0:E9:DB	NingboFr	Ningbo FreeWings Technologies Co.,Ltd
 A0:EB:76	Aircuve	AirCUVE Inc.
@@ -28406,10 +29852,11 @@ A4:11:63:B0:00:00/28	MoogMusi	Moog Music Inc.
 A4:11:63:C0:00:00/28	Viloc
 A4:11:63:D0:00:00/28	Shenzhen	Shenzhen Zhishi Technology Co., Ltd.
 A4:11:63:E0:00:00/28	Tinylogi	tinylogics
+A4:11:94	Lenovo
 A4:12:42	NecPlatf	NEC Platforms, Ltd.
 A4:13:4E	Luxul
 A4:14:37	Hangzhou	Hangzhou Hikvision Digital Technology Co.,Ltd.
-A4:15:66	WeifangG	Weifang GoerTek Technology Co.,Ltd.
+A4:15:66	WeifangG	Weifang Goertek Electronics Co.,Ltd
 A4:15:88	ArrisGro	ARRIS Group, Inc.
 A4:17:31	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 A4:18:75	Cisco	Cisco Systems, Inc
@@ -28420,6 +29867,8 @@ A4:23:05	OpenNetw	Open Networking Laboratory
 A4:24:B3	Flatfrog	FlatFrog Laboratories AB
 A4:24:DD	Cambrion	Cambrionix Ltd
 A4:25:1B	Avaya	Avaya Inc
+A4:26:18	Integrat	Integrated Device Technology (Malaysia) Sdn. Bhd.
+A4:26:55	LtiMotio	LTI Motion (Shanghai) Co., Ltd.
 A4:29:40	Shenzhen	Shenzhen YOUHUA Technology Co., Ltd
 A4:29:83	BoeingDe	Boeing Defence Australia
 A4:29:B7	Bluesky
@@ -28429,10 +29878,13 @@ A4:2C:08	Masterwo	Masterwork Automodules
 A4:31:11	Ziv
 A4:31:35	Apple	Apple, Inc.
 A4:33:D1	Fibrlink	Fibrlink Communications Co.,Ltd.
+A4:33:D7	Mitrasta	MitraStar Technology Corp.
 A4:34:12	ThalesAl	Thales Alenia Space
 A4:34:D9	IntelCor	Intel Corporate
 A4:34:F1	TexasIns	Texas Instruments
+A4:35:23	Guangdon	Guangdong Donyan Network Technologies Co.,Ltd.
 A4:38:31	RfElemen	RF elements s.r.o.
+A4:38:CC	Nintendo	Nintendo Co.,Ltd
 A4:38:FC	PlasticL	Plastic Logic
 A4:3A:69	Vers	Vers Inc
 A4:3B:FA	IeeeRegi	IEEE Registration Authority
@@ -28481,13 +29933,15 @@ A4:4F:29:C0:00:00/28	Shenzhen	Shenzhen Huadoo Bright Group Limitied
 A4:4F:29:D0:00:00/28	Hallibur	Halliburton
 A4:4F:29:E0:00:00/28	NeotechP	Neotech Systems Pvt. Ltd.
 A4:4F:29:F0:00:00/28	Private
-A4:50:55	BuswareD	busware.de
+A4:50:46	XiaomiCo	Xiaomi Communications Co Ltd
+A4:50:55	BuswareD	Busware.De
 A4:51:6F	Microsof	Microsoft Mobile Oy
 A4:52:6F	AdbBroad	ADB Broadband Italia
-A4:53:85	WeifangG	Weifang GoerTek Technology Co.,Ltd.
+A4:53:85	WeifangG	Weifang Goertek Electronics Co.,Ltd
 A4:56:02	Fenglian	fenglian Technology Co.,Ltd.
 A4:56:1B	Mcot	MCOT Corporation
 A4:56:30	Cisco	Cisco Systems, Inc
+A4:56:CC	Technico	Technicolor CH USA Inc.
 A4:58:0F	IeeeRegi	IEEE Registration Authority
 A4:58:0F:00:00:00/28	Innopro
 A4:58:0F:10:00:00/28	StoneLoc	Stone Lock Global, Inc.
@@ -28511,6 +29965,7 @@ A4:5D:A1	AdbBroad	ADB Broadband Italia
 A4:5E:60	Apple	Apple, Inc.
 A4:60:11	Verifone
 A4:60:32	MrvCommu	MRV Communications (Networks) LTD
+A4:61:91	Namjunsa
 A4:62:DF	DsGlobal	DS Global. Co., LTD
 A4:67:06	Apple	Apple, Inc.
 A4:68:BC	Private
@@ -28544,12 +29999,15 @@ A4:8D:3B	Vizio	Vizio, Inc
 A4:8E:0A	DelavalI	DeLaval International AB
 A4:90:05	ChinaGre	China Greatwall Computer Shenzhen Co.,Ltd
 A4:91:B1	Technico	Technicolor
+A4:92:CB	Nokia
+A4:93:3F	HuaweiTe	Huawei Technologies Co.,Ltd
 A4:93:4C	Cisco	Cisco Systems, Inc
 A4:97:BB	HitachiI	Hitachi Industrial Equipment Systems Co.,Ltd
 A4:99:47	HuaweiTe	Huawei Technologies Co.,Ltd
 A4:99:81	FujianEl	FuJian Elite Power Tech CO.,LTD.
 A4:9A:58	SamsungE	Samsung Electronics Co.,Ltd
 A4:9B:13	DigitalC	Digital Check
+A4:9B:4F	HuaweiTe	Huawei Technologies Co.,Ltd
 A4:9B:F5	Hybridse	Hybridserver Tec GmbH
 A4:9D:49	Ketra	Ketra, Inc.
 A4:9E:DB	Autocrib	AutoCrib, Inc.
@@ -28577,6 +30035,7 @@ A4:B9:80	ParkingB	Parking BOXX Inc.
 A4:BA:76	HuaweiTe	Huawei Technologies Co.,Ltd
 A4:BA:DB	Dell	Dell Inc.
 A4:BB:AF	LimeInst	Lime Instruments
+A4:BE:2B	HuaweiTe	Huawei Technologies Co.,Ltd
 A4:BE:61	Eutrovis	EutroVision System, Inc.
 A4:BF:01	IntelCor	Intel Corporate
 A4:C0:C7	Shenzhen	ShenZhen Hitom Communication Technology Co..LTD
@@ -28599,7 +30058,26 @@ A4:D4:B2	Shenzhen	Shenzhen MeiG Smart Technology Co.,Ltd
 A4:D5:78	TexasIns	Texas Instruments
 A4:D8:56	Gimbal	Gimbal, Inc
 A4:D8:CA	HongKong	Hong Kong Water World Technology Co. Limited
+A4:D9:31	Apple	Apple, Inc.
+A4:D9:90	SamsungE	Samsung Electronics Co.,Ltd
 A4:D9:A4	NexusIdS	neXus ID Solutions AB
+A4:DA:22	IeeeRegi	IEEE Registration Authority
+A4:DA:22:00:00:00/28	GeneralE	General Electric Company
+A4:DA:22:10:00:00/28	T2tSyste	T2T System
+A4:DA:22:20:00:00/28	WyzeLabs	Wyze Labs Inc
+A4:DA:22:30:00:00/28	Duratech	DURATECH Enterprise,LLC
+A4:DA:22:40:00:00/28	Loriot	Loriot Ag
+A4:DA:22:50:00:00/28	Original	Original Products Pvt. Ltd.
+A4:DA:22:60:00:00/28	Auranext
+A4:DA:22:70:00:00/28	HydroEle	Hydro Electronic Devices, Inc.
+A4:DA:22:80:00:00/28	Solidpro	SolidPro Technology Corporation
+A4:DA:22:90:00:00/28	MalldonT	Malldon Technology Limited
+A4:DA:22:A0:00:00/28	Abetechs	Abetechs GmbH
+A4:DA:22:B0:00:00/28	Klashwer	Klashwerks Inc.
+A4:DA:22:C0:00:00/28	EhoLink	Eho.Link
+A4:DA:22:D0:00:00/28	ShenZhen	Shen Zhen City YaKun Electronics Co., Ltd
+A4:DA:22:E0:00:00/28	QuuppaOy	Quuppa Oy
+A4:DA:32	TexasIns	Texas Instruments
 A4:DA:3F	Bionics	Bionics Corp.
 A4:DB:2E	Kingspan	Kingspan Environmental Ltd
 A4:DB:30	LiteonTe	Liteon Technology Corporation
@@ -28611,13 +30089,31 @@ A4:E3:2E	SiliconS	Silicon & Software Systems Ltd.
 A4:E3:91	DenyFont	Deny Fontaine
 A4:E4:B8	Blackber	BlackBerry RTS
 A4:E5:97	Gessler	Gessler GmbH
+A4:E6:15	Shenzhen	SHENZHEN CHUANGWEI-RGB ELECTRONICS CO.,LTD
 A4:E6:B1	Shanghai	Shanghai Joindata Technology Co.,Ltd.
 A4:E7:31	Nokia	Nokia Corporation
 A4:E7:E4	Connex	Connex GmbH
 A4:E9:75	Apple	Apple, Inc.
 A4:E9:91	Sistemas	Sistemas Audiovisuales Itelsis S.L.
 A4:E9:A3	HonestTe	Honest Technology Co., Ltd
+A4:EA:8E	ExtremeN	Extreme Networks, Inc.
 A4:EB:D3	SamsungE	Samsung Electronics Co.,Ltd
+A4:ED:43	IeeeRegi	IEEE Registration Authority
+A4:ED:43:00:00:00/28	Sweam	Sweam AB
+A4:ED:43:10:00:00/28	Ingelabs	Ingelabs S.L.
+A4:ED:43:20:00:00/28	Shanghai	Shanghai Mission Information Technologies (Group) Co.,Ltd
+A4:ED:43:30:00:00/28	Dongguan	Dongguan Mingji Electronics technology Group Co., Ltd.
+A4:ED:43:40:00:00/28	NetasTel	Netas Telekomunikasyon A.S.
+A4:ED:43:50:00:00/28	BeijingI	Beijing ICPC CO.,Ltd.
+A4:ED:43:60:00:00/28	Shanghai	Shanghai  Facom  Electronics Technology  Co, ltd.
+A4:ED:43:70:00:00/28	WuxiJunc	Wuxi Junction Infomation Technology Incorporated Company
+A4:ED:43:80:00:00/28	LinseisM	Linseis Messgeraete GmbH
+A4:ED:43:90:00:00/28	HeyuanIn	Heyuan intelligence technology CO.,Ltd
+A4:ED:43:A0:00:00/28	Guangzho	Guangzhou Maxfaith Communication Technology Co.,LTD.
+A4:ED:43:B0:00:00/28	ParagonB	Paragon Business Solutions Ltd.
+A4:ED:43:C0:00:00/28	Leaksmar	leakSMART
+A4:ED:43:D0:00:00/28	BrandNew	Brand New Brand Nordic AB
+A4:ED:43:E0:00:00/28	ToecTech	TOEC TECHNOLOGY CO.，LTD.
 A4:ED:4E	ArrisGro	ARRIS Group, Inc.
 A4:EE:57	SeikoEps	Seiko Epson Corporation
 A4:EF:52	Telewave	Telewave Co., Ltd.
@@ -28628,12 +30124,15 @@ A4:F4:C2	VnptTech	Vnpt Technology
 A4:F5:22	ChofuSei	Chofu Seisakusho Co.,Ltd
 A4:F7:D0	LanAcces	LAN Accessories Co., Ltd.
 A4:FB:8D	Hangzhou	Hangzhou Dunchong Technology Co.Ltd
+A4:FC:77	MegaWell	Mega Well Limited
 A4:FC:CE	Security	Security Expert Ltd.
+A8:01:6D	Aiwa	Aiwa Corporation
 A8:01:80	ImagoTec	IMAGO Technologies GmbH
 A8:06:00	SamsungE	Samsung Electronics Co.,Ltd
 A8:0C:0D	Cisco	Cisco Systems, Inc
 A8:0C:63	HuaweiTe	Huawei Technologies Co.,Ltd
 A8:0C:CA	Shenzhen	Shenzhen Sundray Technologies Company Limited
+A8:10:87	TexasIns	Texas Instruments
 A8:11:FC	ArrisGro	ARRIS Group, Inc.
 A8:13:74	Panasoni	Panasonic Corporation AVC Networks Company
 A8:15:4D	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
@@ -28650,15 +30149,35 @@ A8:1D:16	Azurewav	AzureWave Technology Inc.
 A8:1E:84	QuantaCo	Quanta Computer Inc.
 A8:1F:AF	KryptonP	Krypton Polska
 A8:20:66	Apple	Apple, Inc.
+A8:23:FE	LgElectr	LG Electronics
 A8:24:EB	ZaoNpoIn	ZAO NPO Introtest
 A8:25:EB	Cambridg	Cambridge Industries(Group) Co.,Ltd.
 A8:26:D9	Htc	HTC Corporation
 A8:29:4C	Precisio	Precision Optical Transceivers, Inc.
 A8:2B:B5	Edgecore	Edgecore Networks Corporation
+A8:2B:B9	SamsungE	Samsung Electronics Co.,Ltd
 A8:2B:D6	ShinaSys	Shina System Co., Ltd
-A8:30:AD	WeifangG	Weifang GoerTek Technology Co.,Ltd.
+A8:30:AD	WeifangG	Weifang Goertek Electronics Co.,Ltd
 A8:32:9A	DigicomF	Digicom Futuristic Technologies Ltd.
+A8:36:7A	Frogblue	frogblue TECHNOLOGY GmbH
 A8:39:44	Actionte	Actiontec Electronics, Inc
+A8:3E:0E	HmdGloba	HMD Global Oy
+A8:3F:A1	IeeeRegi	IEEE Registration Authority
+A8:3F:A1:00:00:00/28	ImeconEn	Imecon Engineering SrL
+A8:3F:A1:10:00:00/28	Gtdevice	GTDevice LLC
+A8:3F:A1:20:00:00/28	Medcapta	Medcaptain Medical Technology Co., Ltd.
+A8:3F:A1:30:00:00/28	Guangzho	Guangzhou Tupu Internet Technology Co., Ltd.
+A8:3F:A1:40:00:00/28	Zhejiang	Zhejiang Wellsun Intelligent Technology Co.,Ltd.
+A8:3F:A1:50:00:00/28	Sercomm	Sercomm Corporation.
+A8:3F:A1:60:00:00/28	Beglec
+A8:3F:A1:70:00:00/28	Plejd	Plejd AB
+A8:3F:A1:80:00:00/28	NeosVent	Neos Ventures Limited
+A8:3F:A1:90:00:00/28	Shenzhen	Shenzhen ITLONG Intelligent Technology Co.,Ltd
+A8:3F:A1:A0:00:00/28	Shanghai	Shanghai East China Computer Co., Ltd
+A8:3F:A1:B0:00:00/28	ExelSRLU	Exel s.r.l. unipersonale
+A8:3F:A1:C0:00:00/28	Laonz	Laonz Co.,Ltd
+A8:3F:A1:D0:00:00/28	Shenzhen	Shenzhen BIO I/E Co.,Ltd
+A8:3F:A1:E0:00:00/28	Guangzho	Guangzhou Navigateworx Technologies Co., Limited
 A8:40:41	DraginoT	Dragino Technology Co., Limited
 A8:44:81	Nokia	Nokia Corporation
 A8:45:CD	Siselect	Siselectron Technology LTD.
@@ -28671,12 +30190,15 @@ A8:54:B2	WistronN	Wistron Neweb Corporation
 A8:55:6A	Pocketne	Pocketnet Technology Inc.
 A8:57:4E	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 A8:58:40	Cambridg	Cambridge Industries(Group) Co.,Ltd.
+A8:5A:F3	Shanghai	Shanghai Siflower Communication Technology Co., Ltd
+A8:5B:6C	RobertBo	Robert Bosch Gmbh, CM-CI2
 A8:5B:78	Apple	Apple, Inc.
 A8:5B:B0	Shenzhen	Shenzhen Dehoo Technology Co.,Ltd
 A8:5B:F3	Audivo	Audivo GmbH
 A8:5C:2C	Apple	Apple, Inc.
 A8:5E:E4	12sidedT	12Sided Technology, LLC
 A8:60:B6	Apple	Apple, Inc.
+A8:61:0A	Arduino	Arduino Ag
 A8:61:AA	Cloudvie	Cloudview Limited
 A8:62:A2	Jiwumedi	Jiwumedia Co., Ltd.
 A8:63:DF	Displair	Displaire Corporation
@@ -28696,6 +30218,7 @@ A8:75:E2	Aventura	Aventura Technologies, Inc.
 A8:77:6F	Zonoff
 A8:7B:39	Nokia	Nokia Corporation
 A8:7C:01	SamsungE	Samsung Electronics Co.,Ltd
+A8:7D:12	HuaweiTe	Huawei Technologies Co.,Ltd
 A8:7E:33	NokiaDan	Nokia Danmark A/S
 A8:80:38	Shenzhen	ShenZhen MovingComm Technology Co., Limited
 A8:81:95	SamsungE	Samsung Electronics Co.,Ltd
@@ -28704,12 +30227,14 @@ A8:82:00	HisenseE	Hisense Electric Co.,Ltd
 A8:82:7F	CibnOrie	CIBN Oriental Network(Beijing) CO.,Ltd
 A8:86:DD	Apple	Apple, Inc.
 A8:87:92	Broadban	Broadband Antenna Tracking Systems
+A8:87:B3	SamsungE	Samsung Electronics Co.,Ltd
 A8:87:ED	ArcWirel	ARC Wireless LLC
 A8:88:08	Apple	Apple, Inc.
 A8:8C:EE	Micromad	MicroMade Galka i Drozdz sp.j.
 A8:8D:7B	Sundroid	SunDroid Global limited.
 A8:8E:24	Apple	Apple, Inc.
 A8:90:08	BeijingY	Beijing Yuecheng Technology Co. Ltd.
+A8:90:42	BeijingW	Beijing Wanwei Intelligent Technology Co., Ltd.
 A8:92:2C	LgElectr	LG Electronics (Mobile Communications)
 A8:93:52	Shanghai	Shanghai Zhongmi Communication Technology Co.,Ltd
 A8:93:E6	JiangxiJ	Jiangxi Jinggangshan Cking Communication Technology Co.,Ltd
@@ -28719,6 +30244,8 @@ A8:96:8A	Apple	Apple, Inc.
 A8:97:DC	Ibm
 A8:98:C6	Shinbo	Shinbo Co., Ltd.
 A8:99:5C	Aizo	aizo ag
+A8:99:69	Dell	Dell Inc.
+A8:9A:93	Sagemcom	Sagemcom Broadband SAS
 A8:9B:10	Inmotion	inMotion Ltd.
 A8:9D:21	Cisco	Cisco Systems, Inc
 A8:9D:D2	Shanghai	Shanghai DareGlobal Technologies Co.,Ltd
@@ -28738,6 +30265,7 @@ A8:B8:6E	LgElectr	LG Electronics (Mobile Communications)
 A8:B9:B3	Essys
 A8:BB:50	WizIot	WiZ IoT Company Limited
 A8:BB:CF	Apple	Apple, Inc.
+A8:BC:9C	CloudLig	Cloud Light Technology Limited
 A8:BD:1A	HoneyBee	Honey Bee (Hong Kong) Limited
 A8:BD:27	HewlettP	Hewlett Packard Enterprise
 A8:BD:3A	Unionman	Unionman Technology Co.,Ltd
@@ -28746,6 +30274,7 @@ A8:C2:22	Tm-Resea	TM-Research Inc.
 A8:C8:3A	HuaweiTe	Huawei Technologies Co.,Ltd
 A8:C8:7F	Roqos	Roqos, Inc.
 A8:CA:7B	HuaweiTe	Huawei Technologies Co.,Ltd
+A8:CA:B9	SamsungE	Samsung Electro Mechanics Co., Ltd.
 A8:CB:95	EastBest	East Best Co., Ltd.
 A8:CC:C5	SaabPubl	Saab AB (publ)
 A8:CE:90	Cvc
@@ -28755,12 +30284,15 @@ A8:D2:36	Lightwar	Lightware Visual Engineering
 A8:D3:C8	TopconEl	Topcon Electronics GmbH & Co. KG
 A8:D3:F7	Arcadyan	Arcadyan Technology Corporation
 A8:D4:09	Usa111	USA 111 Inc
+A8:D4:98	AviraOpe	Avira Operations GmbH & Co. KG
 A8:D5:79	BeijingC	Beijing Chushang Science and Technology Co.,Ltd
 A8:D8:28	Ascensia	Ascensia Diabetes Care
 A8:D8:8A	Wyconn
+A8:DA:01	Shenzhen	Shenzhen NUOLIJIA Digital Technology Co.,Ltd
 A8:E0:18	Nokia	Nokia Corporation
 A8:E3:EE	SonyInte	Sony Interactive Entertainment Inc.
 A8:E5:39	Moimston	Moimstone Co.,Ltd
+A8:E5:52	JuwelAqu	JUWEL Aquarium AG & Co. KG
 A8:E7:05	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 A8:E8:24	InimElec	Inim Electronics S.R.L.
 A8:EE:C6	Muuselab	Muuselabs NV/SA
@@ -28768,6 +30300,7 @@ A8:EF:26	Tritonwa	Tritonwave
 A8:F0:38	ShenZhen	Shen Zhen Shi Jin Hua Tai Electronics Co.,Ltd
 A8:F2:74	SamsungE	Samsung Electronics Co.,Ltd
 A8:F4:70	FujianNe	Fujian Newland Communication Science Technologies Co.,Ltd.
+A8:F5:AC	HuaweiTe	Huawei Technologies Co.,Ltd
 A8:F7:E0	PlanetTe	PLANET Technology Corporation
 A8:F9:4B	EltexEnt	Eltex Enterprise Ltd.
 A8:FA:D8	Apple	Apple, Inc.
@@ -28789,14 +30322,17 @@ AC:04:0B	PelotonI	Peloton Interactive, Inc
 AC:04:81	JiangsuH	Jiangsu Huaxing Electronics Co., Ltd.
 AC:06:13	Senselog	Senselogix Ltd
 AC:06:C7	Serverne	ServerNet S.r.l.
+AC:07:5F	HuaweiTe	Huawei Technologies Co.,Ltd
 AC:0A:61	LaborSRL	Labor S.r.L.
 AC:0D:1B	LgElectr	LG Electronics (Mobile Communications)
 AC:0D:FE	Ekon-Myg	Ekon GmbH - myGEKKO
 AC:11:D3	SuzhouHo	Suzhou HOTEK  Video Technology Co. Ltd
 AC:14:61	Ataw	ATAW  Co., Ltd.
 AC:14:D2	Wi-Daq	wi-daq, inc.
+AC:15:85	Silergy	silergy corp
 AC:16:2D	HewlettP	Hewlett Packard
 AC:17:02	FibarGro	Fibar Group sp. z o.o.
+AC:17:C8	CiscoMer	Cisco Meraki
 AC:18:26	SeikoEps	Seiko Epson Corporation
 AC:19:9F	SungrowP	Sungrow Power Supply Co.,Ltd.
 AC:1D:DF	IeeeRegi	IEEE Registration Authority
@@ -28831,10 +30367,12 @@ AC:2D:A3	Txtr	TXTR GmbH
 AC:2F:A8	Humannix	Humannix Co.,Ltd.
 AC:31:9D	Shenzhen	Shenzhen TG-NET Botone Technology Co.,Ltd.
 AC:34:CB	ShanhaiG	Shanhai GBCOM Communication Technology Co. Ltd
+AC:35:EE	Fn-LinkT	FN-LINK TECHNOLOGY LIMITED
 AC:36:13	SamsungE	Samsung Electronics Co.,Ltd
 AC:37:43	Htc	HTC Corporation
 AC:38:70	LenovoMo	Lenovo Mobile Communication Technology Ltd.
 AC:3A:7A	Roku	Roku, Inc.
+AC:3B:77	Sagemcom	Sagemcom Broadband SAS
 AC:3C:0B	Apple	Apple, Inc.
 AC:3C:B4	Nilan	Nilan A/S
 AC:3D:05	Instores	Instorescreen Aisa
@@ -28851,9 +30389,11 @@ AC:4E:2E	Shenzhen	Shenzhen JingHanDa Electronics Co.Ltd
 AC:4E:91	HuaweiTe	Huawei Technologies Co.,Ltd
 AC:4F:FC	Svs-Vist	SVS-VISTEK GmbH
 AC:50:36	Pi-Coral	Pi-Coral Inc
+AC:50:93	MagnaEle	Magna Electronics Europe GmbH & Co. OHG
 AC:51:2C	InfinixM	Infinix mobility limited
 AC:51:35	MpiTech	Mpi Tech
 AC:51:EE	Cambridg	Cambridge Communication Systems Ltd
+AC:54:74	ChinaMob	China Mobile IOT Company Limited
 AC:54:EC	IeeeP182	IEEE P1823 Standards Working Group
 AC:56:2C	LavaInte	LAVA INTERNATIONAL(H.K) LIMITED
 AC:58:3B	HumanAss	Human Assembler, Inc.
@@ -28868,7 +30408,7 @@ AC:61:75	HuaweiTe	Huawei Technologies Co.,Ltd
 AC:61:EA	Apple	Apple, Inc.
 AC:62:0D	JabilCir	Jabil Circuit(Wuxi) Co.,Ltd
 AC:63:BE	AmazonTe	Amazon Technologies Inc.
-AC:64:17	Siemens-	Siemens AG - Industrial Automation - EWA
+AC:64:17	Siemens	Siemens AG
 AC:64:62	Zte	zte corporation
 AC:64:DD	IeeeRegi	IEEE Registration Authority
 AC:64:DD:00:00:00/28	Jia-Teng
@@ -28897,6 +30437,7 @@ AC:6F:D9	Valueplu	Valueplus Inc.
 AC:72:36	LexkingT	Lexking Technology Co., Ltd.
 AC:72:89	IntelCor	Intel Corporate
 AC:74:09	Hangzhou	Hangzhou H3C Technologies Co., Limited
+AC:75:1D	HuaweiTe	Huawei Technologies Co.,Ltd
 AC:7A:42	Iconnect	iConnectivity
 AC:7A:4D	AlpsElec	Alps Electric Co.,Ltd.
 AC:7B:A1	IntelCor	Intel Corporate
@@ -28917,6 +30458,7 @@ AC:87:A3	Apple	Apple, Inc.
 AC:89:95	Azurewav	AzureWave Technology Inc.
 AC:8A:CD	RogerDWe	ROGER D.Wensker, G.Wensker sp.j.
 AC:8D:14	Smartrov	Smartrove Inc
+AC:92:32	HuaweiTe	Huawei Technologies Co.,Ltd
 AC:93:2F	Nokia	Nokia Corporation
 AC:94:03	Envision	Envision Peripherals Inc
 AC:9A:22	NxpSemic	NXP Semiconductors
@@ -28936,6 +30478,7 @@ AC:A9:A0	Audioeng	Audioengine, Ltd.
 AC:AB:2E	BeijingL	Beijing LasNubes Technology Co., Ltd.
 AC:AB:8D	LyngsoMa	Lyngso Marine A/S
 AC:AB:BF	Athentek	AthenTek Inc.
+AC:AE:19	Roku	Roku, Inc
 AC:AF:B9	SamsungE	Samsung Electronics Co.,Ltd
 AC:B3:13	ArrisGro	ARRIS Group, Inc.
 AC:B5:7D	LiteonTe	Liteon Technology Corporation
@@ -28999,10 +30542,11 @@ AC:F7:F3	XiaomiCo	Xiaomi Communications Co Ltd
 AC:F8:5C	Private
 AC:F9:70	HuaweiTe	Huawei Technologies Co.,Ltd
 AC:F9:7E	Elesys	Elesys Inc.
-AC:FD:93	WeifangG	Weifang GoerTek Technology Co.,Ltd.
+AC:FD:93	WeifangG	Weifang Goertek Electronics Co.,Ltd
 AC:FD:CE	IntelCor	Intel Corporate
 AC:FD:EC	Apple	Apple, Inc.
 B0:00:B4	Cisco	Cisco Systems, Inc
+B0:02:7E	MullerSe	Muller Services
 B0:05:94	LiteonTe	Liteon Technology Corporation
 B0:08:BF	VitalCon	Vital Connect, Inc.
 B0:09:D3	Avizia
@@ -29012,6 +30556,7 @@ B0:12:03	Dynamics	Dynamics Hong Kong Limited
 B0:12:66	Futaba-K	Futaba-Kikaku
 B0:14:08	Lightspe	Lightspeed International Co.
 B0:17:43	EdisonGl	Edison Global Circuits Llc
+B0:18:86	Smardtv
 B0:19:C6	Apple	Apple, Inc.
 B0:1B:7C	OntrolAS	Ontrol A.S.
 B0:1B:D2	LeShiZhi	Le Shi Zhi Xin Electronic Technology (Tianjin) Limited
@@ -29037,6 +30582,9 @@ B0:1F:81:F0:00:00/28	Private
 B0:24:F3	Progeny	Progeny Systems
 B0:25:AA	Private
 B0:26:28	Broadcom	Broadcom Limited
+B0:26:80	Cisco	Cisco Systems, Inc
+B0:2A:43	Google	Google, Inc.
+B0:33:A6	JuniperN	Juniper Networks
 B0:34:95	Apple	Apple, Inc.
 B0:35:0B	Mobiwire	MOBIWIRE MOBILES (NINGBO) CO.,LTD
 B0:35:8D	Nokia	Nokia Corporation
@@ -29048,6 +30596,7 @@ B0:3D:96	VisionVa	Vision Valley FZ LLC
 B0:3E:B0	Microdia	MICRODIA Ltd.
 B0:40:89	Senient	Senient Systems LTD
 B0:41:1D	IttimTec	ITTIM Technologies
+B0:41:6F	Shenzhen	Shenzhen Maxtang Computer Co.,Ltd
 B0:43:5D	Nuleds	NuLEDs, Inc.
 B0:45:15	MiraFitn	mira fitness,LLC.
 B0:45:19	TctMobil	TCT mobile ltd
@@ -29063,6 +30612,7 @@ B0:4E:26	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 B0:50:BC	Shenzhen	Shenzhen Basicom Electronic Co.,Ltd.
 B0:51:8E	HollTech	Holl technology CO.Ltd.
 B0:52:16	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
+B0:53:65	ChinaMob	China Mobile IOT Company Limited
 B0:55:08	HuaweiTe	Huawei Technologies Co.,Ltd
 B0:57:06	ValloxOy	Vallox Oy
 B0:58:C4	Broadcas	Broadcast Microwave Services, Inc
@@ -29092,18 +30642,22 @@ B0:79:3C	Revolv	Revolv Inc
 B0:79:94	Motorola	Motorola Mobility LLC, a Lenovo Company
 B0:7D:47	Cisco	Cisco Systems, Inc
 B0:7D:62	Dipl-Ing	Dipl.-Ing. H. Horstmann GmbH
+B0:7E:11	TexasIns	Texas Instruments
 B0:7E:70	ZadaraSt	Zadara Storage Ltd.
 B0:7F:B9	Netgear
 B0:80:8C	LaserLig	Laser Light Engines
 B0:81:D8	I-Sys	I-sys Corp
+B0:83:D6	ArrisGro	ARRIS Group, Inc.
 B0:83:FE	Dell	Dell Inc.
 B0:86:9E	Chloride	Chloride S.r.L
 B0:88:07	StrataWo	Strata Worldwide
 B0:89:00	HuaweiTe	Huawei Technologies Co.,Ltd
 B0:89:91	Lge
 B0:89:C2	Zyptonit	Zyptonite
+B0:8B:CF	Cisco	Cisco Systems, Inc
 B0:8E:1A	Uradio	URadio Systems Co., Ltd
 B0:90:74	FulanEle	Fulan Electronics Limited
+B0:90:7E	Cisco	Cisco Systems, Inc
 B0:90:D4	Shenzhen	Shenzhen Hoin Internet Technology Co., Ltd
 B0:91:22	TexasIns	Texas Instruments
 B0:91:34	Taleo
@@ -29120,22 +30674,27 @@ B0:9B:D4	GnhSoftw	GNH Software India Private Limited
 B0:9F:BA	Apple	Apple, Inc.
 B0:A1:0A	Pivotal	Pivotal Systems Corporation
 B0:A2:E7	Shenzhen	Shenzhen TINNO Mobile Technology Corp.
-B0:A3:7E	QingdaoH	Qingdao Haier Telecom Co.，Ltd
+B0:A3:7E	QingDaoH	Qing Dao Haier Telecom Co.,Ltd.
 B0:A7:2A	Ensemble	Ensemble Designs, Inc.
 B0:A7:37	Roku	Roku, Inc.
 B0:A8:6E	JuniperN	Juniper Networks
 B0:AA:36	Guangdon	Guangdong Oppo Mobile Telecommunications Corp.,Ltd
 B0:AA:77	Cisco	Cisco Systems, Inc
+B0:AC:D2	Zte	zte corporation
 B0:AC:FA	Fujitsu	Fujitsu Limited
 B0:AD:AA	Avaya	Avaya Inc
+B0:AE:25	Varikore	Varikorea
 B0:B2:8F	Sagemcom	Sagemcom Broadband SAS
 B0:B2:DC	ZyxelCom	Zyxel Communications Corporation
 B0:B3:2B	SlicanSp	Slican Sp. z o.o.
+B0:B3:AD	Humax	HUMAX Co., Ltd.
 B0:B4:48	TexasIns	Texas Instruments
+B0:B8:67	HewlettP	Hewlett Packard Enterprise
 B0:B8:D5	NanjingN	Nanjing Nengrui Auto Equipment CO.,Ltd
 B0:B9:8A	Netgear
 B0:BD:6D	Echostre	Echostreams Innovative Solutions
 B0:BD:A1	ZakladEl	Zaklad Elektroniczny Sims
+B0:BE:76	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 B0:BF:99	Wizitdon	Wizitdongdo
 B0:C0:90	ChiconyE	Chicony Electronics Co., Ltd.
 B0:C1:28	AdlerElr	Adler ELREHA GmbH
@@ -29192,6 +30751,7 @@ B0:E7:54	2wire	2Wire Inc
 B0:E8:92	SeikoEps	Seiko Epson Corporation
 B0:E9:7E	Advanced	Advanced Micro Peripherals
 B0:EA:BC	AskeyCom	Askey Computer Corp
+B0:EB:57	HuaweiTe	Huawei Technologies Co.,Ltd
 B0:EC:71	SamsungE	Samsung Electronics Co.,Ltd
 B0:EC:8F	GmxSas	Gmx Sas
 B0:EC:E1	Private
@@ -29203,6 +30763,7 @@ B0:F1:EC	AmpakTec	AMPAK Technology, Inc.
 B0:F8:93	Shanghai	Shanghai MXCHIP Information Technology Co., Ltd.
 B0:F9:63	Hangzhou	Hangzhou H3C Technologies Co., Limited
 B0:FA:EB	Cisco	Cisco Systems, Inc
+B0:FC:0D	AmazonTe	Amazon Technologies Inc.
 B0:FC:36	Cybertan	CyberTAN Technology Inc.
 B0:FE:BD	Private
 B4:00:16	Ingenico	Ingenico Terminals Sas
@@ -29224,6 +30785,7 @@ B4:15:13	HuaweiTe	Huawei Technologies Co.,Ltd
 B4:17:80	DtiGroup	DTI Group Ltd
 B4:18:D1	Apple	Apple, Inc.
 B4:1C:30	Zte	zte corporation
+B4:1D:2B	Shenzhen	Shenzhen YOUHUA Technology Co., Ltd
 B4:1D:EF	Internet	Internet Laboratories, Inc.
 B4:21:1D	BeijingG	Beijing GuangXin Technology Co., Ltd
 B4:21:8A	DogHunte	Dog Hunter LLC
@@ -29235,6 +30797,7 @@ B4:2A:39	OrbitMer	ORBIT MERRET, spol. s r. o.
 B4:2C:92	Zhejiang	Zhejiang Weirong Electronic Co., Ltd
 B4:2C:BE	DirectPa	Direct Payment Solutions Limited
 B4:2D:56	ExtremeN	Extreme Networks, Inc.
+B4:2E:99	Giga-Byt	GIGA-BYTE TECHNOLOGY CO.,LTD.
 B4:2E:F8	ElineTec	Eline Technology co.Ltd
 B4:30:52	HuaweiTe	Huawei Technologies Co.,Ltd
 B4:30:C0	YorkInst	York Instruments Ltd
@@ -29269,14 +30832,31 @@ B4:3D:B2	Degreane	Degreane Horizon
 B4:3E:3B	Viablewa	Viableware, Inc
 B4:41:7A	Shenzhen	Shenzhen Gongjin Electronics Co.,Lt
 B4:43:0D	Broadlin	Broadlink Pty Ltd
+B4:43:26	HuaweiTe	Huawei Technologies Co.,Ltd
 B4:47:5E	Avaya	Avaya Inc
 B4:4B:D2	Apple	Apple, Inc.
+B4:4B:D6	IeeeRegi	IEEE Registration Authority
+B4:4B:D6:00:00:00/28	G4sMonit	G4S Monitoring Technologies Ltd
+B4:4B:D6:10:00:00/28	Shenzhen	Shenzhen Tita Interactive Technology Co.,Ltd
+B4:4B:D6:20:00:00/28	Shenzhen	Shenzhen Cudy Technology Co., Ltd.
+B4:4B:D6:30:00:00/28	HuizhouS	Huizhou Sunoda Technology Co. Ltd
+B4:4B:D6:40:00:00/28	Shenzhen	Shenzhen Hi-Net Technology Co., Ltd.
+B4:4B:D6:50:00:00/28	Shenzhen	ShenZhen Comstar Technology Company
+B4:4B:D6:60:00:00/28	Perspica	Perspicace Intellegince Technology
+B4:4B:D6:70:00:00/28	TaizhouC	Taizhou convergence Information technology Co.,LTD
+B4:4B:D6:80:00:00/28	ArnouseD	Arnouse Digital Devices Corp
+B4:4B:D6:90:00:00/28	QstarTec	Qstar Technology Co,Ltd
+B4:4B:D6:A0:00:00/28	Shenzhen	Shenzhen Huabai Intelligent Technology Co., Ltd.
+B4:4B:D6:B0:00:00/28	Dongyoun	DongYoung media
+B4:4B:D6:C0:00:00/28	ImpaktSA	Impakt S.A.
+B4:4B:D6:D0:00:00/28	ElletaSo	Elleta Solutions Ltd
+B4:4B:D6:E0:00:00/28	Chunghsi	Chunghsin International Electronics Co.,Ltd.
 B4:4C:C2	NrElectr	Nr Electric Co., Ltd
 B4:4F:96	Zhejiang	Zhejiang Xinzailing Technology co., ltd
 B4:51:F9	NbSoftwa	NB Software
 B4:52:53	SeagateT	Seagate Technology
-B4:52:7D	SonyMobi	Sony Mobile Communications AB
-B4:52:7E	SonyMobi	Sony Mobile Communications AB
+B4:52:7D	SonyMobi	Sony Mobile Communications Inc
+B4:52:7E	SonyMobi	Sony Mobile Communications Inc
 B4:55:70	Borea
 B4:56:B9	Teraspek	Teraspek Technologies Co.,Ltd
 B4:58:61	CremoteL	CRemote, LLC
@@ -29288,6 +30868,8 @@ B4:62:93	SamsungE	Samsung Electronics Co.,Ltd
 B4:62:AD	ElysiaGe	Elysia Germany GmbH
 B4:66:98	ZealabsS	Zealabs srl
 B4:67:E9	QingdaoG	Qingdao GoerTek Technology Co., Ltd.
+B4:69:21	IntelCor	Intel Corporate
+B4:6B:FC	IntelCor	Intel Corporate
 B4:6D:35	DalianSe	Dalian Seasky Automation Co;Ltd
 B4:6D:83	IntelCor	Intel Corporate
 B4:73:56	Hangzhou	Hangzhou Treebear Networking Co., Ltd.
@@ -29295,15 +30877,18 @@ B4:74:43	SamsungE	Samsung Electronics Co.,Ltd
 B4:74:47	Coreos
 B4:74:9F	AskeyCom	Askey Computer Corp
 B4:75:0E	BelkinIn	Belkin International Inc.
+B4:77:48	Shenzhen	Shenzhen Neoway Technology Co.,Ltd.
 B4:79:A7	SamsungE	SAMSUNG ELECTRO-MECHANICS(THAILAND)
 B4:7C:29	Shenzhen	Shenzhen Guzidi Technology Co.,Ltd
 B4:7C:9C	AmazonTe	Amazon Technologies Inc.
 B4:7F:5E	Foresigh	Foresight Manufacture (S) Pte Ltd
+B4:81:BF	Meta-Net	Meta-Networks, LLC
 B4:82:55	Research	Research Products Corporation
 B4:82:7B	AkgAcous	AKG Acoustics GmbH
 B4:82:C5	Relay2	Relay2, Inc.
 B4:82:FE	AskeyCom	Askey Computer Corp
 B4:85:47	AmptownS	Amptown System Company GmbH
+B4:86:55	HuaweiTe	Huawei Technologies Co.,Ltd
 B4:89:10	CosterTE	Coster T.E. S.P.A.
 B4:8B:19	Apple	Apple, Inc.
 B4:94:4E	Weteleco	WeTelecom Co., Ltd.
@@ -29324,6 +30909,7 @@ B4:A5:EF	Sercomm	Sercomm Corporation.
 B4:A8:28	Shenzhen	Shenzhen Concox Information Technology Co., Ltd
 B4:A8:2B	HistarDi	Histar Digital Electronics Co., Ltd.
 B4:A8:B9	Cisco	Cisco Systems, Inc
+B4:A9:4F	Mercury	Mercury Corporation
 B4:A9:5A	Avaya	Avaya Inc
 B4:A9:84	Symantec	Symantec Corporation
 B4:A9:FE	GhiaTech	GHIA Technology (Shenzhen) LTD
@@ -29340,16 +30926,21 @@ B4:B5:2F	HewlettP	Hewlett Packard
 B4:B5:42	HubbellP	Hubbell Power Systems, Inc.
 B4:B5:AF	MinsungE	Minsung Electronics
 B4:B6:76	IntelCor	Intel Corporate
+B4:B6:86	HewlettP	Hewlett Packard
 B4:B8:59	Texa	Texa Spa
 B4:B8:8D	Thuh	Thuh Company
 B4:BF:F6	SamsungE	Samsung Electronics Co.,Ltd
+B4:C0:F5	Shenzhen	Shenzhen TINNO Mobile Technology Corp.
 B4:C1:70	YiChipMi	Yi chip Microelectronics (Hangzhou) Co., Ltd
 B4:C4:4E	VxlEtech	VXL eTech Pvt Ltd
 B4:C6:F8	Axilspot	Axilspot Communication
 B4:C7:99	ExtremeN	Extreme Networks, Inc.
 B4:C8:10	UmpiElet	UMPI Elettronica
+B4:CB:57	Guangdon	Guangdong Oppo Mobile Telecommunications Corp.,Ltd
 B4:CC:E9	Prosyst
+B4:CD:27	HuaweiTe	Huawei Technologies Co.,Ltd
 B4:CE:F6	Htc	HTC Corporation
+B4:CE:FE	JamesCze	James Czekaj
 B4:CF:DB	Shenzhen	Shenzhen Jiuzhou Electric Co.,LTD
 B4:D1:35	Cloudist	Cloudistics
 B4:D5:BD	IntelCor	Intel Corporate
@@ -29357,10 +30948,12 @@ B4:D6:4E	Caldero	Caldero Limited
 B4:D8:A9	Betterbo	BetterBots
 B4:D8:DE	IotaComp	iota Computing, Inc.
 B4:DD:15	Controlt	ControlThings Oy Ab
+B4:DD:D0	Continen	Continental Automotive Hungary Kft
 B4:DE:31	Cisco	Cisco Systems, Inc
 B4:DE:DF	Zte	zte corporation
 B4:DF:3B	Chromlec	Chromlech
 B4:DF:FA	LitemaxE	Litemax Electronics Inc.
+B4:E0:1D	Concepti	Conception Electronique
 B4:E0:CD	Fusion-I	Fusion-io, Inc
 B4:E1:0F	Dell	Dell Inc.
 B4:E1:C4	Microsof	Microsoft Mobile Oy
@@ -29370,6 +30963,7 @@ B4:E6:2D	Espressi	Espressif Inc.
 B4:E7:82	Vivalnk
 B4:E9:A3	Port	port GmbH
 B4:E9:B0	Cisco	Cisco Systems, Inc
+B4:EC:02	AlpsElec	Alps Electric Co.,Ltd.
 B4:ED:19	PieDigit	Pie Digital, Inc.
 B4:ED:54	WohlerTe	Wohler Technologies
 B4:EE:B4	AskeyCom	Askey Computer Corp
@@ -29384,6 +30978,7 @@ B4:F3:23	Petatel	Petatel Inc.
 B4:F6:1C	Apple	Apple, Inc.
 B4:F7:A1	LgElectr	LG Electronics (Mobile Communications)
 B4:F8:1E	Kinova
+B4:F9:49	Optilink	optilink networks pvt ltd
 B4:FB:E4	Ubiquiti	Ubiquiti Networks Inc.
 B4:FB:F9	HuaweiTe	Huawei Technologies Co.,Ltd
 B4:FC:75	SemaElec	SEMA Electronics(HK) CO.,LTD
@@ -29417,8 +31012,9 @@ B8:28:8B	ParkerHa	Parker Hannifin Manufacturing (UK) Ltd
 B8:29:F7	BlasterT	Blaster Tech
 B8:2A:72	Dell	Dell Inc.
 B8:2A:DC	EfrEurop	EFR Europäische Funk-Rundsteuerung GmbH
-B8:2C:A0	Honeywel	Honeywell HomMed
+B8:2C:A0	Resideo
 B8:30:A8	Road-Tra	Road-Track Telematics Development
+B8:31:B5	Microsof	Microsoft Corporation
 B8:32:41	WuhanTia	Wuhan Tianyu Information Industry Co., Ltd.
 B8:36:D8	Videoswi	Videoswitch
 B8:37:65	Guangdon	Guangdong Oppo Mobile Telecommunications Corp.,Ltd
@@ -29430,6 +31026,7 @@ B8:3A:9D	AlarmCom	Alarm.com
 B8:3D:4E	Shenzhen	Shenzhen Cultraview Digital Technology Co.,Ltd Shanghai Branch
 B8:3E:59	Roku	Roku, Inc.
 B8:41:5F	Asp	Asp Ag
+B8:41:A4	Apple	Apple, Inc.
 B8:43:E4	Vlatacom
 B8:44:D9	Apple	Apple, Inc.
 B8:47:C6	SanjetTe	SanJet Technology Corp.
@@ -29452,6 +31049,8 @@ B8:63:BC	Robotis	ROBOTIS, Co, Ltd
 B8:64:91	CkTeleco	CK Telecom Ltd
 B8:65:3B	Bolymin	Bolymin, Inc.
 B8:69:C2	SunitecE	Sunitec Enterprise Co., Ltd.
+B8:69:F4	Routerbo	Routerboard.com
+B8:6A:97	Edgecore	Edgecore Networks Corporation
 B8:6B:23	Toshiba
 B8:6C:E8	SamsungE	Samsung Electronics Co.,Ltd
 B8:70:F4	CompalIn	COMPAL INFORMATION (KUNSHAN) CO., LTD.
@@ -29460,12 +31059,16 @@ B8:74:47	Converge	Convergence Technologies
 B8:75:C0	Paypal	PayPal, Inc.
 B8:76:3F	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 B8:77:C3	MeterGro	METER Group
+B8:78:26	Nintendo	Nintendo Co.,Ltd
 B8:78:2E	Apple	Apple, Inc.
 B8:78:79	RocheDia	Roche Diagnostics GmbH
 B8:79:7E	SecureMe	Secure Meters (UK) Limited
 B8:7A:C9	Siemens	Siemens Ltd.
+B8:7C:6F	NxpChina	NXP (China) Management Ltd.
 B8:7C:F2	Aerohive	Aerohive Networks Inc.
 B8:81:98	IntelCor	Intel Corporate
+B8:83:03	HewlettP	Hewlett Packard Enterprise
+B8:85:84	Dell	Dell Inc.
 B8:86:87	LiteonTe	Liteon Technology Corporation
 B8:87:1E	GoodMind	Good Mind Industries Co., Ltd.
 B8:87:A8	StepAhea	Step Ahead Innovations Inc.
@@ -29473,12 +31076,14 @@ B8:88:E3	CompalIn	COMPAL INFORMATION (KUNSHAN) CO., LTD.
 B8:89:81	ChengduI	Chengdu InnoThings Technology Co., Ltd.
 B8:89:CA	IljinEle	ILJIN ELECTRIC Co., Ltd.
 B8:8A:60	IntelCor	Intel Corporate
+B8:8A:EC	Nintendo	Nintendo Co.,Ltd
 B8:8D:12	Apple	Apple, Inc.
 B8:8E:3A	Infinite	Infinite Technologies JLT
 B8:8E:C6	Stateles	Stateless Networks
 B8:8E:DF	Zencheer	Zencheer Communication Technology Co., Ltd.
 B8:8F:14	Analytic	Analytica GmbH
 B8:92:1D	BgT&A	BG T&A
+B8:94:36	HuaweiTe	Huawei Technologies Co.,Ltd
 B8:94:D2	RetailIn	Retail Innovation HTT AB
 B8:96:74	Alldsp	AllDSP GmbH & Co. KG
 B8:97:5A	BiostarM	BIOSTAR Microtech Int'l Corp.
@@ -29486,6 +31091,7 @@ B8:98:B0	Atlona	Atlona Inc.
 B8:98:F7	GioneeCo	Gionee Communication Equipment Co,Ltd.ShenZhen
 B8:99:19	7signalS	7signal Solutions, Inc
 B8:99:B0	CohereTe	Cohere Technologies
+B8:9A:9A	XinShiJi	Xin Shi Jia Technology (Beijing) Co.,Ltd
 B8:9A:CD	EliteOpt	ELITE OPTOELECTRONIC(ASIA)CO.,LTD
 B8:9A:ED	Oceanser	OceanServer Technology, Inc
 B8:9B:C9	SmcNetwo	SMC Networks Inc
@@ -29505,6 +31111,7 @@ B8:B2:EB	GoogolTe	Googol Technology (HK) Limited
 B8:B3:DC	DerekSha	DEREK (SHAOGUAN) LIMITED
 B8:B4:2E	GioneeCo	Gionee Communication Equipment Co,Ltd.ShenZhen
 B8:B7:D7	2gigTech	2GIG Technologies
+B8:B7:F1	WistronN	Wistron Neweb Corporation
 B8:B8:1E	IntelCor	Intel Corporate
 B8:B9:4E	Shenzhen	Shenzhen iBaby Labs, Inc.
 B8:BA:68	XiAnJizh	Xi'an Jizhong Digital Communication Co.,Ltd
@@ -29515,6 +31122,7 @@ B8:BB:AF	SamsungE	Samsung Electronics Co.,Ltd
 B8:BC:1B	HuaweiTe	Huawei Technologies Co.,Ltd
 B8:BD:79	Trendpoi	TrendPoint Systems
 B8:BE:BF	Cisco	Cisco Systems, Inc
+B8:BE:F4	Devolo	devolo AG
 B8:BF:83	IntelCor	Intel Corporate
 B8:C1:11	Apple	Apple, Inc.
 B8:C1:A2	DragonPa	Dragon Path Technologies Co., Limited
@@ -29578,7 +31186,7 @@ B8:F7:4A	Rcntec
 B8:F8:28	Changshu	Changshu Gaoshida Optoelectronic Technology Co. Ltd.
 B8:F8:83	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 B8:F8:BE	Bluecom
-B8:F9:34	SonyMobi	Sony Mobile Communications AB
+B8:F9:34	SonyMobi	Sony Mobile Communications Inc
 B8:FC:9A	LeShiZhi	Le Shi Zhi Xin Electronic Technology (Tianjin) Limited
 B8:FD:32	Zhejiang	Zhejiang ROICX Microelectronics
 B8:FF:61	Apple	Apple, Inc.
@@ -29606,9 +31214,12 @@ BC:1A:67	YfTechno	YF Technology Co., Ltd
 BC:1C:81	SichuanI	Sichuan iLink Technology Co., Ltd.
 BC:20:A4	SamsungE	Samsung Electronics Co.,Ltd
 BC:20:BA	InspurSh	Inspur (Shandong) Electronic Information Co., Ltd
+BC:22:FB	RfIndust	RF Industries
 BC:25:E0	HuaweiTe	Huawei Technologies Co.,Ltd
 BC:25:F0	3dDispla	3D Display Technologies Co., Ltd.
 BC:26:1D	HongKong	Hong Kong Tecon Technology
+BC:26:43	Elprotro	Elprotronic Inc.
+BC:26:C7	Cisco	Cisco Systems, Inc
 BC:28:2C	E-SmartP	e-Smart Systems Pvt. Ltd
 BC:28:46	NextbitC	NextBIT Computing Pvt. Ltd.
 BC:28:D6	RowleyAs	Rowley Associates Limited
@@ -29621,6 +31232,8 @@ BC:2F:3D	VivoMobi	vivo Mobile Communication Co., Ltd.
 BC:30:5B	Dell	Dell Inc.
 BC:30:7D	WistronN	Wistron Neweb Corporation
 BC:30:7E	WistronN	Wistron Neweb Corporation
+BC:30:D9	Arcadyan	Arcadyan Corporation
+BC:32:5F	Zhejiang	Zhejiang Dahua Technology Co., Ltd.
 BC:34:00	IeeeRegi	IEEE Registration Authority
 BC:34:00:00:00:00/28	Redvisio	Redvision CCTV
 BC:34:00:10:00:00/28	IplinkTe	IPLINK Technology Corp
@@ -29639,6 +31252,7 @@ BC:34:00:D0:00:00/28	Hangzhou	Hangzhou Linker Digital Technology Co., Ltd
 BC:34:00:E0:00:00/28	LldTechn	LLD Technology Ltd.
 BC:34:00:F0:00:00/28	Private
 BC:35:E5	Hydro	Hydro Systems Company
+BC:38:65	Jwcnetwo	Jwcnetworks
 BC:38:D2	Pandachi	Pandachip Limited
 BC:39:A6	CsunSyst	CSUN System Technology Co.,LTD
 BC:39:D9	Z-Tec
@@ -29646,6 +31260,7 @@ BC:3A:EA	Guangdon	Guangdong Oppo Mobile Telecommunications Corp.,Ltd
 BC:3B:AF	Apple	Apple, Inc.
 BC:3D:85	HuaweiTe	Huawei Technologies Co.,Ltd
 BC:3E:13	Accordan	Accordance Systems Inc.
+BC:3F:4E	Teleepoc	Teleepoch Ltd
 BC:3F:8F	HuaweiTe	Huawei Technologies Co.,Ltd
 BC:41:00	CodacoEl	CODACO ELECTRONIC s.r.o.
 BC:41:01	Shenzhen	Shenzhen TINNO Mobile Technology Corp.
@@ -29669,8 +31284,9 @@ BC:54:51	SamsungE	Samsung Electronics Co.,Ltd
 BC:54:F9	DrogooTe	Drogoo Technology Co., Ltd.
 BC:54:FC	Shenzhen	Shenzhen Mercury Communication Technologies Co.,Ltd.
 BC:5C:4C	Elecom	Elecom Co.,Ltd.
+BC:5E:A1	Psikick	PsiKick, Inc.
 BC:5F:F4	AsrockIn	ASRock Incorporation
-BC:5F:F6	Shenzhen	Shenzhen Mercury Communication Technologies Co.,Ltd.
+BC:5F:F6	MercuryC	Mercury Communication Technologies Co.,Ltd.
 BC:60:10	QingdaoH	Qingdao Hisense Communications Co.,Ltd.
 BC:60:A7	SonyInte	Sony Interactive Entertainment Inc.
 BC:62:0E	HuaweiTe	Huawei Technologies Co.,Ltd
@@ -29703,12 +31319,13 @@ BC:6A:2F	HengeDoc	Henge Docks LLC
 BC:6A:44	CommendI	Commend International GmbH
 BC:6B:4D	Nokia
 BC:6C:21	Apple	Apple, Inc.
-BC:6E:64	SonyMobi	Sony Mobile Communications AB
+BC:6E:64	SonyMobi	Sony Mobile Communications Inc
 BC:6E:76	GreenEne	Green Energy Options Ltd
 BC:71:C1	Xtrillio	XTrillion, Inc.
 BC:72:B1	SamsungE	Samsung Electronics Co.,Ltd
 BC:74:D7	Hangzhou	HangZhou JuRu Technology CO.,LTD
 BC:75:74	HuaweiTe	Huawei Technologies Co.,Ltd
+BC:75:96	BeijingB	Beijing Broadwit Technology Co., Ltd.
 BC:76:4E	Rackspac	Rackspace US, Inc.
 BC:76:5E	SamsungE	Samsung Electronics Co.,Ltd
 BC:76:70	HuaweiTe	Huawei Technologies Co.,Ltd
@@ -29733,23 +31350,30 @@ BC:8D:0E	Nokia
 BC:90:3A	RobertBo	Robert Bosch GmbH
 BC:91:B5	InfinixM	Infinix mobility limited
 BC:92:6B	Apple	Apple, Inc.
+BC:93:25	NingboJo	Ningbo Joyson Preh Car Connect Co.,Ltd.
 BC:96:80	Shenzhen	Shenzhen Gongjin Electronics Co.,Lt
 BC:98:89	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
+BC:99:11	ZyxelCom	Zyxel Communications Corporation
 BC:99:BC	FonseeTe	FonSee Technology Inc.
+BC:9B:68	Technico	Technicolor CH USA Inc.
 BC:9C:31	HuaweiTe	Huawei Technologies Co.,Ltd
 BC:9C:C5	BeijingH	Beijing Huafei Technology Co., Ltd.
 BC:9D:A5	DascomEu	DASCOM Europe GmbH
 BC:9F:EF	Apple	Apple, Inc.
 BC:A0:42	Shanghai	Shanghai Flyco Electrical Appliance Co.,Ltd
 BC:A4:E1	Nabto
+BC:A5:8B	SamsungE	Samsung Electronics Co.,Ltd
 BC:A8:A6	IntelCor	Intel Corporate
 BC:A9:20	Apple	Apple, Inc.
 BC:A9:D6	Cyber-Ra	Cyber-Rain, Inc.
+BC:AB:7C	TrnpKore	TRnP KOREA Co Ltd
 BC:AD:28	Hangzhou	Hangzhou Hikvision Digital Technology Co.,Ltd.
 BC:AD:AB	Avaya	Avaya Inc
 BC:AE:C5	AsustekC	ASUSTek COMPUTER INC.
+BC:AF:91	TeConnec	TE Connectivity Sensor Solutions
 BC:B1:81	Sharp	Sharp Corporation
 BC:B1:F3	SamsungE	Samsung Electronics Co.,Ltd
+BC:B2:2B	Em-Tech
 BC:B3:08	Hongkong	Hongkong Ragentek Communication Technology Co.,Limited
 BC:B8:52	Cybera	Cybera, Inc.
 BC:BA:E1	Arec	AREC Inc.
@@ -29774,7 +31398,10 @@ BC:D1:D3	Shenzhen	Shenzhen TINNO Mobile Technology Corp.
 BC:D5:B6	D2dTechn	d2d technologies
 BC:D7:13	OwlLabs	Owl Labs
 BC:D9:40	Asr	ASR Co,.Ltd.
+BC:DD:C2	Espressi	Espressif Inc.
 BC:E0:9D	Eoslink
+BC:E1:43	Apple	Apple, Inc.
+BC:E2:65	HuaweiTe	Huawei Technologies Co.,Ltd
 BC:E5:9F	Waterwor	WATERWORLD Technology Co.,LTD
 BC:E6:3F	SamsungE	Samsung Electronics Co.,Ltd
 BC:E7:67	Quanzhou	Quanzhou  TDX Electronics Co., Ltd
@@ -29787,20 +31414,24 @@ BC:EE:7B	AsustekC	ASUSTek COMPUTER INC.
 BC:F1:F2	Cisco	Cisco Systems, Inc
 BC:F2:92	Plantron	Plantronics, Inc.
 BC:F2:AF	Devolo	devolo AG
+BC:F3:10	Aerohive	Aerohive Networks Inc.
 BC:F5:AC	LgElectr	LG Electronics (Mobile Communications)
 BC:F6:1C	Geomodel	Geomodeling Wuxi Technology Co. Ltd.
 BC:F6:85	D-LinkIn	D-Link International
 BC:F8:11	XiamenDn	Xiamen DNAKE Technology Co.,Ltd
 BC:FE:8C	Altronic	Altronic, LLC
+BC:FE:D9	Apple	Apple, Inc.
 BC:FF:AC	Topcon	Topcon Corporation
 BC:FF:EB	Motorola	Motorola Mobility LLC, a Lenovo Company
 C0:00:00	WesternD	Western Digital (may be reversed 00 00 C0?)
 C0:02:8D	WinstarD	WINSTAR Display CO.,Ltd
+C0:03:80	JuniperN	Juniper Networks
 C0:05:C2	ArrisGro	ARRIS Group, Inc.
 C0:0D:7E	Additech	Additech, Inc.
 C0:11:73	SamsungE	Samsung Electronics Co.,Ltd
 C0:11:A6	Fort-Tel	Fort-Telecom ltd.
 C0:12:42	AlphaSec	Alpha Security Products
+C0:13:2B	SichuanC	Sichuan Changhong Electric Ltd.
 C0:14:3D	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 C0:17:4D	SamsungE	Samsung Electronics Co.,Ltd
 C0:18:85	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
@@ -29834,10 +31465,13 @@ C0:3E:0F	Bskyb	BSkyB Ltd
 C0:3F:0E	Netgear
 C0:3F:2A	Biscotti	Biscotti, Inc.
 C0:3F:D5	Elitegro	Elitegroup Computer Systems Co.,Ltd.
+C0:40:04	Medicaro	Medicaroid Corporation
 C0:41:F6	LgElectr	Lg Electronics Inc
 C0:42:D0	JuniperN	Juniper Networks
 C0:43:01	EpecOy	Epec Oy
 C0:44:E3	Shenzhen	Shenzhen Sinkna Electronics Co., LTD
+C0:48:E6	SamsungE	Samsung Electronics Co.,Ltd
+C0:48:FB	Shenzhen	Shenzhen JingHanDa Electronics Co.Ltd
 C0:49:3D	Maitrise	Maitrise Technologique
 C0:4A:00	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 C0:4A:09	Zhejiang	Zhejiang Everbright Communication Equip. Co,. Ltd
@@ -29859,12 +31493,32 @@ C0:6C:6D	Magnemot	MagneMotion, Inc.
 C0:6D:1A	TianjinH	Tianjin Henxinhuifeng Technology Co.,Ltd.
 C0:70:09	HuaweiTe	Huawei Technologies Co.,Ltd
 C0:74:2B	Shenzhen	Shenzhen Xunlong Software Co.,Limited
+C0:74:AD	Grandstr	Grandstream Networks, Inc.
+C0:78:78	Flextron	FLEXTRONICS MANUFACTURING(ZHUHAI)CO.,LTD.
 C0:7B:BC	Cisco	Cisco Systems, Inc
 C0:7C:D1	Pegatron	Pegatron Corporation
 C0:7E:40	Shenzhen	Shenzhen Xdk Communication Equipment Co.,Ltd
+C0:81:35	NingboFo	Ningbo Forfan technology Co., LTD
 C0:81:70	EffigisG	Effigis GeoSolutions
 C0:83:0A	2wire	2Wire Inc
+C0:83:59	IeeeRegi	IEEE Registration Authority
+C0:83:59:00:00:00/28	Chongqin	Chongqing Jiuyu Smart Technology Co.Ltd.
+C0:83:59:10:00:00/28	GemvaxTe	Gemvax Technology ,. Co.Ltd
+C0:83:59:20:00:00/28	HuaxinSm	Huaxin SM Optics Co. LTD.
+C0:83:59:30:00:00/28	PchEngin	PCH Engineering A/S
+C0:83:59:40:00:00/28	Ants
+C0:83:59:50:00:00/28	ViperDes	Viper Design, LLC
+C0:83:59:60:00:00/28	BeijingC	Beijing Cloud Fly Technology Development Co.Ltd
+C0:83:59:70:00:00/28	FuzhouFd	Fuzhou Fdlinker Technology Co.,LTD
+C0:83:59:80:00:00/28	IstaInte	ista International GmbH
+C0:83:59:90:00:00/28	Shenzhen	Shenzhen Pay Device Technology Co., Ltd.
+C0:83:59:A0:00:00/28	Shanghai	Shanghai Charmhope Information Technology Co.,Ltd.
+C0:83:59:B0:00:00/28	SuzhouSi	Suzhou Siheng Science and Technology Ltd.
+C0:83:59:C0:00:00/28	Private
+C0:83:59:D0:00:00/28	GardnerD	Gardner Denver Thomas GmbH
+C0:83:59:E0:00:00/28	CyberSci	Cyber Sciences, Inc.
 C0:84:7A	Apple	Apple, Inc.
+C0:84:7D	AmpakTec	AMPAK Technology, Inc.
 C0:84:88	Finis	Finis Inc
 C0:85:4C	Ragentek	Ragentek Technology Group
 C0:87:EB	SamsungE	Samsung Electronics Co.,Ltd
@@ -29877,6 +31531,7 @@ C0:91:32	PatriotM	Patriot Memory
 C0:91:34	Procurve	ProCurve Networking by HP
 C0:97:27	SamsungE	SAMSUNG ELECTRO-MECHANICS(THAILAND)
 C0:98:79	Acer	Acer Inc.
+C0:98:DA	ChinaMob	China Mobile IOT Company Limited
 C0:98:E5	Universi	University of Michigan
 C0:9A:71	XiamenMe	Xiamen Meitu Mobile Technology Co.Ltd
 C0:9C:04	ShaanxiG	Shaanxi GuoLian Digital TV Technology Co.,Ltd.
@@ -29895,16 +31550,21 @@ C0:A3:64	3dMassac	3D Systems Massachusetts
 C0:A3:9E	Earthcam	EarthCam, Inc.
 C0:A5:3E	Apple	Apple, Inc.
 C0:A5:DD	Shenzhen	Shenzhen Mercury Communication Technologies Co.,Ltd.
+C0:A6:00	Apple	Apple, Inc.
 C0:A8:F0	AdamsonE	Adamson Systems Engineering
 C0:AA:68	OsasiTec	OSASI Technos Inc.
 C0:AC:54	Sagemcom	Sagemcom Broadband SAS
 C0:B3:39	Comigo	Comigo Ltd.
 C0:B3:57	YoshikiE	Yoshiki Electronics Industry Ltd.
+C0:B6:58	Apple	Apple, Inc.
+C0:B6:F9	IntelCor	Intel Corporate
 C0:B7:13	BeijingX	Beijing Xiaoyuer Technology Co. Ltd.
 C0:B8:B1	Bitbox	BitBox Ltd
 C0:BA:E6	Applicat	Application Solutions (Electronics and Vision) Ltd
 C0:BD:42	ZpaSmart	ZPA Smart Energy a.s.
+C0:BD:C8	SamsungE	Samsung Electronics Co.,Ltd
 C0:BD:D1	SamsungE	SAMSUNG ELECTRO-MECHANICS(THAILAND)
+C0:BF:A7	JuniperN	Juniper Networks
 C0:BF:C0	HuaweiTe	Huawei Technologies Co.,Ltd
 C0:C1:C0	Cisco-Li	Cisco-Linksys, LLC
 C0:C3:B6	Automati	Automatic Systems
@@ -29920,6 +31580,8 @@ C0:CE:CD	Apple	Apple, Inc.
 C0:CF:A3	Creative	Creative Electronics & Software, Inc.
 C0:D0:12	Apple	Apple, Inc.
 C0:D0:44	Sagemcom	Sagemcom Broadband SAS
+C0:D0:FF	ChinaMob	China Mobile IOT Company Limited
+C0:D2:F3	HuiZhouG	Hui Zhou Gaoshengda Technology Co.,LTD
 C0:D3:91	IeeeRegi	IEEE Registration Authority
 C0:D3:91:00:00:00/28	FuzhouJi	Fuzhou Jinshi Technology Co.,Ltd.
 C0:D3:91:10:00:00/28	B9creati	B9Creations
@@ -29947,9 +31609,11 @@ C0:E4:2D	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 C0:E5:4E	AriesEmb	ARIES Embedded GmbH
 C0:EA:E4	Sonicwal	Sonicwall
 C0:EE:40	LairdTec	Laird Technologies
+C0:EE:B5	EniceNet	Enice Network.
 C0:EE:FB	OneplusT	OnePlus Tech (Shenzhen) Ltd
 C0:F1:C4	Pacidal	Pacidal Corporation Ltd.
 C0:F2:FB	Apple	Apple, Inc.
+C0:F4:E6	HuaweiTe	Huawei Technologies Co.,Ltd
 C0:F6:36	Hangzhou	Hangzhou Kuaiyue Technologies, Ltd.
 C0:F7:9D	Powercod	Powercode
 C0:F8:DA	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
@@ -29987,14 +31651,18 @@ C4:1C:FF	Vizio	Vizio, Inc
 C4:1E:CE	HmiSourc	HMI Sources Ltd.
 C4:21:C8	Kyocera	Kyocera Corporation
 C4:23:7A	Whiznets	WhizNets Inc.
+C4:23:A2	PtEmsoni	PT. Emsonic Indonesia
 C4:24:2E	Galvanic	Galvanic Applied Sciences Inc
+C4:24:56	PaloAlto	Palo Alto Networks
 C4:26:28	AiroWire	Airo Wireless
 C4:27:95	Technico	Technicolor CH USA Inc.
 C4:28:2D	Embedded	Embedded Intellect Pty Ltd
 C4:29:1D	KlemsanE	Klemsan Elektrik Elektronik San.Ve Tic.As.
 C4:2C:03	Apple	Apple, Inc.
+C4:2C:4F	QingdaoH	Qingdao Hisense Mobile Communication Technology Co,Ltd
 C4:2F:90	Hangzhou	Hangzhou Hikvision Digital Technology Co.,Ltd.
 C4:30:18	McsLogic	MCS Logic Inc.
+C4:33:06	ChinaMob	China Mobile Group Device Co.,Ltd.
 C4:34:6B	HewlettP	Hewlett Packard
 C4:36:55	Shenzhen	Shenzhen Fenglian Technology Co., Ltd.
 C4:36:6C	LgInnote	LG Innotek
@@ -30002,7 +31670,7 @@ C4:36:DA	Rustelet	Rusteletech Ltd.
 C4:38:D3	Tagatec	Tagatec Co.,Ltd
 C4:39:3A	SmcNetwo	SMC Networks Inc
 C4:3A:9F	Siconix	Siconix Inc.
-C4:3A:BE	SonyMobi	Sony Mobile Communications AB
+C4:3A:BE	SonyMobi	Sony Mobile Communications Inc
 C4:3C:3C	CybelecS	Cybelec Sa
 C4:3D:C7	Netgear
 C4:40:44	Racktop	RackTop Systems Inc.
@@ -30020,7 +31688,9 @@ C4:4B:44	Omniprin	Omniprint Inc.
 C4:4B:D1	WallysCo	Wallys Communications  Teachnologies Co.,Ltd.
 C4:4E:1F	Bluen
 C4:4E:AC	Shenzhen	Shenzhen Shiningworth Technology Co., Ltd.
+C4:4F:33	Espressi	Espressif Inc.
 C4:50:06	SamsungE	Samsung Electronics Co.,Ltd
+C4:51:8D	Shenzhen	Shenzhen YOUHUA Technology Co., Ltd
 C4:54:44	QuantaCo	Quanta Computer Inc.
 C4:55:A6	CadacHol	Cadac Holdings Ltd
 C4:55:C2	Bach-Sim	Bach-Simpson
@@ -30046,12 +31716,14 @@ C4:6A:B7	XiaomiCo	Xiaomi Communications Co Ltd
 C4:6B:B4	Myidkey
 C4:6D:F1	Datagrav	DataGravity
 C4:6E:1F	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
+C4:6E:7B	Shenzhen	SHENZHEN RF-LINK TECHNOLOGY CO.,LTD.
 C4:70:0B	Guangzho	Guangzhou Chip Technologies Co.,Ltd
 C4:71:30	FonTechn	Fon Technology S.L.
 C4:71:54	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 C4:71:FE	Cisco	Cisco Systems, Inc
 C4:72:95	Cisco	Cisco Systems, Inc
 C4:73:1E	SamsungE	Samsung Electronics Co.,Ltd
+C4:74:F8	HotPeppe	Hot Pepper, Inc.
 C4:77:AB	BeijingA	Beijing ASU Tech Co.,Ltd
 C4:77:AF	Advanced	Advanced Digital Broadcast SA
 C4:7B:2F	BeijingJ	Beijing JoinHope Image Technology Ltd.
@@ -30091,11 +31763,16 @@ C4:92:4C	Keisokuk	Keisokuki Center Co.,Ltd.
 C4:93:00	8devices
 C4:93:13	100fioNe	100fio networks technology llc
 C4:93:80	Speedyte	Speedytel technology
+C4:93:D9	SamsungE	Samsung Electronics Co.,Ltd
+C4:95:00	AmazonTe	Amazon Technologies Inc.
 C4:95:A2	Shenzhen	Shenzhen Weijiu Industry And Trade Development Co., Ltd
 C4:98:05	MinieumN	Minieum Networks, Inc
+C4:98:5C	HuiZhouG	Hui Zhou Gaoshengda Technology Co.,LTD
+C4:98:80	Apple	Apple, Inc.
 C4:9A:02	LgElectr	LG Electronics (Mobile Communications)
 C4:9D:ED	Microsof	Microsoft Corporation
 C4:9E:41	G24Power	G24 Power Limited
+C4:9F:4C	HuaweiTe	Huawei Technologies Co.,Ltd
 C4:9F:F3	MciaoTec	Mciao Technologies, Inc.
 C4:A3:66	Zte	zte corporation
 C4:A8:1D	D-LinkIn	D-Link International
@@ -30106,6 +31783,7 @@ C4:AD:F1	Gopeace	GOPEACE Inc.
 C4:AE:12	SamsungE	Samsung Electronics Co.,Ltd
 C4:B3:01	Apple	Apple, Inc.
 C4:B5:12	GeneralE	General Electric Digital Energy
+C4:B8:B4	HuaweiTe	Huawei Technologies Co.,Ltd
 C4:B9:CD	Cisco	Cisco Systems, Inc
 C4:BA:99	I+MeActi	I+ME Actia Informatik und Mikro-Elektronik GmbH
 C4:BA:A3	BeijingW	Beijing Winicssec Technologies Co., Ltd.
@@ -30149,6 +31827,8 @@ C4:F4:64	SpicaInt	Spica international
 C4:F5:7C	BrocadeC	Brocade Communications Systems, Inc.
 C4:F5:A5	Kumalift	Kumalift Co., Ltd.
 C4:FC:E4	DishtvNz	DishTV NZ Ltd
+C4:FD:E6	Drtech
+C4:FE:E2	AmiccomE	AMICCOM Electronics Corporation
 C4:FF:1F	HuaweiTe	Huawei Technologies Co.,Ltd
 C4:FF:BC	IeeeRegi	IEEE Registration Authority
 C4:FF:BC:00:00:00/28	DanegoBv	Danego BV
@@ -30219,11 +31899,13 @@ C8:40:29	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 C8:45:29	ImkNetwo	IMK Networks Co.,Ltd
 C8:45:44	AsiaPaci	Asia Pacific CIS (Wuxi) Co, Ltd
 C8:45:8F	Wyler	Wyler AG
+C8:47:82	AresonTe	Areson Technology Corp.
 C8:47:8C	Beken	Beken Corporation
 C8:48:F5	MedisonX	MEDISON Xray Co., Ltd
 C8:4C:75	Cisco	Cisco Systems, Inc
 C8:50:E9	Raisecom	Raisecom Technology CO., LTD
 C8:51:95	HuaweiTe	Huawei Technologies Co.,Ltd
+C8:54:4B	ZyxelCom	Zyxel Communications Corporation
 C8:56:45	Intermas	Intermas France
 C8:56:63	SunflexE	Sunflex Europe GmbH
 C8:5B:76	LcfcHefe	LCFC(HeFei) Electronics Technology co., ltd
@@ -30242,7 +31924,7 @@ C8:72:48	AplicomO	Aplicom Oy
 C8:73:24	SowCheng	Sow Cheng Technology Co. Ltd.
 C8:75:5B	Quantify	Quantify Technology Pty. Ltd.
 C8:77:65	Tiesse	Tiesse SpA
-C8:77:8B	ThemisCo	Themis Computer
+C8:77:8B	Mercury–	Mercury Systems – Trusted Mission Solutions, Inc.
 C8:7B:5B	Zte	zte corporation
 C8:7C:BC	Valink	Valink Co., Ltd.
 C8:7D:77	Shenzhen	Shenzhen Kingtech Communication Equipment Co.,Ltd
@@ -30250,6 +31932,7 @@ C8:7E:75	SamsungE	Samsung Electronics Co.,Ltd
 C8:84:39	SunriseT	Sunrise Technologies
 C8:84:47	Beautifu	Beautiful Enterprise Co., Ltd
 C8:85:50	Apple	Apple, Inc.
+C8:86:29	Shenzhen	Shenzhen Duubee Intelligent Technologies Co.,LTD.
 C8:87:22	Lumenpul	Lumenpulse
 C8:87:3B	NetOptic	Net Optics
 C8:8A:83	Dongguan	Dongguan HuaHong Electronics Co.,Ltd
@@ -30272,6 +31955,7 @@ C8:8E:D1:C0:00:00/28	Shanghai	Shanghai Bwave Technology Co.,Ltd
 C8:8E:D1:D0:00:00/28	PhoenixE	Phoenix Engineering Corp.
 C8:8E:D1:E0:00:00/28	Aventics	Aventics GmbH
 C8:8E:D1:F0:00:00/28	Private
+C8:8F:26	Skyworth	Skyworth Digital Technology(Shenzhen) Co.,Ltd
 C8:90:3E	PaktonTe	Pakton Technologies
 C8:91:F9	Sagemcom	Sagemcom Broadband SAS
 C8:93:46	Mxchip	MXCHIP Company Limited
@@ -30279,6 +31963,7 @@ C8:93:83	Embedded	Embedded Automation, Inc.
 C8:94:BB	HuaweiTe	Huawei Technologies Co.,Ltd
 C8:94:D2	JiangsuD	Jiangsu Datang  Electronic Products Co., Ltd
 C8:97:9F	Nokia	Nokia Corporation
+C8:9C:13	Inspirem	Inspiremobile
 C8:9C:1D	Cisco	Cisco Systems, Inc
 C8:9C:DC	Elitegro	Elitegroup Computer Systems Co.,Ltd.
 C8:9F:1D	Shenzhen	Shenzhen Communication Technologies Co.,Ltd
@@ -30298,22 +31983,26 @@ C8:AA:CC	Private
 C8:AE:9C	Shanghai	Shanghai TYD Elecronic Technology Co. Ltd
 C8:AF:40	MarcoSys	marco Systemanalyse und Entwicklung GmbH
 C8:AF:E3	HefeiRad	Hefei Radio Communication Technology Co., Ltd
+C8:B1:EE	Qorvo
 C8:B2:1E	ChipseaT	CHIPSEA TECHNOLOGIES (SHENZHEN) CORP.
 C8:B3:73	Cisco-Li	Cisco-Linksys, LLC
 C8:B5:AD	HewlettP	Hewlett Packard Enterprise
 C8:B5:B7	Apple	Apple, Inc.
 C8:BA:94	SamsungE	SAMSUNG ELECTRO-MECHANICS(THAILAND)
+C8:BA:E9	Qdis
 C8:BB:D3	Embrane
 C8:BC:C8	Apple	Apple, Inc.
 C8:BE:19	D-LinkIn	D-Link International
 C8:C1:26	ZpmIndus	ZPM Industria e Comercio Ltda
 C8:C1:3C	Ruggedte	RuggedTek Hangzhou Co., Ltd
 C8:C2:C6	Shanghai	Shanghai Airm2m Communication Technology Co., Ltd
+C8:C2:F5	Flextron	FLEXTRONICS MANUFACTURING(ZHUHAI)CO.,LTD.
 C8:C5:0E	Shenzhen	Shenzhen Primestone Network Technologies.Co., Ltd.
 C8:C7:91	Zero1Tv	Zero1.tv GmbH
 C8:CB:B8	HewlettP	Hewlett Packard
 C8:CD:72	Sagemcom	Sagemcom Broadband SAS
 C8:D0:19	Shanghai	Shanghai Tigercel Communication Technology Co.,Ltd
+C8:D0:83	Apple	Apple, Inc.
 C8:D1:0B	Nokia	Nokia Corporation
 C8:D1:2A	Comtrend	Comtrend Corporation
 C8:D1:5E	HuaweiTe	Huawei Technologies Co.,Ltd
@@ -30325,8 +32014,9 @@ C8:D4:29	Muehlbau	Muehlbauer AG
 C8:D5:90	FlightDa	Flight Data Systems
 C8:D5:FE	Shenzhen	Shenzhen Zowee Technology Co., Ltd
 C8:D7:19	Cisco-Li	Cisco-Linksys, LLC
-C8:D7:79	QingdaoH	Qingdao Haier Telecom Co.，Ltd
+C8:D7:79	QingDaoH	Qing Dao Haier Telecom Co.,Ltd.
 C8:D7:B0	SamsungE	Samsung Electronics Co.,Ltd
+C8:D9:D2	HewlettP	Hewlett Packard
 C8:DB:26	Logitech
 C8:DD:C9	LenovoMo	Lenovo Mobile Communication Technology Ltd.
 C8:DE:51	Integrao	IntegraOptics
@@ -30338,7 +32028,7 @@ C8:E1:30	Milkyway	Milkyway Group Ltd
 C8:E1:A7	Vertu	Vertu Corporation Limited
 C8:E4:2F	Technica	Technical Research Design and Development
 C8:E7:76	PtcomTec	PTCOM Technology
-C8:E7:D8	Shenzhen	Shenzhen Mercury Communication Technologies Co.,Ltd.
+C8:E7:D8	MercuryC	Mercury Communication Technologies Co.,Ltd.
 C8:E7:F0	JuniperN	Juniper Networks
 C8:EE:08	TangtopT	Tangtop Technology Co.,Ltd
 C8:EE:75	PishionI	Pishion International Co. Ltd
@@ -30357,6 +32047,7 @@ C8:F9:46	LocosysT	LOCOSYS Technology Inc.
 C8:F9:81	SenecaSR	Seneca s.r.l.
 C8:F9:C8	Newsharp	NewSharp Technology(SuZhou)Co,Ltd
 C8:F9:F9	Cisco	Cisco Systems, Inc
+C8:FA:E1	ArqDigit	ARQ Digital LLC
 C8:FB:26	CiscoSpv	Cisco SPVTG
 C8:FD:19	TexasIns	Texas Instruments
 C8:FE:30	BejingDa	Bejing DAYO Mobile Communication Technology Ltd.
@@ -30379,6 +32070,7 @@ CC:07:AB	SamsungE	Samsung Electronics Co.,Ltd
 CC:07:E4	LenovoMo	Lenovo Mobile Communication Technology Ltd.
 CC:08:8D	Apple	Apple, Inc.
 CC:08:E0	Apple	Apple, Inc.
+CC:08:FB	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 CC:09:C8	Imaqliq	Imaqliq Ltd
 CC:0C:DA	Miljovak	Miljovakt AS
 CC:0D:EC	CiscoSpv	Cisco SPVTG
@@ -30408,6 +32100,7 @@ CC:1B:E0:F0:00:00/28	Private
 CC:1E:FF	Metrolog	Metrological Group BV
 CC:1F:C4	Invue
 CC:20:E8	Apple	Apple, Inc.
+CC:21:19	SamsungE	Samsung Electronics Co.,Ltd
 CC:22:18	Innodigi	InnoDigital Co., Ltd.
 CC:22:37	IeeeRegi	IEEE Registration Authority
 CC:22:37:00:00:00/28	MedcomSp	MEDCOM sp. z o.o.
@@ -30443,7 +32136,7 @@ CC:35:40	Technico	Technicolor CH USA Inc.
 CC:37:AB	Edgecore	Edgecore Networks Corportation
 CC:39:8C	Shiningt	Shiningtek
 CC:3A:61	SamsungE	Samsung Electro Mechanics Co., Ltd.
-CC:3A:DF	NeptuneT	Neptune Technology Group Inc.
+CC:3A:DF	Private
 CC:3B:3E	LesterEl	Lester Electrical
 CC:3B:58	Curiouse	Curiouser Products Inc
 CC:3C:3F	SaSSDate	SA.S.S. Datentechnik AG
@@ -30465,6 +32158,8 @@ CC:4E:EC	Humax	HUMAX Co., Ltd.
 CC:50:0A	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 CC:50:1C	KvhIndus	KVH Industries, Inc.
 CC:50:76	OcomComm	Ocom Communications, Inc.
+CC:50:E3	Espressi	Espressif Inc.
+CC:51:B4	Integrat	Integrated Device Technology (Malaysia) Sdn. Bhd.
 CC:52:AF	Universa	Universal Global Scientific Industrial Co., Ltd.
 CC:53:B5	HuaweiTe	Huawei Technologies Co.,Ltd
 CC:54:59	OntimeNe	OnTime Networks AS
@@ -30486,6 +32181,7 @@ CC:6D:A0	Roku	Roku, Inc.
 CC:6D:EF	TjkTieto	TJK Tietolaite Oy
 CC:6E:A4	SamsungE	Samsung Electronics Co.,Ltd
 CC:72:0F	Viscount	Viscount Systems Inc.
+CC:72:86	XiAnFeng	Xi'an Fengyu Information Technology Co., Ltd.
 CC:73:14	HongKong	Hong Kong Wheatek Technology Limited
 CC:74:98	Filmetri	Filmetrics Inc.
 CC:76:69	Seetech
@@ -30495,6 +32191,7 @@ CC:79:4A	BluProdu	BLU Products Inc.
 CC:79:CF	Shenzhen	SHENZHEN RF-LINK TECHNOLOGY CO.,LTD.
 CC:7A:30	CmaxWire	CMAX Wireless Co., Ltd.
 CC:7B:35	Zte	zte corporation
+CC:7B:61	Nikkiso	Nikkiso Co., Ltd.
 CC:7D:37	ArrisGro	ARRIS Group, Inc.
 CC:7E:E7	Panasoni	Panasonic Corporation AVC Networks Company
 CC:81:DA	PhicommS	Phicomm (Shanghai) Co., Ltd.
@@ -30507,12 +32204,15 @@ CC:8E:71	Cisco	Cisco Systems, Inc
 CC:90:93	HansongT	Hansong Tehnologies
 CC:90:E8	Shenzhen	Shenzhen YOUHUA Technology Co., Ltd
 CC:91:2B	TeConnec	TE Connectivity Touch Solutions
+CC:93:4A	SierraWi	Sierra Wireless
 CC:94:4A	Pfeiffer	Pfeiffer Vacuum GmbH
 CC:94:70	Kinestra	Kinestral Technologies, Inc.
 CC:95:D7	Vizio	Vizio, Inc
 CC:96:35	Lvs	LVS Co.,Ltd.
 CC:96:A0	HuaweiTe	Huawei Technologies Co.,Ltd
+CC:98:8B	SonyVisu	SONY Visual Products Inc.
 CC:98:91	Cisco	Cisco Systems, Inc
+CC:99:16	Integrat	Integrated Device Technology (Malaysia) Sdn. Bhd.
 CC:9E:00	Nintendo	Nintendo Co., Ltd.
 CC:9F:35	Transbit	Transbit Sp. z o.o.
 CC:9F:7A	ChiunMai	Chiun Mai Communication Systems, Inc
@@ -30535,17 +32235,22 @@ CC:B6:91	Necmagnu	NECMagnusCommunications
 CC:B8:88	AnbSecur	AnB Securite s.a.
 CC:B8:A8	AmpakTec	AMPAK Technology, Inc.
 CC:B8:F1	EagleKin	Eagle Kingdom Technologies Limited
+CC:BB:FE	HuaweiTe	Huawei Technologies Co.,Ltd
 CC:BD:35	Steinel	Steinel GmbH
 CC:BD:D3	Ultimake	Ultimaker B.V.
 CC:BE:59	Calix	Calix Inc.
 CC:BE:71	Optilogi	OptiLogix BV
+CC:C0:79	MurataMa	Murata Manufacturing Co., Ltd.
 CC:C1:04	AppliedT	Applied Technical Systems
+CC:C2:E0	Raisecom	Raisecom Technology CO., LTD
 CC:C3:EA	Motorola	Motorola Mobility LLC, a Lenovo Company
 CC:C5:0A	Shenzhen	Shenzhen Dajiahao Technology Co.,Ltd
+CC:C5:E5	Dell	Dell Inc.
 CC:C5:EF	Co-CommS	Co-Comm Servicios Telecomunicaciones S.L.
 CC:C6:2B	Tri-Syst	Tri-Systems Corporation
 CC:C7:60	Apple	Apple, Inc.
 CC:C8:D7	CiasElet	CIAS Elettronica srl
+CC:C9:2C	Schindle	Schindler - PORT Technology
 CC:CC:4E	SunFount	Sun Fountainhead USA. Corp
 CC:CC:81	HuaweiTe	Huawei Technologies Co.,Ltd
 CC:CD:64	Sm-Elect	SM-Electronic GmbH
@@ -30565,10 +32270,11 @@ CC:D3:1E:80:00:00/28	Inoage	inoage GmbH
 CC:D3:1E:90:00:00/28	SiemensM	Siemens AG, MO MLT BG
 CC:D3:1E:A0:00:00/28	HaishuTe	Haishu Technology LIMITED
 CC:D3:1E:B0:00:00/28	ElkProdu	Elk Products
-CC:D3:1E:C0:00:00/28	FluidicE	Fluidic Energy
+CC:D3:1E:C0:00:00/28	Nantener	NantEnergy
 CC:D3:1E:D0:00:00/28	CujoLlc	Cujo Llc
 CC:D3:1E:E0:00:00/28	Shenzhen	ShenZhenBoryNet Co.,LTD.
 CC:D3:E2	JiangsuY	Jiangsu Yinhe  Electronics Co.,Ltd.
+CC:D4:A1	Mitrasta	MitraStar Technology Corp.
 CC:D5:39	Cisco	Cisco Systems, Inc
 CC:D8:11	AiconnTe	Aiconn Technology Corporation
 CC:D8:C1	Cisco	Cisco Systems, Inc
@@ -30580,8 +32286,9 @@ CC:E7:98	MySocial	My Social Stuff
 CC:E7:DF	American	American Magnetics, Inc.
 CC:E8:AC	SoyeaTec	SOYEA Technology Co.,Ltd.
 CC:EA:1C	Dconwork	DCONWORKS  Co., Ltd
-CC:EE:D9	VahleDet	VAHLE DETO GmbH
+CC:EE:D9	VahleAut	VAHLE Automation GmbH
 CC:EF:48	Cisco	Cisco Systems, Inc
+CC:F0:FD	ChinaMob	China Mobile (Hangzhou) Information Technology Co., Ltd.
 CC:F3:A5	ChiMeiCo	Chi Mei Communication Systems, Inc
 CC:F4:07	EukreaEl	Eukrea Electromatique Sarl
 CC:F5:38	3isysnet	3isysnetworks
@@ -30598,6 +32305,7 @@ CC:FC:B1	Wireless	Wireless Technology, Inc.
 CC:FD:17	TctMobil	TCT mobile ltd
 CC:FE:3C	SamsungE	Samsung Electronics Co.,Ltd
 D0:03:4B	Apple	Apple, Inc.
+D0:03:DF	SamsungE	Samsung Electronics Co.,Ltd
 D0:04:01	Motorola	Motorola Mobility LLC, a Lenovo Company
 D0:04:92	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 D0:05:2A	Arcadyan	Arcadyan Corporation
@@ -30611,6 +32319,7 @@ D0:12:42	Bios	BIOS Corporation
 D0:13:1E	SunrexTe	Sunrex Technology Corp
 D0:13:FD	LgElectr	LG Electronics (Mobile Communications)
 D0:15:4A	Zte	zte corporation
+D0:16:B4	HuaweiTe	Huawei Technologies Co.,Ltd
 D0:17:6A	SamsungE	Samsung Electronics Co.,Ltd
 D0:17:C2	AsustekC	ASUSTek COMPUTER INC.
 D0:1A:A7	Uniprint
@@ -30633,7 +32342,7 @@ D0:22:12:E0:00:00/28	U::Lux	u::Lux GmbH
 D0:22:12:F0:00:00/28	Private
 D0:22:BE	SamsungE	SAMSUNG ELECTRO-MECHANICS(THAILAND)
 D0:23:DB	Apple	Apple, Inc.
-D0:25:16	Shenzhen	Shenzhen Mercury Communication Technologies Co.,Ltd.
+D0:25:16	MercuryC	Mercury Communication Technologies Co.,Ltd.
 D0:25:44	SamsungE	SAMSUNG ELECTRO-MECHANICS(THAILAND)
 D0:25:98	Apple	Apple, Inc.
 D0:27:88	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
@@ -30657,7 +32366,7 @@ D0:4C:C1	Sintrone	SINTRONES Technology Corp.
 D0:4D:2C	Roku	Roku, Inc.
 D0:4F:7E	Apple	Apple, Inc.
 D0:50:99	AsrockIn	ASRock Incorporation
-D0:51:62	SonyMobi	Sony Mobile Communications AB
+D0:51:62	SonyMobi	Sony Mobile Communications Inc
 D0:52:A8	Physical	Physical Graph Corporation
 D0:53:49	LiteonTe	Liteon Technology Corporation
 D0:54:2D	Cambridg	Cambridge Industries(Group) Co.,Ltd.
@@ -30668,6 +32377,7 @@ D0:57:85	Pantech	Pantech Co., Ltd.
 D0:57:A1	WermaSig	Werma Signaltechnik GmbH & Co. KG
 D0:58:75	ActiveCo	Active Control Technology Inc.
 D0:58:A8	Zte	zte corporation
+D0:58:FC	Bskyb	BSkyB Ltd
 D0:59:95	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 D0:59:C3	Ceramicr	CeraMicro Technology Corporation
 D0:59:E4	SamsungE	Samsung Electronics Co.,Ltd
@@ -30715,11 +32425,14 @@ D0:76:50:C0:00:00/28	Electro-	Electro-Motive Diesel
 D0:76:50:D0:00:00/28	Tecnotro	tecnotron elekronik gmbh
 D0:76:50:E0:00:00/28	Revox	Revox Inc.
 D0:76:50:F0:00:00/28	Private
+D0:76:E7	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
+D0:77:14	Motorola	Motorola Mobility LLC, a Lenovo Company
 D0:7A:B5	HuaweiTe	Huawei Technologies Co.,Ltd
 D0:7C:2D	LeieIotT	Leie IOT technology Co., Ltd
 D0:7D:E5	ForwardP	Forward Pay Systems, Inc.
 D0:7E:28	HewlettP	Hewlett Packard
 D0:7E:35	IntelCor	Intel Corporate
+D0:7F:A0	SamsungE	Samsung Electronics Co.,Ltd
 D0:7F:C4	OuWeiTec	Ou Wei Technology Co.，Ltd. of Shenzhen City
 D0:81:7A	Apple	Apple, Inc.
 D0:83:D4	XtelWire	Xtel Wireless ApS
@@ -30727,10 +32440,12 @@ D0:84:B0	Sagemcom	Sagemcom Broadband SAS
 D0:87:E2	SamsungE	Samsung Electronics Co.,Ltd
 D0:89:99	Apcon	APCON, Inc.
 D0:8A:55	Skullcan	Skullcandy
+D0:8A:91	Technico	Technicolor CH USA Inc.
 D0:8B:7E	PassifSe	Passif Semiconductor
 D0:8C:B5	TexasIns	Texas Instruments
 D0:8C:FF	Upwis	Upwis Ab
 D0:92:9E	Microsof	Microsoft Corporation
+D0:92:FA	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 D0:93:80	DucereTe	Ducere Technologies Pvt. Ltd.
 D0:93:F8	Stonestr	Stonestreet One LLC
 D0:94:66	Dell	Dell Inc.
@@ -30750,12 +32465,14 @@ D0:AE:EC	AlphaNet	Alpha Networks Inc.
 D0:AF:B6	LinktopT	Linktop Technology Co., LTD
 D0:B0:CD	Moen
 D0:B1:28	SamsungE	Samsung Electronics Co.,Ltd
+D0:B2:14	Poewit	PoeWit Inc
 D0:B2:C4	Technico	Technicolor CH USA Inc.
 D0:B3:3F	Shenzhen	Shenzhen TINNO Mobile Technology Corp.
 D0:B4:98	RobertBo	Robert Bosch LLC Automotive Electronics
 D0:B5:23	Bestcare	Bestcare Cloucal Corp.
 D0:B5:3D	SeproRob	Sepro Robotique
 D0:B5:C2	TexasIns	Texas Instruments
+D0:B6:0A	XingluoT	Xingluo Technology Company  Limited
 D0:BA:E4	Shanghai	Shanghai MXCHIP Information Technology Co., Ltd.
 D0:BB:80	ShlTelem	SHL Telemedicine International Ltd.
 D0:BD:01	DsIntern	DS International
@@ -30766,6 +32483,8 @@ D0:C1:93	Skybell	Skybell, Inc
 D0:C1:B1	SamsungE	Samsung Electronics Co.,Ltd
 D0:C2:82	Cisco	Cisco Systems, Inc
 D0:C4:2F	Tamagawa	Tamagawa Seiki Co.,Ltd.
+D0:C5:D3	Azurewav	AzureWave Technology Inc.
+D0:C5:D8	Latecoer	Latecoere
 D0:C5:F3	Apple	Apple, Inc.
 D0:C7:89	Cisco	Cisco Systems, Inc
 D0:C7:C0	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
@@ -30780,6 +32499,7 @@ D0:D3:FC	Mios	Mios, Ltd.
 D0:D4:12	AdbBroad	ADB Broadband Italia
 D0:D4:71	Mvtech	MVTECH co., Ltd
 D0:D6:CC	Wintop
+D0:D7:83	HuaweiTe	Huawei Technologies Co.,Ltd
 D0:D9:4F	IeeeRegi	IEEE Registration Authority
 D0:D9:4F:00:00:00/28	PerfantT	Perfant Technology Co., Ltd
 D0:D9:4F:10:00:00/28	Mycable	mycable GmbH
@@ -30808,6 +32528,7 @@ D0:E5:4D	ArrisGro	ARRIS Group, Inc.
 D0:E7:82	Azurewav	AzureWave Technology Inc.
 D0:EB:03	ZhehuaTe	Zhehua technology limited
 D0:EB:9E	Seowoo	Seowoo Inc.
+D0:EF:C1	HuaweiTe	Huawei Technologies Co.,Ltd
 D0:F0:DB	Ericsson
 D0:F2:7F	Steadyse	SteadyServ Technoligies, LLC
 D0:F7:3B	HelmutMa	Helmut Mauell GmbH Werk Weida
@@ -30831,6 +32552,7 @@ D4:0F:B2	AppliedM	Applied Micro Electronics AME bv
 D4:10:90	Inform	iNFORM Systems AG
 D4:10:CF	Huanshun	Huanshun Network Science and Technology Co., Ltd.
 D4:11:D6	Shotspot	ShotSpotter, Inc.
+D4:12:43	AmpakTec	AMPAK Technology, Inc.
 D4:12:96	AnobitTe	Anobit Technologies Ltd.
 D4:12:BB	Quadrant	Quadrant Components Inc. Ltd
 D4:13:6F	AsiaPaci	Asia Pacific Brands
@@ -30840,7 +32562,7 @@ D4:1D:71	PaloAlto	Palo Alto Networks
 D4:1E:35	TohoElec	TOHO Electronics INC.
 D4:1F:0C	JaiOy	JAI Oy
 D4:20:6D	Htc	HTC Corporation
-D4:21:22	Sercomm	Sercomm Corporation
+D4:21:22	Sercomm	Sercomm Corporation.
 D4:22:3F	LenovoMo	Lenovo Mobile Communication Technology Ltd.
 D4:22:4E	AlcatelL	Alcatel Lucent
 D4:25:8B	IntelCor	Intel Corporate
@@ -30853,11 +32575,12 @@ D4:2C:3D	SkyLight	Sky Light Digital Limited
 D4:2C:44	Cisco	Cisco Systems, Inc
 D4:2F:23	AkenoriP	Akenori PTE Ltd
 D4:31:9D	Sinwatec
+D4:32:60	Gopro
 D4:32:66	Fike	Fike Corporation
 D4:36:39	TexasIns	Texas Instruments
 D4:36:DB	JiangsuT	Jiangsu Toppower Automotive Electronics Co., Ltd
 D4:37:D7	Zte	zte corporation
-D4:38:9C	SonyMobi	Sony Mobile Communications AB
+D4:38:9C	SonyMobi	Sony Mobile Communications Inc
 D4:3A:65	IgrsEngi	IGRS Engineering Lab Ltd.
 D4:3A:E9	Dongguan	DONGGUAN ipt INDUSTRIAL CO., LTD
 D4:3D:67	CarmaInd	Carma Industries Inc.
@@ -30888,16 +32611,18 @@ D4:60:E3	Sercomm	Sercomm Corporation.
 D4:61:2E	HuaweiTe	Huawei Technologies Co.,Ltd
 D4:61:32	ProConce	Pro Concept Manufacturer Co.,Ltd.
 D4:61:9D	Apple	Apple, Inc.
+D4:61:DA	Apple	Apple, Inc.
 D4:61:FE	Hangzhou	Hangzhou H3C Technologies Co., Limited
 D4:63:C6	Motorola	Motorola Mobility LLC, a Lenovo Company
 D4:63:FE	Arcadyan	Arcadyan Corporation
 D4:64:F7	ChengduU	Chengdu Usee Digital Technology Co., Ltd
-D4:66:A8	RiedoNet	Riedo Networks GmbH
-D4:67:61	SahabTec	Sahab Technology
+D4:66:A8	RiedoNet	Riedo Networks Ltd
+D4:67:61	UnitedGu	United Gulf Gate Co.
 D4:67:E7	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 D4:68:4D	RuckusWi	Ruckus Wireless
 D4:68:67	Neoventu	Neoventus Design Group
 D4:68:BA	Shenzhen	Shenzhen Sundray Technologies Company Limited
+D4:69:A5	Miura	Miura Systems Ltd.
 D4:6A:6A	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 D4:6A:91	SnapAv	Snap AV
 D4:6A:A8	HuaweiTe	Huawei Technologies Co.,Ltd
@@ -30909,6 +32634,8 @@ D4:6E:0E	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 D4:6E:5C	HuaweiTe	Huawei Technologies Co.,Ltd
 D4:6F:42	WaxessUs	WAXESS USA Inc
 D4:72:08	Bragi	Bragi GmbH
+D4:72:26	Zte	zte corporation
+D4:74:1B	BeijingH	Beijing HuaDa ZhiBao Electronic System Co.,Ltd.
 D4:76:EA	Zte	zte corporation
 D4:78:56	Avaya	Avaya Inc
 D4:79:C3	Camerone	Cameronet GmbH & Co. KG
@@ -30916,6 +32643,22 @@ D4:7A:E2	SamsungE	Samsung Electronics Co.,Ltd
 D4:7B:35	NeoMonit	NEO Monitors AS
 D4:7B:75	HartingE	HARTING Electronics GmbH
 D4:7B:B0	AskeyCom	Askey Computer Corp
+D4:7C:44	IeeeRegi	IEEE Registration Authority
+D4:7C:44:00:00:00/28	ExaforeO	Exafore Oy
+D4:7C:44:10:00:00/28	InnovizT	Innoviz Technologies LTD
+D4:7C:44:20:00:00/28	YundingN	YunDing Network Technology (Beijing) Co., Ltd
+D4:7C:44:30:00:00/28	OmronSen	Omron Sentech Co., Ltd.
+D4:7C:44:40:00:00/28	SammiOnf	Sammi Onformation Systems
+D4:7C:44:50:00:00/28	LsCommun	LS Communication Co.,Ltd.
+D4:7C:44:60:00:00/28	AsdaIct	ASDA ICT Co., Ltd.
+D4:7C:44:70:00:00/28	PongeeIn	Pongee Industries Co., Ltd.
+D4:7C:44:80:00:00/28	BeijingM	Beijing Maystar Information Technology Co., Ltd.
+D4:7C:44:90:00:00/28	SuzhouWa	Suzhou Wan Dian Zhang Network Technology Co., Ltd
+D4:7C:44:A0:00:00/28	Tendzone	Tendzone International Pte Ltd
+D4:7C:44:B0:00:00/28	Optim	OPTiM Corporation
+D4:7C:44:C0:00:00/28	StriveOr	Strive Orthopedics Inc
+D4:7C:44:D0:00:00/28	HuaqinTe	Huaqin Telecom Technology Co.,Ltd.
+D4:7C:44:E0:00:00/28	Shenzhen	Shenzhen Anysec Technology Co. Ltd
 D4:7D:FC	TecnoMob	Tecno Mobile Limited
 D4:81:CA	Idevices	iDevices, LLC
 D4:81:D7	Dell	Dell Inc.
@@ -30945,6 +32688,7 @@ D4:9B:5C	Chongqin	Chongqing Miedu Technology Co., Ltd.
 D4:9C:28	JaybirdL	JayBird LLC
 D4:9C:8E	Universi	University of FUKUI
 D4:9C:F4	PaloAlto	Palo Alto Networks
+D4:9E:05	Zte	zte corporation
 D4:9E:6D	WuhanZho	Wuhan Zhongyuan Huadian Science & Technology Co.,
 D4:A0:2A	Cisco	Cisco Systems, Inc
 D4:A1:48	HuaweiTe	Huawei Technologies Co.,Ltd
@@ -30953,6 +32697,7 @@ D4:A4:25	SmaxTech	SMAX Technology Co., Ltd.
 D4:A4:99	InviewTe	InView Technology Corporation
 D4:A9:28	Greenwav	GreenWave Reality Inc
 D4:AA:FF	MicroWor	Micro World
+D4:AB:82	ArrisGro	ARRIS Group, Inc.
 D4:AC:4E	BodiRsLl	BODi rS, LLC
 D4:AD:2D	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 D4:AE:05	SamsungE	Samsung Electronics Co.,Ltd
@@ -30962,9 +32707,11 @@ D4:B1:69	LeShiZhi	Le Shi Zhi Xin Electronic Technology (Tianjin) Limited
 D4:B2:7A	ArrisGro	ARRIS Group, Inc.
 D4:B4:3E	Messcomp	Messcomp Datentechnik GmbH
 D4:B8:FF	HomeCont	Home Control Singapore Pte Ltd
+D4:BD:1E	5vtTechn	5VT Technologies,Taiwan LTd.
 D4:BE:D9	Dell	Dell Inc.
 D4:BF:2D	SeContro	SE Controls Asia Pacific Ltd
 D4:BF:7F	Upvel
+D4:C1:9E	RuckusWi	Ruckus Wireless
 D4:C1:C8	Zte	zte corporation
 D4:C1:FC	Nokia	Nokia Corporation
 D4:C7:66	Acentic	Acentic GmbH
@@ -31005,7 +32752,9 @@ D4:F4:6F	Apple	Apple, Inc.
 D4:F4:BE	PaloAlto	Palo Alto Networks
 D4:F5:13	TexasIns	Texas Instruments
 D4:F6:3F	IeaSRL	Iea S.R.L.
+D4:F7:86	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 D4:F9:A1	HuaweiTe	Huawei Technologies Co.,Ltd
+D4:FC:13	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 D8:00:4D	Apple	Apple, Inc.
 D8:05:2E	Skyviia	Skyviia Corporation
 D8:06:D1	Honeywel	Honeywell Fire System (Shanghai) Co,. Ltd.
@@ -31013,6 +32762,7 @@ D8:08:31	SamsungE	Samsung Electronics Co.,Ltd
 D8:08:F5	ArcadiaN	Arcadia Networks Co. Ltd.
 D8:09:C3	Cercacor	Cercacor Labs
 D8:0C:CF	CGVSAS	C.G.V. S.A.S.
+D8:0D:17	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 D8:0D:E3	FxiTechn	Fxi Technologies As
 D8:0F:99	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 D8:14:D6	SureSyst	SURE SYSTEM Co Ltd
@@ -31020,15 +32770,18 @@ D8:15:0D	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 D8:16:0A	NipponEl	Nippon Electro-Sensory Devices
 D8:16:C1	DewavHkE	DEWAV (HK) ELECTRONICS LIMITED
 D8:18:2B	ContiTem	Conti Temic Microelectronic GmbH
+D8:18:D3	JuniperN	Juniper Networks
 D8:19:7A	Nuheara	Nuheara Ltd
 D8:19:CE	Telesqua	Telesquare
 D8:1B:FE	Twinlinx	Twinlinx Corporation
 D8:1C:14	Compacta	Compacta International, Ltd.
+D8:1C:79	Apple	Apple, Inc.
 D8:1D:72	Apple	Apple, Inc.
 D8:1E:DE	B&WGroup	B&W Group Ltd
 D8:1F:CC	BrocadeC	Brocade Communications Systems, Inc.
 D8:20:9F	CubroAcr	Cubro Acronet GesmbH
 D8:22:F4	AvnetSil	Avnet Silica
+D8:24:77	Universa	Universal Electric Corporation
 D8:24:BD	Cisco	Cisco Systems, Inc
 D8:25:22	ArrisGro	ARRIS Group, Inc.
 D8:25:B0	Rockeete	Rockeetech Systems Co.,Ltd.
@@ -31045,6 +32798,7 @@ D8:30:62	Apple	Apple, Inc.
 D8:31:CF	SamsungE	Samsung Electronics Co.,Ltd
 D8:32:14	TendaTec	Tenda Technology Co.,Ltd.Dongguan branch
 D8:32:5A	Shenzhen	Shenzhen YOUHUA Technology Co., Ltd
+D8:32:E3	XiaomiCo	Xiaomi Communications Co Ltd
 D8:33:7F	OfficeFa	Office FA.com Co.,Ltd.
 D8:37:BE	Shenzhen	Shenzhen Gongjin Electronics Co.,Lt
 D8:38:0D	Shenzhen	SHENZHEN IP-COM Network Co.,Ltd
@@ -31085,6 +32839,7 @@ D8:65:95	ToySMyth	Toy's Myth Inc.
 D8:66:C6	Shenzhen	Shenzhen Daystar Technology Co.,ltd
 D8:66:EE	BoxinCom	Boxin Communication Co.,Ltd.
 D8:67:D9	Cisco	Cisco Systems, Inc
+D8:68:C3	SamsungE	Samsung Electronics Co.,Ltd
 D8:69:60	Steinsvi	Steinsvik
 D8:6B:F7	Nintendo	Nintendo Co., Ltd.
 D8:6C:02	HuaqinTe	Huaqin Telecom Technology Co.,Ltd
@@ -31097,6 +32852,7 @@ D8:76:0A	Escort	Escort, Inc.
 D8:78:E5	KuhnSa	Kuhn Sa
 D8:79:88	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 D8:7C:DD	Sanix	Sanix Incorporated
+D8:7D:7F	Sagemcom	Sagemcom Broadband SAS
 D8:7E:B1	XOWare	x.o.ware, inc.
 D8:80:39	Microchi	Microchip Technology Inc.
 D8:80:3C	AnhuiHua	Anhui Huami Information Technology Company Limited
@@ -31109,6 +32865,7 @@ D8:8B:4C	Kingting	KingTing Tech.
 D8:8D:5C	Elentec
 D8:8F:76	Apple	Apple, Inc.
 D8:90:E8	SamsungE	Samsung Electronics Co.,Ltd
+D8:91:2A	ZyxelCom	Zyxel Communications Corporation
 D8:93:41	GeneralE	General Electric Global Research
 D8:94:03	HewlettP	Hewlett Packard Enterprise
 D8:95:2F	TexasIns	Texas Instruments
@@ -31129,6 +32886,8 @@ D8:A0:1D	Espressi	Espressif Inc.
 D8:A1:05	Syslane	Syslane, Co., Ltd.
 D8:A2:5E	Apple	Apple, Inc.
 D8:A5:34	Spectron	Spectronix Corporation
+D8:A7:56	Sagemcom	Sagemcom Broadband SAS
+D8:A9:8B	TexasIns	Texas Instruments
 D8:AD:DD	Sonavati	Sonavation, Inc.
 D8:AE:90	ItibiaTe	Itibia Technologies
 D8:AF:3B	Hangzhou	Hangzhou Bigbright Integrated communications system Co.,Ltd
@@ -31165,6 +32924,7 @@ D8:D3:85	HewlettP	Hewlett Packard
 D8:D4:3C	Sony	Sony Corporation
 D8:D5:B9	Rainfore	Rainforest Automation, Inc.
 D8:D6:7E	GskCncEq	Gsk Cnc Equipment Co.,Ltd
+D8:D6:F3	Integrat	Integrated Device Technology (Malaysia) Sdn. Bhd.
 D8:D7:23	Ids	IDS, Inc
 D8:D7:75	Sagemcom	Sagemcom Broadband SAS
 D8:D8:66	Shenzhen	Shenzhen Tozed Technologies Co.,Ltd.
@@ -31189,6 +32949,7 @@ D8:EE:78	MoogProt	Moog Protokraft
 D8:EF:CD	Nokia
 D8:F0:F2	Zeebo	Zeebo Inc
 D8:F1:F0	PepximIn	Pepxim International Limited
+D8:F3:DB	PostCh	Post CH AG
 D8:F7:10	LibreWir	Libre Wireless Technologies Inc.
 D8:FB:11	Axacore
 D8:FB:5E	AskeyCom	Askey Computer Corp
@@ -31220,6 +32981,7 @@ DC:0D:30	Shenzhen	Shenzhen Feasycom Technology Co., Ltd.
 DC:0E:A1	CompalIn	COMPAL INFORMATION (KUNSHAN) CO., LTD.
 DC:15:DB	GeRuiliI	Ge Ruili Intelligent Technology ( Beijing ) Co., Ltd.
 DC:16:A2	Medtroni	Medtronic Diabetes
+DC:16:B2	HuaweiTe	Huawei Technologies Co.,Ltd
 DC:17:5A	HitachiH	Hitachi High-Technologies Corporation
 DC:17:92	Captivat	Captivate Network
 DC:1A:01	EcolivTe	Ecoliv Technology ( Shenzhen ) Ltd.
@@ -31229,6 +32991,7 @@ DC:1D:D4	Microste	Microstep-MIS spol. s r.o.
 DC:1E:A3	Accensus	Accensus LLC
 DC:20:08	AsdElect	ASD Electronics Ltd
 DC:28:34	Hakko	HAKKO Corporation
+DC:29:19	Altobeam	AltoBeam (Xiamen) Technology Ltd, Co.
 DC:29:3A	Shenzhen	Shenzhen Nuoshi Technology Co., LTD.
 DC:2A:14	Shanghai	Shanghai Longjing Technology Co.
 DC:2B:2A	Apple	Apple, Inc.
@@ -31240,14 +33003,15 @@ DC:2D:CB	BeijingU	Beijing Unis HengYue Technology Co., Ltd.
 DC:2E:6A	Hct	HCT. Co., Ltd.
 DC:2F:03	StepForw	Step forward Group Co., Ltd.
 DC:30:9C	Heyrex	Heyrex Limited
-DC:33:0D	QingdaoH	Qingdao Haier Telecom Co.，Ltd
+DC:33:0D	QingDaoH	Qing Dao Haier Telecom Co.,Ltd.
 DC:33:50	Techsat	TechSAT GmbH
 DC:35:F1	Positivo	Positivo Informática SA.
 DC:37:14	Apple	Apple, Inc.
 DC:37:52	Ge
+DC:37:57	Integrat	Integrated Device Technology (Malaysia) Sdn. Bhd.
 DC:37:D2	HunanHkt	Hunan HKT Electronic Technology Co., Ltd
 DC:38:E1	JuniperN	Juniper Networks
-DC:39:79	Skyport	Skyport Systems
+DC:39:79	Cisco	Cisco Systems, Inc
 DC:3A:5E	Roku	Roku, Inc.
 DC:3C:2E	Manufact	Manufacturing System Insights, Inc.
 DC:3C:84	TicomGeo	Ticom Geomatics, Inc.
@@ -31255,6 +33019,7 @@ DC:3C:F6	AtomicRu	Atomic Rules LLC
 DC:3E:51	SolbergA	Solberg & Andersen AS
 DC:3E:F8	Nokia	Nokia Corporation
 DC:41:5F	Apple	Apple, Inc.
+DC:41:E5	Shenzhen	Shenzhen Zhixin Data Service Co., Ltd.
 DC:44:27	IeeeRegi	IEEE Registration Authority
 DC:44:27:00:00:00/28	Suritel
 DC:44:27:10:00:00/28	TeslaMot	Tesla Motors, Inc
@@ -31280,6 +33045,7 @@ DC:49:C9	CascoSig	Casco Signal Ltd
 DC:4A:3E	HewlettP	Hewlett Packard
 DC:4D:23	MrvComun	MRV Comunications
 DC:4E:DE	ShinyeiT	Shinyei Technology Co., Ltd.
+DC:4E:F4	Shenzhen	Shenzhen MTN Electronics CO., Ltd
 DC:4F:22	Espressi	Espressif Inc.
 DC:53:60	IntelCor	Intel Corporate
 DC:53:7C	CompalBr	Compal Broadband Networks, Inc.
@@ -31300,6 +33066,7 @@ DC:6F:00	Livescri	Livescribe, Inc.
 DC:6F:08	BayStora	Bay Storage Technology
 DC:70:14	Private
 DC:71:44	SamsungE	Samsung Electro Mechanics Co., Ltd.
+DC:72:9B	HuaweiTe	Huawei Technologies Co.,Ltd
 DC:74:A8	SamsungE	Samsung Electronics Co.,Ltd
 DC:78:34	LogicomS	Logicom Sa
 DC:7B:94	Cisco	Cisco Systems, Inc
@@ -31308,6 +33075,9 @@ DC:82:5B	JanusSpo	JANUS, spol. s r.o.
 DC:82:F6	Iport
 DC:85:DE	Azurewav	AzureWave Technology Inc.
 DC:86:D8	Apple	Apple, Inc.
+DC:8B:28	IntelCor	Intel Corporate
+DC:90:88	HuaweiTe	Huawei Technologies Co.,Ltd
+DC:99:14	HuaweiTe	Huawei Technologies Co.,Ltd
 DC:9A:8E	NanjingC	Nanjing Cocomm electronics co., LTD
 DC:9B:1E	Intercom	Intercom, Inc.
 DC:9B:9C	Apple	Apple, Inc.
@@ -31316,6 +33086,7 @@ DC:9C:9F	Shenzhen	Shenzhen YOUHUA Technology Co., Ltd
 DC:9F:A4	Nokia	Nokia Corporation
 DC:9F:DB	Ubiquiti	Ubiquiti Networks Inc.
 DC:A2:66	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
+DC:A3:33	Shenzhen	Shenzhen YOUHUA Technology Co., Ltd
 DC:A3:AC	Rbcloudt	RBcloudtech
 DC:A4:CA	Apple	Apple, Inc.
 DC:A5:F4	Cisco	Cisco Systems, Inc
@@ -31327,8 +33098,10 @@ DC:A9:71	IntelCor	Intel Corporate
 DC:A9:89	Macandc
 DC:AD:9E	Greenpri	GreenPriz
 DC:AE:04	Celoxica	CELOXICA Ltd
+DC:AF:68	WeifangG	Weifang Goertek Electronics Co.,Ltd
 DC:B0:58	BürkertW	Bürkert Werke GmbH
 DC:B3:B4	Honeywel	Honeywell Environmental & Combustion Controls (Tianjin) Co., Ltd.
+DC:B4:AC	Flextron	FLEXTRONICS MANUFACTURING(ZHUHAI)CO.,LTD.
 DC:B4:C4	Microsof	Microsoft XCG
 DC:BE:7A	Zhejiang	Zhejiang Nurotron Biotechnology Co.
 DC:BF:90	HuizhouQ	Huizhou Qiaoxing Telecommunication Industry Co.,Ltd.
@@ -31351,6 +33124,7 @@ DC:D0:F7	Bentek	Bentek Systems Ltd.
 DC:D2:55	KinpoEle	Kinpo Electronics, Inc.
 DC:D2:FC	HuaweiTe	Huawei Technologies Co.,Ltd
 DC:D3:21	Humax	HUMAX Co., Ltd.
+DC:D3:A2	Apple	Apple, Inc.
 DC:D5:2A	SunnyHea	Sunny Heart Limited
 DC:D8:7C	BeijingJ	Beijing Jingdong Century Trading Co., LTD.
 DC:D8:7F	Shenzhen	Shenzhen JoinCyber Telecom Equipment Ltd
@@ -31359,20 +33133,29 @@ DC:DA:4F	GetckTec	Getck Technology, Inc
 DC:DB:70	TonfunkS	Tonfunk Systementwicklung und Service GmbH
 DC:DC:07	TrpBv	TRP Systems BV
 DC:DD:24	Energica	Energica Motor Company SpA
+DC:DE:4F	GioneeCo	Gionee Communication Equipment Co Ltd
 DC:DE:CA	Akyllor
 DC:E0:26	PatrolTa	Patrol Tag, Inc
+DC:E0:EB	NanjingA	Nanjing Aozheng Information Technology Co.Ltd
 DC:E1:AD	Shenzhen	Shenzhen Wintop Photoelectric Technology Co., Ltd
 DC:E2:AC	LumensDi	Lumens Digital Optics Inc.
+DC:E3:05	ZaoNpkRo	ZAO NPK Rotek
 DC:E5:33	IeeeRegi	IEEE Registration Authority
 DC:E5:33:00:00:00/28	FlyhtAer	FLYHT Aerospace
 DC:E5:33:10:00:00/28	AmbiLabs	Ambi Labs Limited
 DC:E5:33:20:00:00/28	Remko	Remko GmbH & Co. KG
 DC:E5:33:30:00:00/28	Shenzhen	ShenZhen C&D Electronics CO.Ltd.
+DC:E5:33:40:00:00/28	Shenzhen	shenzhen bangying electronics co,.ltd
 DC:E5:33:50:00:00/28	Controls	Controls Inc
 DC:E5:33:60:00:00/28	WecanSol	WECAN Solution Inc.
 DC:E5:33:70:00:00/28	SanEngin	SAN Engineering
+DC:E5:33:80:00:00/28	Jb-Light	JB-Lighting Lichtanlagen GmbH
 DC:E5:33:90:00:00/28	Tiertime	Tiertime Corporation
 DC:E5:33:A0:00:00/28	Private
+DC:E5:33:B0:00:00/28	TintelHo	Tintel Hongkong Co.Ltd
+DC:E5:33:C0:00:00/28	Brck
+DC:E5:33:D0:00:00/28	SuzhouAt	Suzhou ATES electronic technology co.LTD
+DC:E5:33:E0:00:00/28	GiantPow	Giant Power Technology Biomedical Corporation
 DC:E5:78	Experime	Experimental Factory of Scientific Engineering and Special Design Department
 DC:E7:1C	AugElekt	AUG Elektronik GmbH
 DC:E8:38	CkTeleco	CK Telecom (Shenzhen) Limited
@@ -31385,7 +33168,11 @@ DC:EF:CA	MurataMa	Murata Manufacturing Co., Ltd.
 DC:F0:5D	LettaTek	Letta Teknoloji
 DC:F0:90	NubiaTec	Nubia Technology Co.,Ltd.
 DC:F1:10	Nokia	Nokia Corporation
+DC:F4:01	Dell	Dell Inc.
+DC:F5:05	Azurewav	AzureWave Technology Inc.
+DC:F7:19	Cisco	Cisco Systems, Inc
 DC:F7:55	Sitronik
+DC:F7:56	SamsungE	Samsung Electronics Co.,Ltd
 DC:F8:58	LorentNe	Lorent Networks, Inc.
 DC:FA:D5	StrongGe	STRONG Ges.m.b.H.
 DC:FB:02	Buffalo	Buffalo.Inc
@@ -31399,10 +33186,14 @@ E0:0B:28	Inovonic	Inovonics
 E0:0C:7F	Nintendo	Nintendo Co., Ltd.
 E0:0D:B9	Cree	Cree, Inc.
 E0:0E:DA	Cisco	Cisco Systems, Inc
+E0:0E:E1	We	We Corporation Inc.
 E0:10:7F	RuckusWi	Ruckus Wireless
+E0:12:83	Shenzhen	Shenzhen Fanzhuo Communication Technology Co., Lt
+E0:13:B5	VivoMobi	vivo Mobile Communication Co., Ltd.
 E0:14:3E	Modoosis	Modoosis Inc.
 E0:18:77	Fujitsu	Fujitsu Limited
 E0:19:1D	HuaweiTe	Huawei Technologies Co.,Ltd
+E0:19:D8	BhTechno	Bh Technologies
 E0:1A:EA	AlliedTe	Allied Telesis, Inc.
 E0:1C:41	Aerohive	Aerohive Networks Inc.
 E0:1C:EE	BravoTec	Bravo Tech, Inc.
@@ -31425,11 +33216,13 @@ E0:2F:6D	Cisco	Cisco Systems, Inc
 E0:30:05	Alcatel-	Alcatel-Lucent Shanghai Bell Co., Ltd
 E0:31:9E	Valve	Valve Corporation
 E0:31:D0	SzTelsta	SZ Telstar CO., LTD
+E0:33:8E	Apple	Apple, Inc.
 E0:34:E4	FeitElec	Feit Electric Company, Inc.
 E0:35:60	Challeng	Challenger Supply Holdings, LLC
 E0:36:76	HuaweiTe	Huawei Technologies Co.,Ltd
 E0:36:E3	StageOne	Stage One International Co., Ltd.
 E0:37:BF	WistronN	Wistron Neweb Corporation
+E0:38:3F	Zte	zte corporation
 E0:39:D7	Plexxi	Plexxi, Inc.
 E0:3C:5B	Shenzhen	Shenzhen Jiaxinjie Electron Co.,Ltd
 E0:3E:44	Broadcom
@@ -31438,9 +33231,12 @@ E0:3E:7D	Data-Com	data-complex GmbH
 E0:3F:49	AsustekC	ASUSTek COMPUTER INC.
 E0:41:36	Mitrasta	MitraStar Technology Corp.
 E0:43:DB	Shenzhen	Shenzhen ViewAt Technology Co.,Ltd.
+E0:45:6D	ChinaMob	China Mobile Group Device Co.,Ltd.
 E0:46:9A	Netgear
+E0:46:E5	GosuncnT	Gosuncn Technology Group Co., Ltd.
 E0:48:AF	Premiete	Premietech Limited
 E0:48:D3	Mobiwire	MOBIWIRE MOBILES (NINGBO) CO.,LTD
+E0:49:ED	AudezeLl	Audeze LLC
 E0:4B:45	Hi-PElec	Hi-P Electronics Pte Ltd
 E0:4F:43	Universa	Universal Global Scientific Industrial Co., Ltd.
 E0:4F:BD	SichuanT	Sichuan Tianyi Comheart Telecomco.,Ltd
@@ -31452,25 +33248,31 @@ E0:55:97	Emergent	Emergent Vision Technologies Inc.
 E0:56:F4	Axesnetw	AxesNetwork Solutions inc.
 E0:58:9E	LaerdalM	Laerdal Medical
 E0:5B:70	Innovid	Innovid, Co., Ltd.
+E0:5D:5C	OyEveron	Oy Everon Ab
 E0:5D:A6	DetlefFi	Detlef Fink Elektronik & Softwareentwicklung
 E0:5F:45	Apple	Apple, Inc.
 E0:5F:B9	Cisco	Cisco Systems, Inc
-E0:60:66	Sercomm	Sercomm Corporation
+E0:60:66	Sercomm	Sercomm Corporation.
 E0:60:89	Cloudlea	Cloudleaf, Inc.
 E0:61:B2	Hangzhou	Hangzhou Zenointel Technology Co., Ltd
+E0:62:67	XiaomiCo	Xiaomi Communications Co Ltd
 E0:62:90	JinanJov	Jinan Jovision Science & Technology Co., Ltd.
-E0:63:E5	SonyMobi	Sony Mobile Communications AB
+E0:63:DA	Ubiquiti	Ubiquiti Networks Inc.
+E0:63:E5	SonyMobi	Sony Mobile Communications Inc
 E0:64:BB	Digiview	DigiView S.r.l.
 E0:66:78	Apple	Apple, Inc.
 E0:67:B3	C-DataTe	C-Data Technology Co., Ltd
 E0:68:6D	Raybased	Raybased AB
 E0:69:95	Pegatron	Pegatron Corporation
+E0:73:5F	Nucom
 E0:75:0A	AlpsElec	Alps Electric Co.,Ltd.
 E0:75:7D	Motorola	Motorola Mobility LLC, a Lenovo Company
 E0:76:D0	AmpakTec	AMPAK Technology, Inc.
 E0:78:A3	Shanghai	Shanghai Winner Information Technology Co.,Inc
+E0:79:5E	WuxiXiao	Wuxi Xiaohu Technology Co.,Ltd.
 E0:7C:13	Zte	zte corporation
 E0:7C:62	WhistleL	Whistle Labs, Inc.
+E0:7D:EA	TexasIns	Texas Instruments
 E0:7F:53	Techboar	Techboard Srl
 E0:7F:88	Evidence	EVIDENCE Network SIA
 E0:81:77	Greenbyt	GreenBytes, Inc.
@@ -31496,6 +33298,7 @@ E0:A1:98	NojaPowe	NOJA Power Switchgear Pty Ltd
 E0:A1:D7	Sfr
 E0:A3:0F	Pevco
 E0:A3:AC	HuaweiTe	Huawei Technologies Co.,Ltd
+E0:A5:09	BitmainT	Bitmain Technologies Inc
 E0:A6:70	Nokia	Nokia Corporation
 E0:A7:00	Verkada	Verkada Inc
 E0:A8:B8	LeShiZhi	Le Shi Zhi Xin Electronic Technology (Tianjin) Limited
@@ -31509,6 +33312,7 @@ E0:AE:5E	AlpsElec	Alps Electric Co.,Ltd.
 E0:AE:B2	Bender&A	Bender GmbH &amp; Co.KG
 E0:AE:ED	Loenk
 E0:AF:4B	Pluribus	Pluribus Networks, Inc.
+E0:AF:4F	Deutsche	Deutsche Telekom AG
 E0:B2:F1	Fn-LinkT	FN-LINK TECHNOLOGY LIMITED
 E0:B5:2D	Apple	Apple, Inc.
 E0:B6:F5	IeeeRegi	IEEE Registration Authority
@@ -31533,6 +33337,7 @@ E0:B9:4D	Shenzhen	SHENZHEN BILIAN ELECTRONIC CO.，LTD
 E0:B9:A5	Azurewav	AzureWave Technology Inc.
 E0:B9:BA	Apple	Apple, Inc.
 E0:B9:E5	Technico	Technicolor
+E0:BA:B4	Arrcus	Arrcus, Inc
 E0:BC:43	C2Micros	C2 Microsystems, Inc.
 E0:C0:D1	CkTeleco	CK Telecom (Shenzhen) Limited
 E0:C2:86	AisaiCom	Aisai Communication Technology Co., Ltd.
@@ -31569,6 +33374,7 @@ E0:DB:88	OpenStan	Open Standard Digital-IF Interface for SATCOM Systems
 E0:DC:A0	SiemensI	Siemens Industrial Automation Products Ltd Chengdu
 E0:DD:C0	VivoMobi	vivo Mobile Communication Co., Ltd.
 E0:E5:CF	TexasIns	Texas Instruments
+E0:E6:2E	TctMobil	TCT mobile ltd
 E0:E6:31	SnbTechn	Snb Technologies Limited
 E0:E7:51	Nintendo	Nintendo Co., Ltd.
 E0:E7:BB	Nureva	Nureva, Inc.
@@ -31588,6 +33394,7 @@ E0:FF:F7	Softiron	Softiron Inc.
 E2:0C:0F	Kingston	Kingston Technologies
 E4:02:9B	IntelCor	Intel Corporate
 E4:04:39	TomtomSo	TomTom Software Ltd
+E4:0E:EE	HuaweiTe	Huawei Technologies Co.,Ltd
 E4:11:5B	HewlettP	Hewlett Packard
 E4:12:18	Shenzhen	ShenZhen Rapoo Technology Co., Ltd.
 E4:12:1D	SamsungE	Samsung Electronics Co.,Ltd
@@ -31598,6 +33405,7 @@ E4:1A:2C	Zpe	ZPE Systems, Inc.
 E4:1C:4B	V2Techno	V2 TECHNOLOGY, INC.
 E4:1D:2D	Mellanox	Mellanox Technologies, Inc.
 E4:1F:13	Ibm	IBM Corp
+E4:1F:E9	Dunkermo	Dunkermotoren GmbH
 E4:22:A5	Plantron	Plantronics, Inc.
 E4:23:54	Shenzhen	Shenzhen Fuzhi Software Technology Co.,Ltd
 E4:25:E7	Apple	Apple, Inc.
@@ -31613,23 +33421,27 @@ E4:2F:56	Optomet	OptoMET GmbH
 E4:2F:F6	UnicoreC	Unicore communication Inc.
 E4:30:22	HanwhaTe	Hanwha Techwin Security Vietnam
 E4:32:CB	SamsungE	Samsung Electronics Co.,Ltd
+E4:34:93	HuaweiTe	Huawei Technologies Co.,Ltd
 E4:35:93	Hangzhou	Hangzhou GoTo technology Co.Ltd
 E4:35:C8	HuaweiTe	Huawei Technologies Co.,Ltd
 E4:35:FB	SabreTec	Sabre Technology (Hull) Ltd
 E4:37:D7	HenriDep	Henri Depaepe S.A.S.
 E4:38:F2	Advantag	Advantage Controls
 E4:3A:6E	Shenzhen	Shenzhen Zeroone Technology CO.,LTD
+E4:3C:80	Universi	University of Oklahoma
 E4:3E:D7	Arcadyan	Arcadyan Corporation
 E4:3F:A2	WuxiDspT	Wuxi DSP Technologies Inc.
 E4:40:E2	SamsungE	Samsung Electronics Co.,Ltd
 E4:41:E6	OttecTec	Ottec Technology GmbH
 E4:42:A6	IntelCor	Intel Corporate
+E4:43:4B	Dell	Dell Inc.
 E4:46:BD	C&CTechn	C&C TECHNIC TAIWAN CO., LTD.
 E4:46:DA	XiaomiCo	Xiaomi Communications Co Ltd
 E4:47:90	Guangdon	Guangdong Oppo Mobile Telecommunications Corp.,Ltd
 E4:48:C7	CiscoSpv	Cisco SPVTG
 E4:4C:6C	Shenzhen	Shenzhen Guo Wei Electronic Co,. Ltd.
 E4:4E:18	Gardasof	Gardasoft VisionLimited
+E4:4E:76	Champion	CHAMPIONTECH  ENTERPRISE (SHENZHEN) INC
 E4:4F:29	MaLighti	MA Lighting Technology GmbH
 E4:4F:5F	EdsElekt	EDS Elektronik Destek San.Tic.Ltd.Sti
 E4:50:9A	HwCommun	HW Communications Ltd
@@ -31643,6 +33455,7 @@ E4:5A:A2	VivoMobi	vivo Mobile Communication Co., Ltd.
 E4:5D:51	Sfr
 E4:5D:52	Avaya	Avaya Inc
 E4:5D:75	SamsungE	Samsung Electronics Co.,Ltd
+E4:60:59	Pingtek	Pingtek Co., Ltd.
 E4:62:51	HaoCheng	Hao Cheng Group Limited
 E4:64:49	ArrisGro	ARRIS Group, Inc.
 E4:67:BA	DanishIn	Danish Interpretation Systems A/S
@@ -31666,6 +33479,7 @@ E4:7E:66	HuaweiTe	Huawei Technologies Co.,Ltd
 E4:7F:B2	Fujitsu	Fujitsu Limited
 E4:81:84	Nokia
 E4:81:B3	Shenzhen	Shenzhen ACT Industrial Co.,Ltd.
+E4:82:CC	Jumptron	Jumptronic GmbH
 E4:83:99	ArrisGro	ARRIS Group, Inc.
 E4:85:01	GeberitI	Geberit International AG
 E4:8A:D5	RfWindow	Rf Window Co., Ltd.
@@ -31673,6 +33487,7 @@ E4:8B:7F	Apple	Apple, Inc.
 E4:8C:0F	Discover	Discovery Insure
 E4:8D:8C	Routerbo	Routerboard.com
 E4:8F:34	Vodafone	Vodafone Italia S.p.A.
+E4:8F:65	YelatmaI	Yelatma Instrument Making Enterprise, JSC
 E4:90:69	Rockwell	Rockwell Automation
 E4:90:7E	Motorola	Motorola Mobility LLC, a Lenovo Company
 E4:92:E7	Gridlink	Gridlink Tech. Co.,Ltd.
@@ -31717,32 +33532,40 @@ E4:AD:7D	SclEleme	SCL Elements
 E4:AF:A1	Hes-So
 E4:B0:05	BeijingI	Beijing IQIYI Science & Technology Co., Ltd.
 E4:B0:21	SamsungE	Samsung Electronics Co.,Ltd
+E4:B2:FB	Apple	Apple, Inc.
 E4:B3:18	IntelCor	Intel Corporate
+E4:B9:7A	Dell	Dell Inc.
 E4:BA:D9	360Fly	360 Fly Inc.
 E4:BD:4B	Zte	zte corporation
 E4:BE:ED	NetcoreT	Netcore Technology Inc.
 E4:C1:46	Objetivo	Objetivos y Servicios de Valor A
 E4:C1:F1	Shenzhen	SHENZHEN SPOTMAU INFORMATION TECHNOLIGY CO., Ltd
 E4:C2:D1	HuaweiTe	Huawei Technologies Co.,Ltd
+E4:C4:83	Guangdon	Guangdong Oppo Mobile Telecommunications Corp.,Ltd
 E4:C6:2B	Airware
 E4:C6:3D	Apple	Apple, Inc.
 E4:C6:E6	MophieLl	Mophie, LLC
 E4:C7:22	Cisco	Cisco Systems, Inc
 E4:C8:01	BluProdu	BLU Products Inc
 E4:C8:06	CeiecEle	Ceiec Electric Technology Inc.
+E4:CA:12	Zte	zte corporation
 E4:CB:59	BeijingL	Beijing Loveair Science and Technology Co. Ltd.
 E4:CE:02	Wyrestor	WyreStorm Technologies Ltd
 E4:CE:70	HealthLi	Health & Life co., Ltd.
 E4:CE:8F	Apple	Apple, Inc.
+E4:D1:24	MojoNetw	Mojo Networks, Inc.
 E4:D3:32	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 E4:D3:F1	Cisco	Cisco Systems, Inc
 E4:D5:3D	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 E4:D7:1D	OrayaThe	Oraya Therapeutics
+E4:DB:6D	BeijingX	Beijing Xiaomi Electronics Co., Ltd.
 E4:DD:79	En-Visio	En-Vision America, Inc.
 E4:E0:A6	Apple	Apple, Inc.
 E4:E0:C5	SamsungE	Samsung Electronics Co.,Ltd
+E4:E1:30	TctMobil	TCT mobile ltd
 E4:E4:09	Leifheit	Leifheit Ag
 E4:E4:AB	Apple	Apple, Inc.
+E4:EA:83	Shenzhen	Shenzhen Gongjin Electronics Co.,Lt
 E4:EC:10	Nokia	Nokia Corporation
 E4:EE:FD	Mr&DManu	MR&D Manufacturing
 E4:F0:04	Dell	Dell Inc.
@@ -31761,6 +33584,7 @@ E4:FA:ED	SamsungE	Samsung Electronics Co.,Ltd
 E4:FA:FD	IntelCor	Intel Corporate
 E4:FB:5D	HuaweiTe	Huawei Technologies Co.,Ltd
 E4:FB:8F	Mobiwire	MOBIWIRE MOBILES (NINGBO) CO.,LTD
+E4:FC:82	JuniperN	Juniper Networks
 E4:FE:D9	EdmiEuro	EDMI Europe Ltd
 E4:FF:DD	Electron	Electron India
 E8:00:36	Befs	Befs co,. ltd
@@ -31804,6 +33628,9 @@ E8:18:63:C0:00:00/28	Shenzhen	Shenzhen Hipad Telecommunication Technology Co.,Lt
 E8:18:63:D0:00:00/28	DigitalD	Digital Dynamics, Inc.
 E8:18:63:E0:00:00/28	AcopianT	Acopian Technical Company
 E8:18:63:F0:00:00/28	Private
+E8:1A:58	Technolo	Technologic Systems
+E8:1A:AC	OrfeoSou	ORFEO SOUNDWORKS Inc.
+E8:1C:BA	Fortinet	Fortinet, Inc.
 E8:1D:A8	RuckusWi	Ruckus Wireless
 E8:20:E2	Humax	HUMAX Co., Ltd.
 E8:28:77	Tmy	TMY Co., Ltd.
@@ -31840,9 +33667,11 @@ E8:55:B4	SaiTechn	SAI Technology Inc.
 E8:56:59	Advanced	Advanced-Connectek Inc.
 E8:56:D6	Nctech	NCTech Ltd
 E8:5A:A7	LlcEmzio	LLC Emzior
+E8:5A:D1	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 E8:5B:5B	LgElectr	Lg Electronics Inc
 E8:5B:F0	ImagingD	Imaging Diagnostics
 E8:5D:6B	Luminate	Luminate Wireless
+E8:5D:86	ChangYow	Chang Yow Technologies International Co.,Ltd.
 E8:5E:53	Infratec	Infratec Datentechnik GmbH
 E8:61:1F	DawningI	Dawning Information Industry Co.,Ltd
 E8:61:7E	LiteonTe	Liteon Technology Corporation
@@ -31852,6 +33681,7 @@ E8:65:49	Cisco	Cisco Systems, Inc
 E8:65:D4	TendaTec	Tenda Technology Co.,Ltd.Dongguan branch
 E8:66:C4	Diamanti
 E8:68:19	HuaweiTe	Huawei Technologies Co.,Ltd
+E8:6A:64	LcfcHefe	LCFC(HeFei) Electronics Technology co., ltd
 E8:6C:DA	Supercom	Supercomputers and Neurocomputers Research Center
 E8:6D:52	ArrisGro	ARRIS Group, Inc.
 E8:6D:54	DigitMob	Digit Mobile Inc
@@ -31876,26 +33706,31 @@ E8:91:20	Motorola	Motorola Mobility LLC, a Lenovo Company
 E8:92:18	Arcontia	Arcontia International AB
 E8:92:A4	LgElectr	LG Electronics (Mobile Communications)
 E8:93:09	SamsungE	Samsung Electronics Co.,Ltd
+E8:93:63	Nokia
 E8:94:4C	CogentHe	Cogent Healthcare Systems Ltd
 E8:94:F6	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 E8:96:06	TestoIns	testo Instruments (Shenzhen) Co., Ltd.
+E8:98:6D	PaloAlto	Palo Alto Networks
 E8:99:5A	PiigabPr	PiiGAB, Processinformation i Goteborg AB
 E8:99:C4	Htc	HTC Corporation
 E8:9A:8F	QuantaCo	Quanta Computer Inc.
-E8:9A:FF	FujianLa	Fujian Landi Commercial Equipment Co.,Ltd
+E8:9A:FF	FujianLa	Fujian LANDI Commercial Equipment Co.,Ltd
 E8:9D:87	Toshiba
 E8:9E:0C	Private
 E8:9E:B4	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 E8:9F:EC	ChengduK	CHENGDU KT ELECTRONIC HI-TECH CO.,LTD
 E8:A3:64	SignalPa	Signal Path International / Peachtree Audio
 E8:A4:C1	DeepSeaE	Deep Sea Electronics PLC
+E8:A7:88	XiamenLe	Xiamen Leelen Technology Co., Ltd
 E8:A7:F2	Straffic
 E8:AB:F3	HuaweiTe	Huawei Technologies Co.,Ltd
 E8:AB:FA	Shenzhen	Shenzhen Reecam Tech.Ltd.
+E8:AD:A6	Sagemcom	Sagemcom Broadband SAS
 E8:B1:FC	IntelCor	Intel Corporate
 E8:B2:AC	Apple	Apple, Inc.
 E8:B4:AE	Shenzhen	Shenzhen C&D Electronics Co.,Ltd
 E8:B4:C8	SamsungE	Samsung Electronics Co.,Ltd
+E8:B5:41	Zte	zte corporation
 E8:B6:C2	JuniperN	Juniper Networks
 E8:B7:48	Cisco	Cisco Systems, Inc
 E8:BA:70	Cisco	Cisco Systems, Inc
@@ -31907,12 +33742,14 @@ E8:C1:B8	NanjingB	Nanjing Bangzhong Electronic Commerce Limited
 E8:C1:D7	Philips
 E8:C2:29	H-Displa	H-Displays (MSC) Bhd
 E8:C3:20	AustcoCo	Austco Communication Systems Pty Ltd
+E8:C5:7A	Ufispace	Ufispace Co., LTD.
 E8:C7:4F	LiteonTe	Liteon Technology Corporation
 E8:CB:A1	Nokia	Nokia Corporation
 E8:CC:18	D-LinkIn	D-Link International
 E8:CC:32	Micronet	Micronet  LTD
 E8:CD:2D	HuaweiTe	Huawei Technologies Co.,Ltd
 E8:CE:06	Skyhawke	SkyHawke Technologies, LLC.
+E8:D0:99	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 E8:D0:FA	MksInstr	MKS Instruments Deutschland GmbH
 E8:D1:1B	AskeyCom	Askey Computer Corp
 E8:D4:83	Ultimate	ULTIMATE Europe Transportation Equipment GmbH
@@ -31948,6 +33785,7 @@ E8:F2:E2	LgInnote	LG Innotek
 E8:F2:E3	StarcorB	Starcor Beijing Co.,Limited
 E8:F7:24	HewlettP	Hewlett Packard Enterprise
 E8:F9:28	RftechSr	Rftech Srl
+E8:FA:F7	Guangdon	Guangdong Uniteddata Holding Group Co., Ltd.
 E8:FC:60	ElcomInn	ELCOM Innovations Private Limited
 E8:FC:AF	Netgear
 E8:FD:72	Shanghai	Shanghai Linguo Technology Co., Ltd.
@@ -31956,6 +33794,7 @@ E8:FD:E8	CelaLink	CeLa Link Corporation
 EA:34:B4	Thinkrf	ThinkRF Inc.
 EA:60:76	Cloudsim	CloudSimple, Inc.
 EA:9F:B1	PhilipsI	Philips International B.V.
+EA:BE:A7	Private
 EA:DD:88	IeeePes-	IEEE PES-PSRC Working Group H3, PC37.237
 EA:E0:D9	Berk-Tek	Berk-tek LLC
 EC:01:33	Trinus	Trinus Systems Inc.
@@ -31995,6 +33834,7 @@ EC:2E:4E	Hitachi-	HITACHI-LG DATA STORAGE INC
 EC:30:91	Cisco	Cisco Systems, Inc
 EC:35:86	Apple	Apple, Inc.
 EC:36:3F	Markov	Markov Corporation
+EC:38:73	JuniperN	Juniper Networks
 EC:38:8F	HuaweiTe	Huawei Technologies Co.,Ltd
 EC:3B:F0	Novelsat
 EC:3C:5A	ShenZhen	Shen Zhen Heng Sheng Hui Digital Technology Co.,Ltd
@@ -32020,6 +33860,7 @@ EC:51:BC	Guangdon	Guangdong Oppo Mobile Telecommunications Corp.,Ltd
 EC:52:DC	WorldMed	WORLD MEDIA AND TECHNOLOGY Corp.
 EC:54:2E	Shanghai	Shanghai XiMei Electronic Technology Co. Ltd
 EC:55:F9	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
+EC:58:EA	RuckusWi	Ruckus Wireless
 EC:59:E7	Microsof	Microsoft Corporation
 EC:5A:86	YulongCo	Yulong Computer Telecommunication Scientific (Shenzhen) Co.,Ltd
 EC:5C:69	Mitsubis	Mitsubishi Heavy Industries Mechatronics Systems,Ltd.
@@ -32028,37 +33869,47 @@ EC:60:E0	Avi-OnLa	AVI-ON LABS
 EC:62:64	Global41	Global411 Internet Services, LLC
 EC:63:E5	EpboardD	ePBoard Design LLC
 EC:64:E7	Mocacare	MOCACARE Corporation
+EC:65:CC	Panasoni	Panasonic Automotive Systems Company of America
 EC:66:D1	B&WGroup	B&W Group LTD
 EC:68:81	PaloAlto	Palo Alto Networks
 EC:6C:9F	ChengduV	Chengdu Volans Technology CO.,LTD
+EC:6F:0B	Fadu	FADU, Inc.
 EC:70:97	ArrisGro	ARRIS Group, Inc.
 EC:71:DB	Shenzhen	Shenzhen Baichuan Digital Technology Co., Ltd.
 EC:74:BA	Hirschma	Hirschmann Automation and Control GmbH
+EC:79:F2	Startel
 EC:7C:74	JustoneT	Justone Technologies Co., Ltd.
 EC:7D:11	VivoMobi	vivo Mobile Communication Co., Ltd.
 EC:7D:9D	Mei
+EC:7F:C6	EccelSas	Eccel Corporation Sas
 EC:80:09	Novaspar	NovaSparks
 EC:81:93	Logitech	Logitech, Inc
 EC:83:50	Microsof	Microsoft Corporation
 EC:83:6C	RmTech	RM Tech Co., Ltd.
+EC:83:D5	Gird	GIRD Systems Inc
+EC:84:B4	CigShang	Cig Shanghai Co Ltd
 EC:85:2F	Apple	Apple, Inc.
 EC:88:8F	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 EC:88:92	Motorola	Motorola Mobility LLC, a Lenovo Company
+EC:89:14	HuaweiTe	Huawei Technologies Co.,Ltd
 EC:89:F5	LenovoMo	Lenovo Mobile Communication Technology Ltd.
 EC:8A:4C	Zte	zte corporation
 EC:8A:C7	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
+EC:8C:9A	HuaweiTe	Huawei Technologies Co.,Ltd
 EC:8C:A2	RuckusWi	Ruckus Wireless
 EC:8E:AD	Dlx
 EC:8E:AE	Nagravis	Nagravision SA
 EC:8E:B5	HewlettP	Hewlett Packard
 EC:92:33	EddyfiNd	Eddyfi NDT Inc
 EC:93:27	Memmert+	MEMMERT GmbH + Co. KG
+EC:93:65	MapperAi	Mapper.ai, Inc.
 EC:93:ED	Ddos-Gua	DDoS-Guard LTD
 EC:96:81	2276427O	2276427 Ontario Inc
 EC:98:6C	LufftMes	Lufft Mess- und Regeltechnik GmbH
 EC:98:C1	BeijingR	Beijing Risbo Network Technology Co.,Ltd
 EC:9A:74	HewlettP	Hewlett Packard
 EC:9B:5B	Nokia	Nokia Corporation
+EC:9B:8B	HewlettP	Hewlett Packard Enterprise
 EC:9B:F3	SamsungE	SAMSUNG ELECTRO-MECHANICS(THAILAND)
 EC:9E:CD	ArtesynE	Artesyn Embedded Technologies
 EC:9F:0D	IeeeRegi	IEEE Registration Authority
@@ -32082,9 +33933,11 @@ EC:A8:6B	Elitegro	Elitegroup Computer Systems Co.,Ltd.
 EC:A9:FA	Guangdon	Guangdong Genius Technology Co.,Ltd.
 EC:AA:A0	Pegatron	Pegatron Corporation
 EC:AD:B8	Apple	Apple, Inc.
+EC:AF:97	Git
 EC:B0:E1	Ciena	Ciena Corporation
 EC:B1:06	AcuroNet	Acuro Networks, Inc
 EC:B1:D7	HewlettP	Hewlett Packard
+EC:B3:13	Shenzhen	Shenzhen Gongjin Electronics Co.,Lt
 EC:B5:41	ShinanoE	SHINANO E and E Co.Ltd.
 EC:B5:FA	PhilipsL	Philips Lighting BV
 EC:B8:70	BeijingH	Beijing Heweinet Technology Co.,Ltd.
@@ -32095,6 +33948,7 @@ EC:BD:09	FusionEl	FUSION Electronics Ltd
 EC:BD:1D	Cisco	Cisco Systems, Inc
 EC:C0:6A	Powercho	PowerChord Group Limited
 EC:C3:8A	Accuener	Accuenergy (CANADA) Inc
+EC:C4:0D	Nintendo	Nintendo Co.,Ltd
 EC:C8:82	Cisco	Cisco Systems, Inc
 EC:CB:30	HuaweiTe	Huawei Technologies Co.,Ltd
 EC:CD:6D	AlliedTe	Allied Telesis, Inc.
@@ -32127,6 +33981,7 @@ EC:F3:42	Guangdon	Guangdong Oppo Mobile Telecommunications Corp.,Ltd
 EC:F3:5B	Nokia	Nokia Corporation
 EC:F4:51	Arcadyan	Arcadyan Corporation
 EC:F4:BB	Dell	Dell Inc.
+EC:F6:BD	SncfMobi	SNCF MOBILITÉS
 EC:F7:2B	HdDigita	Hd Digital Tech Co., Ltd.
 EC:F8:EB	SichuanT	Sichuan Tianyi Comheart Telecomco., Ltd
 EC:FA:03	Fca
@@ -32142,10 +33997,13 @@ F0:03:8C	Azurewav	AzureWave Technology Inc.
 F0:07:86	Shandong	Shandong Bittel Electronics Co., Ltd
 F0:08:F1	SamsungE	Samsung Electronics Co.,Ltd
 F0:0D:5C	Jinqianm	JinQianMao  Technology Co.,Ltd.
+F0:0E:1D	Megafone	Megafone Limited
+F0:0F:EC	HuaweiTe	Huawei Technologies Co.,Ltd
 F0:13:C3	Shenzhen	Shenzhen Fenda Technology Co., Ltd
 F0:15:A0	Kyungdon	KyungDong One Co., Ltd.
 F0:15:B9	Playfusi	PlayFusion Limited
 F0:18:2B	LgChem	LG Chem
+F0:18:98	Apple	Apple, Inc.
 F0:1B:6C	VivoMobi	vivo Mobile Communication Co., Ltd.
 F0:1C:13	LgElectr	LG Electronics (Mobile Communications)
 F0:1C:2D	JuniperN	Juniper Networks
@@ -32197,15 +34055,34 @@ F0:3E:90	RuckusWi	Ruckus Wireless
 F0:3E:BF	GogoroTa	Gogoro Taiwan Limited
 F0:3F:F8	RLDrake	R L Drake
 F0:40:7B	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
+F0:41:C8	IeeeRegi	IEEE Registration Authority
+F0:41:C8:00:00:00/28	LinpaAco	Linpa Acoustic Technology Co.,Ltd
+F0:41:C8:10:00:00/28	Dongguan	DongGuan Siyoto Electronics Co., Ltd
+F0:41:C8:20:00:00/28	Shenzhen	Shenzhen Medica Technology Development Co., Ltd.
+F0:41:C8:30:00:00/28	Shenzhen	Shenzhen Wisewing Internet Technology Co.,Ltd
+F0:41:C8:40:00:00/28	Candelic	Candelic Limited
+F0:41:C8:50:00:00/28	XiAnMeiS	XI'AN MEI SHANG MEI WIRELESS TECHNOLOGY.Co., Ltd.
+F0:41:C8:60:00:00/28	AedEngin	AED Engineering GmbH
+F0:41:C8:70:00:00/28	Nanchang	Nanchang BlackShark Co.,Ltd.
+F0:41:C8:80:00:00/28	PostiumK	Postium Korea Co., Ltd.
+F0:41:C8:90:00:00/28	Shenzhen	Shenzhen  Nufilo Electronic Technology Co., Ltd.
+F0:41:C8:A0:00:00/28	Telstra
+F0:41:C8:B0:00:00/28	Powervau	Powervault Ltd
+F0:41:C8:C0:00:00/28	Shanghai	Shanghai Think-Force Electronic Technology Co. Ltd
+F0:41:C8:D0:00:00/28	AtnMedia	ATN Media Group FZ LLC
+F0:41:C8:E0:00:00/28	Shenzhen	Shenzhen Umind Technology Co., Ltd.
 F0:42:1C	IntelCor	Intel Corporate
 F0:43:35	DvnShang	DVN(Shanghai)Ltd.
 F0:43:47	HuaweiTe	Huawei Technologies Co.,Ltd
 F0:45:DA	TexasIns	Texas Instruments
 F0:4A:2B	PyramidC	PYRAMID Computer GmbH
+F0:4B:3A	JuniperN	Juniper Networks
 F0:4B:6A	Scientif	Scientific Production Association Siberian Arsenal, Ltd.
 F0:4B:F2	JtechCom	JTECH Communications, Inc.
+F0:4C:D5	Maxlinea	Maxlinear, Inc
 F0:4D:A2	Dell	Dell Inc.
 F0:4F:7C	Private
+F0:54:94	Honeywel	Honeywell Connected Building
 F0:58:49	Careview	CareView Communications
 F0:5A:09	SamsungE	Samsung Electronics Co.,Ltd
 F0:5B:7B	SamsungE	Samsung Electronics Co.,Ltd
@@ -32216,6 +34093,7 @@ F0:5F:5A	Getriebe	Getriebebau NORD GmbH and Co. KG
 F0:61:30	Advantag	Advantage Pharmacy Services, LLC
 F0:62:0D	Shenzhen	Shenzhen Egreat Tech Corp.,Ltd
 F0:62:81	Procurve	ProCurve Networking by HP
+F0:63:F9	HuaweiTe	Huawei Technologies Co.,Ltd
 F0:65:C2	YanfengV	Yanfeng Visteon Electronics Technology (Shanghai) Co.,Ltd.
 F0:65:DD	PrimaxEl	Primax Electronics Ltd.
 F0:68:53	Integrat	Integrated Corporation
@@ -32239,6 +34117,7 @@ F0:7B:CB	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 F0:7D:68	D-Link	D-Link Corporation
 F0:7F:06	Cisco	Cisco Systems, Inc
 F0:7F:0C	LeopoldK	Leopold Kostal GmbH &Co. KG
+F0:81:73	AmazonTe	Amazon Technologies Inc.
 F0:81:AF	IrzAutom	Irz Automation Technologies Ltd
 F0:82:61	Sagemcom	Sagemcom Broadband SAS
 F0:84:2F	AdbBroad	ADB Broadband Italia
@@ -32252,15 +34131,19 @@ F0:92:1C	HewlettP	Hewlett Packard
 F0:92:B4	SichuanT	Sichuan Tianyi Comheart Telecomco., Ltd
 F0:93:3A	Nxtconec	NxtConect
 F0:93:C5	GarlandT	Garland Technology
+F0:95:F1	CarlZeis	Carl Zeiss AG
 F0:97:E5	Tamio	Tamio, Inc
 F0:98:38	HuaweiTe	Huawei Technologies Co.,Ltd
 F0:98:9D	Apple	Apple, Inc.
+F0:99:B6	Apple	Apple, Inc.
 F0:99:BF	Apple	Apple, Inc.
 F0:9A:51	Shanghai	Shanghai Viroyal Electronic Technology Company Limited
 F0:9C:BB	Raonthin	RaonThink Inc.
+F0:9C:D7	Guangzho	Guangzhou Blue Cheetah Intelligent Technology Co., Ltd.
 F0:9C:E9	Aerohive	Aerohive Networks Inc.
 F0:9E:63	Cisco	Cisco Systems, Inc
 F0:9F:C2	Ubiquiti	Ubiquiti Networks Inc.
+F0:9F:FC	Sharp	SHARP Corporation
 F0:A2:25	Private
 F0:A7:64	Gst	GST Co., Ltd.
 F0:AB:54	MitsumiE	Mitsumi Electric Co.,Ltd.
@@ -32283,14 +34166,19 @@ F0:AC:D7:D0:00:00/28	SmartPow	Smart Power Technology Co., Ltd.
 F0:AC:D7:E0:00:00/28	Fiziico	Fiziico Co., Ltd.
 F0:AD:4E	Globalsc	Globalscale Technologies, Inc.
 F0:AE:51	Xi3	Xi3 Corp
+F0:AF:50	PhantomI	Phantom Intelligence
+F0:AF:85	ArrisGro	ARRIS Group, Inc.
+F0:B0:14	AvmAudio	AVM Audiovisuelles Marketing und Computersysteme GmbH
 F0:B0:52	RuckusWi	Ruckus Wireless
 F0:B0:E7	Apple	Apple, Inc.
 F0:B2:E5	Cisco	Cisco Systems, Inc
 F0:B4:29	XiaomiCo	Xiaomi Communications Co Ltd
 F0:B4:79	Apple	Apple, Inc.
 F0:B5:B7	Disrupti	Disruptive Technologies Research AS
+F0:B5:D1	TexasIns	Texas Instruments
 F0:B6:EB	PoslabTe	Poslab Technology Co., Ltd.
 F0:BC:C8	MaxidPty	MaxID (Pty) Ltd
+F0:BC:C9	Pfu	Pfu Limited
 F0:BD:2E	H+SPolat	H+S Polatis Ltd
 F0:BD:F1	Sipod	Sipod Inc.
 F0:BF:97	Sony	Sony Corporation
@@ -32313,6 +34201,7 @@ F0:D5:BF	IntelCor	Intel Corporate
 F0:D6:57	Echosens
 F0:D7:67	AxemaPas	Axema Passagekontroll AB
 F0:D7:AA	Motorola	Motorola Mobility LLC, a Lenovo Company
+F0:D7:DC	WesineWu	Wesine (Wuhan) Technology Co., Ltd.
 F0:D9:B2	ExoSA	Exo S.A.
 F0:DA:7C	RlhIndus	Rlh Industries,Inc.
 F0:DB:30	Yottabyt	Yottabyte
@@ -32322,6 +34211,7 @@ F0:DC:E2	Apple	Apple, Inc.
 F0:DE:71	Shanghai	Shanghai EDO Technologies Co.,Ltd.
 F0:DE:B9	Shanghai	ShangHai Y&Y Electronics Co., Ltd
 F0:DE:F1	WistronI	Wistron Infocomm (Zhongshan) Corporation
+F0:E3:DC	TeconMtL	Tecon MT, LLC
 F0:E5:C3	Drägerwe	Drägerwerk AG & Co. KG aA
 F0:E7:7E	SamsungE	Samsung Electronics Co.,Ltd
 F0:EB:D0	Shanghai	Shanghai Feixun Communication Co.,Ltd.
@@ -32332,6 +34222,7 @@ F0:EE:58	PaceTele	PACE Telematics GmbH
 F0:EE:BB	Vipar	VIPAR GmbH
 F0:EF:D2	TfPaymen	Tf Payment Service Co., Ltd
 F0:F0:02	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
+F0:F0:8F	NextekSo	Nextek Solutions Pte Ltd
 F0:F2:49	HitronTe	Hitron Technologies. Inc
 F0:F2:60	Mobitec	Mobitec AB
 F0:F3:36	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
@@ -32344,6 +34235,7 @@ F0:F7:B3	Phorm
 F0:F8:42	Keebox	KEEBOX, Inc.
 F0:F8:F2	TexasIns	Texas Instruments
 F0:F9:F7	Ies	IES GmbH & Co. KG
+F0:FC:C8	ArrisGro	ARRIS Group, Inc.
 F0:FD:A0	AcurixNe	Acurix Networks Pty Ltd
 F0:FE:6B	Shanghai	Shanghai High-Flying Electronics Technology Co., Ltd
 F4:03:04	Google	Google, Inc.
@@ -32401,6 +34293,7 @@ F4:31:C3	Apple	Apple, Inc.
 F4:36:E1	AbilisSa	Abilis Systems SARL
 F4:37:B7	Apple	Apple, Inc.
 F4:38:14	Shanghai	Shanghai Howell Electronic Co.,Ltd
+F4:39:09	HewlettP	Hewlett Packard
 F4:3D:80	FagIndus	FAG Industrial Services GmbH
 F4:3E:61	Shenzhen	Shenzhen Gongjin Electronics Co.,Lt
 F4:3E:9D	BenuNetw	Benu Networks, Inc.
@@ -32435,7 +34328,9 @@ F4:5F:69	MatsufuE	Matsufu Electronics distribution Company
 F4:5F:D4	CiscoSpv	Cisco SPVTG
 F4:5F:F7	DqTechno	DQ Technology Inc.
 F4:60:0D	Panoptic	Panoptic Technology, Inc
+F4:60:E2	XiaomiCo	Xiaomi Communications Co Ltd
 F4:62:D0	NotForRa	Not for Radio, LLC
+F4:63:1F	HuaweiTe	Huawei Technologies Co.,Ltd
 F4:63:49	Diffon	Diffon Corporation
 F4:64:5D	Toshiba
 F4:67:2D	Shenzhen	ShenZhen Topstar Technology Company
@@ -32452,6 +34347,7 @@ F4:76:26	Viltechm	Viltechmeda UAB
 F4:7A:4E	Woojeon&	Woojeon&Handan
 F4:7A:CC	Solidfir	SolidFire, Inc.
 F4:7B:5E	SamsungE	Samsung Electronics Co.,Ltd
+F4:7D:EF	SamsungE	Samsung Electronics Co.,Ltd
 F4:7F:35	Cisco	Cisco Systems, Inc
 F4:81:39	Canon	Canon Inc.
 F4:83:CD	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
@@ -32470,6 +34366,7 @@ F4:91:1E	ZhuhaiEw	Zhuhai Ewpe Information Technology Inc
 F4:93:9F	HonHaiPr	Hon Hai Precision Ind. Co., Ltd.
 F4:94:61	NexgenSt	NexGen Storage
 F4:94:66	Countmax	CountMax,  ltd
+F4:95:1B	HefeiRad	Hefei Radio Communication Technology Co., Ltd
 F4:96:34	IntelCor	Intel Corporate
 F4:96:51	Nakayo	NAKAYO Inc
 F4:99:AC	WeberSch	WEBER Schraubautomaten GmbH
@@ -32492,7 +34389,9 @@ F4:B7:B3	VivoMobi	vivo Mobile Communication Co., Ltd.
 F4:B7:E2	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 F4:B8:5E	TexasIns	Texas Instruments
 F4:B8:A7	Zte	zte corporation
+F4:BC:97	Shenzhen	Shenzhen Crave Communication Co., LTD
 F4:BD:7C	ChengduJ	Chengdu jinshi communication Co., LTD
+F4:BF:80	HuaweiTe	Huawei Technologies Co.,Ltd
 F4:C2:48	SamsungE	Samsung Electronics Co.,Ltd
 F4:C4:47	CoagentI	Coagent International Enterprise Limited
 F4:C4:D6	Shenzhen	Shenzhen Xinfa Electronic Co.,ltd
@@ -32508,9 +34407,11 @@ F4:CD:90	Vispiron	Vispiron Rotec GmbH
 F4:CE:46	HewlettP	Hewlett Packard
 F4:CF:E2	Cisco	Cisco Systems, Inc
 F4:D0:32	YunnanId	Yunnan Ideal Information&Technology.,Ltd
+F4:D1:08	IntelCor	Intel Corporate
 F4:D2:61	Semocon	SEMOCON Co., Ltd
 F4:D7:B2	LgsInnov	LGS Innovations, LLC
 F4:D9:FB	SamsungE	Samsung Electronics Co.,Ltd
+F4:DB:E6	Cisco	Cisco Systems, Inc
 F4:DC:41	Youngzon	YOUNGZONE CULTURE (SHANGHAI) CORP
 F4:DC:4D	BeijingC	Beijing CCD Digital Technology Co., Ltd
 F4:DC:A5	DawonDns	Dawon Dns
@@ -32518,6 +34419,7 @@ F4:DC:DA	ZhuhaiJi	Zhuhai Jiahe Communication Technology Co., limited
 F4:DC:F9	HuaweiTe	Huawei Technologies Co.,Ltd
 F4:DD:9E	Gopro
 F4:DE:0C	Espod	ESPOD Ltd.
+F4:E1:1E	TexasIns	Texas Instruments
 F4:E1:42	DeltaEle	Delta Elektronika BV
 F4:E2:04	Traqueur
 F4:E3:FB	HuaweiTe	Huawei Technologies Co.,Ltd
@@ -32530,9 +34432,10 @@ F4:EA:B5	Aerohive	Aerohive Networks Inc.
 F4:EB:38	Sagemcom	Sagemcom Broadband SAS
 F4:EC:38	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 F4:ED:5F	Shenzhen	Shenzhen Ktc Technology Group
-F4:EE:14	Shenzhen	Shenzhen Mercury Communication Technologies Co.,Ltd.
+F4:EE:14	MercuryC	Mercury Communication Technologies Co.,Ltd.
 F4:EF:9E	SgsgScie	SGSG SCIENCE & TECHNOLOGY CO. LTD
 F4:F1:5A	Apple	Apple, Inc.
+F4:F1:97	Emtake	EMTAKE Inc
 F4:F1:E1	Motorola	Motorola Mobility LLC, a Lenovo Company
 F4:F2:6D	Tp-LinkT	TP-LINK TECHNOLOGIES CO.,LTD.
 F4:F3:AA	Jbl	JBL GmbH & Co. KG
@@ -32607,10 +34510,12 @@ F8:20:55	GreenInf	Green Information System
 F8:22:85	CypressT	Cypress Technology CO., LTD.
 F8:23:B2	HuaweiTe	Huawei Technologies Co.,Ltd
 F8:24:41	Yeelink
+F8:27:2E	Mercku
 F8:27:93	Apple	Apple, Inc.
 F8:28:19	LiteonTe	Liteon Technology Corporation
 F8:2B:C8	JiangsuS	Jiangsu Switter Co., Ltd
 F8:2C:18	2wire	2Wire Inc
+F8:2D:C0	ArrisGro	ARRIS Group, Inc.
 F8:2E:DB	Rtw	RTW GmbH & Co. KG
 F8:2F:08	Molex
 F8:2F:5B	EgaugeLl	eGauge Systems LLC
@@ -32622,6 +34527,8 @@ F8:33:76	GoodMind	Good Mind Innovation Co., Ltd.
 F8:34:41	IntelCor	Intel Corporate
 F8:35:53	MagentaR	Magenta Research Ltd.
 F8:35:DD	GemtekTe	Gemtek Technology Co., Ltd.
+F8:36:9B	TexasIns	Texas Instruments
+F8:38:80	Apple	Apple, Inc.
 F8:3D:4E	Softlink	Softlink Automation System Co., Ltd
 F8:3D:FF	HuaweiTe	Huawei Technologies Co.,Ltd
 F8:3F:51	SamsungE	Samsung Electronics Co.,Ltd
@@ -32636,6 +34543,7 @@ F8:4A:73	Eumtech	Eumtech Co., Ltd
 F8:4A:7F	Innometr	Innometriks Inc
 F8:4A:BF	HuaweiTe	Huawei Technologies Co.,Ltd
 F8:4F:57	Cisco	Cisco Systems, Inc
+F8:50:1C	TianjinG	Tianjin Geneuo Technology Co.,Ltd
 F8:50:63	Verathon
 F8:51:6D	DenwaTec	Denwa Technology Corp.
 F8:52:DF	VnlEurop	VNL Europe AB
@@ -32647,6 +34555,7 @@ F8:5B:9C	Sb	SB SYSTEMS Co.,Ltd
 F8:5B:C9	M-Cube	M-Cube Spa
 F8:5C:45	IcNexus	IC Nexus Co. Ltd.
 F8:5C:4D	Nokia
+F8:5E:3C	Shenzhen	Shenzhen Zhibotong Electronics Co.,Ltd
 F8:5F:2A	Nokia	Nokia Corporation
 F8:62:14	Apple	Apple, Inc.
 F8:62:AA	Xn	xn systems
@@ -32659,6 +34568,7 @@ F8:69:71	SeibuEle	Seibu Electric Co.,
 F8:6C:E1	TaicangT	Taicang T&W Electronics
 F8:6E:CF	Arcx	Arcx Inc
 F8:6E:EE	HuaweiTe	Huawei Technologies Co.,Ltd
+F8:6F:C1	Apple	Apple, Inc.
 F8:71:FE	GoldmanS	The Goldman Sachs Group, Inc.
 F8:72:EA	Cisco	Cisco Systems, Inc
 F8:73:94	Netgear
@@ -32691,6 +34601,7 @@ F8:8A:3C:B0:00:00/28	FaraAs	Fara As
 F8:8A:3C:C0:00:00/28	ExcetopT	EXCETOP TECHNOLOGY (BEIJING) CO., LTD.
 F8:8A:3C:D0:00:00/28	Thk	THK Co.,LTD.
 F8:8A:3C:E0:00:00/28	Avateq	Avateq Corp.
+F8:8B:37	ArrisGro	ARRIS Group, Inc.
 F8:8C:1C	KaishunE	Kaishun Electronic Technology Co., Ltd. Beijing
 F8:8D:EF	Tenebrae	Tenebraex
 F8:8E:85	Comtrend	Comtrend Corporation
@@ -32701,9 +34612,12 @@ F8:93:F3	Volans
 F8:94:C2	IntelCor	Intel Corporate
 F8:95:50	ProtonPr	Proton Products Chengdu Ltd
 F8:95:C7	LgElectr	LG Electronics (Mobile Communications)
+F8:95:EA	Apple	Apple, Inc.
 F8:97:CF	Daeshin-	DAESHIN-INFORMATION TECHNOLOGY CO., LTD.
 F8:98:3A	LeemanIn	Leeman International (HongKong) Limited
 F8:98:B9	HuaweiTe	Huawei Technologies Co.,Ltd
+F8:98:EF	HuaweiTe	Huawei Technologies Co.,Ltd
+F8:99:10	Integrat	Integrated Device Technology (Malaysia) Sdn. Bhd.
 F8:99:55	Fortress	Fortress Technology Inc
 F8:9D:0D	ControlT	Control Technology Inc.
 F8:9D:BB	Tintri
@@ -32749,12 +34663,15 @@ F8:BF:09	HuaweiTe	Huawei Technologies Co.,Ltd
 F8:C0:01	JuniperN	Juniper Networks
 F8:C0:91	Highgate	Highgates Technology
 F8:C1:20	XiAnLink	Xi'an Link-Science Technology Co.,Ltd
+F8:C2:49	Private
 F8:C2:88	Cisco	Cisco Systems, Inc
 F8:C3:72	TsuzukiD	Tsuzuki Denki
 F8:C3:97	Nzxt	NZXT Corp. Ltd.
+F8:C3:9E	HuaweiTe	Huawei Technologies Co.,Ltd
 F8:C6:78	Carefusi	Carefusion
 F8:C9:6C	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 F8:CA:B8	Dell	Dell Inc.
+F8:CC:6E	DepoElec	DEPO Electronics Ltd
 F8:CF:C5	Motorola	Motorola Mobility LLC, a Lenovo Company
 F8:D0:27	SeikoEps	Seiko Epson Corporation
 F8:D0:AC	SonyInte	Sony Interactive Entertainment Inc.
@@ -32764,6 +34681,7 @@ F8:D3:A9	AxanNetw	AXAN Networks
 F8:D4:62	Pumatron	Pumatronix Equipamentos Eletronicos Ltda.
 F8:D7:56	SimmTron	Simm Tronic Limited
 F8:D7:BF	RevRitte	REV Ritter GmbH
+F8:D9:B8	OpenMesh	Open Mesh, Inc.
 F8:DA:0C	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 F8:DA:DF	Ecotech	EcoTech, Inc.
 F8:DA:E2	BetaLase	Beta LaserMike
@@ -32772,8 +34690,10 @@ F8:DB:4C	PnyTechn	PNY Technologies, INC.
 F8:DB:7F	Htc	HTC Corporation
 F8:DB:88	Dell	Dell Inc.
 F8:DC:7A	Variscit	Variscite LTD
+F8:DF:15	SunitecE	Sunitec Enterprise Co.,Ltd
 F8:DF:A8	Zte	zte corporation
 F8:E0:79	Motorola	Motorola Mobility LLC, a Lenovo Company
+F8:E4:4E	Mcot	Mcot Inc.
 F8:E4:FB	Actionte	Actiontec Electronics, Inc
 F8:E6:1A	SamsungE	Samsung Electronics Co.,Ltd
 F8:E7:1E	RuckusWi	Ruckus Wireless
@@ -32790,6 +34710,7 @@ F8:F1:B6	Motorola	Motorola Mobility LLC, a Lenovo Company
 F8:F2:1E	IntelCor	Intel Corporate
 F8:F2:5A	G-Lab	G-Lab GmbH
 F8:F4:64	RaweElec	Rawe Electonic GmbH
+F8:F5:32	ArrisGro	ARRIS Group, Inc.
 F8:F7:D3	Internat	International Communications Corporation
 F8:F7:FF	Syn-Tech	SYN-TECH SYSTEMS INC
 F8:FB:2F	Santur	Santur Corporation
@@ -32806,13 +34727,16 @@ FA:55:6F	Symbolic	SymbolicIO
 FA:61:0E	Laborato	Laboratory for Computational Sensing and Robotics, Johns Hopkins University
 FA:63:E1	SamsungE	Samsung Electronics (UK) Ltd
 FA:94:F1	Ieee8021	IEEE 802.1 Working Group
+FA:BA:85	Private
 FA:E1:90	InWinDev	In Win Development Inc.
 FA:E5:1A	RsaeLabs	RSAE Labs Inc
+FA:EB:6E	XranOrg	xRAN.org
 FA:F9:C0	Raid	RAID Incorporated
 FC:00:12	ToshibaS	Toshiba Samsung Storage Technolgoy Korea Corporation
 FC:01:7C	HonHaiPr	Hon Hai Precision Ind. Co.,Ltd.
 FC:01:9E	Vievu
 FC:01:CD	Fundacio	Fundacion Tekniker
+FC:03:9F	SamsungE	Samsung Electronics Co.,Ltd
 FC:06:47	Cortland	Cortland Research, LLC
 FC:06:ED	M2motive	M2Motive Technology Inc.
 FC:07:A0	LreMedic	LRE Medical GmbH
@@ -32844,6 +34768,7 @@ FC:23:25	EostekSh	EosTek (Shenzhen) Co., Ltd.
 FC:25:3F	Apple	Apple, Inc.
 FC:27:A2	TransEle	Trans Electric Co., Ltd.
 FC:2A:54	Connecte	Connected Data, Inc.
+FC:2A:9C	Apple	Apple, Inc.
 FC:2D:5E	Zte	zte corporation
 FC:2E:2D	LoromInd	Lorom Industrial Co.LTD.
 FC:2F:40	Calxeda	Calxeda, Inc.
@@ -32884,18 +34809,22 @@ FC:5B:26	Mikrobit	MikroBits
 FC:5B:39	Cisco	Cisco Systems, Inc
 FC:60:18	Zhejiang	Zhejiang Kangtai Electric Co., Ltd.
 FC:61:98	NecPerso	NEC Personal Products, Ltd
+FC:61:E9	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 FC:62:6E	BeijingM	Beijing MDC Telecom
 FC:62:B9	AlpsElec	Alps Electric Co.,Ltd.
 FC:64:3A	SamsungE	Samsung Electronics Co.,Ltd
 FC:64:BA	XiaomiCo	Xiaomi Communications Co Ltd
 FC:65:DE	AmazonTe	Amazon Technologies Inc.
 FC:68:3E	Directed	Directed Perception, Inc
+FC:69:47	TexasIns	Texas Instruments
+FC:6B:F0	TopwellI	Topwell International Holdinds Limited
 FC:6C:31	Lxinstru	LXinstruments GmbH
 FC:6D:C0	Bme	Bme Corporation
 FC:6F:B7	ArrisGro	ARRIS Group, Inc.
 FC:75:16	D-LinkIn	D-Link International
 FC:75:E6	Handream	Handreamnet
 FC:79:0B	HitachiH	Hitachi High Technologies America, Inc.
+FC:7C:02	PhicommS	Phicomm (Shanghai) Co., Ltd.
 FC:7C:E7	FciUsaLl	Fci Usa Llc
 FC:7F:56	CosystCo	CoSyst Control Systems GmbH
 FC:83:29	TreiTech	Trei technics
@@ -32903,14 +34832,17 @@ FC:83:99	Avaya	Avaya Inc
 FC:83:C6	N-RadioT	N-Radio Technologies Co., Ltd.
 FC:8B:97	Shenzhen	Shenzhen Gongjin Electronics Co.,Lt
 FC:8E:7E	ArrisGro	ARRIS Group, Inc.
+FC:8F:7D	Shenzhen	Shenzhen Gongjin Electronics Co.,Lt
 FC:8F:90	SamsungE	Samsung Electronics Co.,Ltd
 FC:8F:C4	Intellig	Intelligent Technology Inc.
+FC:90:FA	Independ	Independent Technologies
 FC:91:14	Technico	Technicolor CH USA Inc.
 FC:92:3B	Nokia	Nokia Corporation
 FC:94:6C	Ubivelox
 FC:94:E3	Technico	Technicolor CH USA Inc.
 FC:99:47	Cisco	Cisco Systems, Inc
 FC:9A:FA	MotusGlo	Motus Global Inc.
+FC:9B:C6	Sumavisi	Sumavision Technologies Co.,Ltd
 FC:9D:D8	BeijingT	Beijing TongTongYiLian Science and Technology Ltd.
 FC:9F:AE	Fidus	Fidus Systems Inc
 FC:9F:E1	ConwinTe	CONWIN.Tech. Ltd
@@ -32918,19 +34850,25 @@ FC:A1:3E	SamsungE	Samsung Electronics Co.,Ltd
 FC:A1:83	AmazonTe	Amazon Technologies Inc.
 FC:A2:2A	PtCallys	PT. Callysta Multi Engineering
 FC:A3:86	Shenzhen	SHENZHEN CHUANGWEI-RGB ELECTRONICS CO.,LTD
+FC:A6:21	SamsungE	Samsung Electronics Co.,Ltd
 FC:A6:67	AmazonTe	Amazon Technologies Inc.
 FC:A6:CD	Fiberhom	Fiberhome Telecommunication Technologies Co.,LTD
 FC:A8:41	Avaya	Avaya Inc
 FC:A8:9A	SunitecE	Sunitec Enterprise Co.,Ltd
 FC:A9:B0	Miartech	MIARTECH (SHANGHAI),INC.
 FC:AA:14	Giga-Byt	GIGA-BYTE TECHNOLOGY CO.,LTD.
+FC:AA:B6	SamsungE	Samsung Electronics Co.,Ltd
 FC:AD:0F	QtsNetwo	Qts Networks
+FC:AE:34	ArrisGro	ARRIS Group, Inc.
 FC:AF:6A	Qulsar	Qulsar Inc
 FC:AF:AC	Socionex	Socionext Inc.
 FC:B0:C4	Shanghai	Shanghai DareGlobal Technologies Co.,Ltd
+FC:B1:0D	Shenzhen	Shenzhen Tian Kun Technology Co.,LTD.
 FC:B4:E6	AskeyCom	Askey Computer Corp
 FC:B5:8A	Wapice	Wapice Ltd.
 FC:B6:98	Cambridg	Cambridge Industries(Group) Co.,Ltd.
+FC:B6:D8	Apple	Apple, Inc.
+FC:B7:F0	IdahoNat	Idaho National Laboratory
 FC:BB:A1	Shenzhen	Shenzhen Minicreate Technology Co.,Ltd
 FC:BC:9C	Vimar	Vimar Spa
 FC:C2:33	Private
@@ -32960,6 +34898,7 @@ FC:E1:FB	ArrayNet	Array Networks
 FC:E2:3F	ClayPaky	Clay Paky Spa
 FC:E3:3C	HuaweiTe	Huawei Technologies Co.,Ltd
 FC:E5:57	Nokia	Nokia Corporation
+FC:E6:6A	Industri	Industrial Software Co
 FC:E8:92	Hangzhou	Hangzhou Lancable Technology Co.,Ltd
 FC:E9:98	Apple	Apple, Inc.
 FC:EC:DA	Ubiquiti	Ubiquiti Networks Inc.
@@ -32978,9 +34917,258 @@ FC:FC:48	Apple	Apple, Inc.
 FC:FE:77	HitachiR	Hitachi Reftechno, Inc.
 FC:FE:C2	Invensys	Invensys Controls UK Limited
 FC:FF:AA	IeeeRegi	IEEE Registration Authority
-
-00:1B:C5	IeeeRegi	IEEE Registration Authority
+#
+# Well-known addresses.
+#
+# Wireshark - Network traffic analyzer
+# By Gerald Combs <gerald [AT] wireshark.org>
+# Copyright 1998 Gerald Combs
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# The data below has been assembled from the following sources:
+#
+# Michael Patton's "Ethernet Codes Master Page" available from:
+# <http://www.cavebear.com/CaveBear/Ethernet/>
+# <ftp://ftp.cavebear.com/pub/Ethernet.txt>
+#
+# Microsoft Windows 2000 Server
+# Operating System
+# Network Load Balancing Technical Overview
+# White Paper
+#
+00-00-00-00-FE-21	Checkpoint-Uninitialized-Cluster-Member
+00-00-0C-07-AC/40	All-HSRP-routers
+00-00-5E-00-01/40	IETF-VRRP-VRID
+00-BF-00-00-00-00/16	MS-NLB-VirtServer
+00-E0-2B-00-00-00	Extreme-EDP
+# Extreme Encapsulation Protocol (basically EDP renamed)
+00-E0-2B-00-00-01	Extreme-EEP
+00-E0-2B-00-00-02	Extreme-ESRP-Client
+00-E0-2B-00-00-04	Extreme-EAPS
+00-E0-2B-00-00-06	Extreme-EAPS-SL
+00-E0-2B-00-00-08	Extreme-ESRP-Master
+01-00-0C-00-00/40	ISL-Frame
+01-00-0C-CC-CC-CC	CDP/VTP/DTP/PAgP/UDLD
+01-00-0C-CC-CC-CD	PVST+
+01-00-0C-CD-CD-CD	STP-UplinkFast
+01-00-0C-CD-CD-CE	VLAN-bridge
+01-00-0C-CD-CD-D0	GBPT
+01-00-0C-DD-DD-DD	CGMP
+01-00-10-00-00-20	Hughes-Lan-Systems-Terminal-Server-S/W-download
+01-00-10-FF-FF-20	Hughes-Lan-Systems-Terminal-Server-S/W-request
+01-00-1D-00-00-00	Cabletron-PC-OV-PC-discover-(on-demand)
+01-00-1D-00-00-05	Cabletron-PVST-BPDU
+01-00-1D-00-00-06	Cabletron-QCSTP-BPDU
+01-00-1D-42-00-00	Cabletron-PC-OV-Bridge-discover-(on-demand)
+01-00-1D-52-00-00	Cabletron-PC-OV-MMAC-discover-(on-demand)
+01-00-3C		Auspex-Systems-(Serverguard)
+01-00-5E/25		IPv4mcast
+01-00-81-00-00-00	Nortel-Network-Management
+01-00-81-00-00-02	Nortel-Network-Management
+01-00-81-00-01-00	Nortel-autodiscovery
+01-00-81-00-01-01	Nortel-autodiscovery
+# Cisco Fabric Path
+01-0F-FF-C1-01-C0	FP-Flood-to-all-VLANs
+01-0F-FF-C1-02-C0	FP-Flood-to-all-Fabrics
+#
+# As per
+#
+#	http://www.t11.org/ftp/t11/pub/fc/bb-5/08-334v0.pdf
+#
+# Broadcom "donated" one of their OUIs, 00-10-18, for use for
+# Fibre Channel over Ethernet, so we add entries for the
+# addresses in that document and a group of addresses for all
+# otherwise unlisted 01-10-18-XX-XX-XX addresses.
+#
+01-10-18-01-00-00	All-FCoE-MACs
+01-10-18-01-00-01	All-ENode-MACs
+01-10-18-01-00-02	All-FCF-MACs
+01-10-18-00-00-00/24	FCoE-group
+01-11-1E-00-00-01	EPLv2_SoC
+01-11-1E-00-00-02	EPLv2_PRes
+01-11-1E-00-00-03	EPLv2_SoA
+01-11-1E-00-00-04	EPLv2_ASnd
+01-11-1E-00-00-05	EPLv2_AMNI
+01-20-25/25		Control-Technology-Inc's-Industrial-Ctrl-Proto.
+01-80-24-00-00-00	Kalpana-Etherswitch-every-60-seconds
+01-80-C2-00-00-00/44	Spanning-tree-(for-bridges)
+01-80-C2-00-00-02	Slow-Protocols
+01-80-C2-00-00-03	Nearest customer bridge
+01-80-C2-00-00-0E	LLDP_Multicast
+01-80-C2-00-00-0F	Nearest non-TPMR bridge
+01-80-C2-00-00-10	Bridge-Management
+01-80-C2-00-00-11	Load-Server
+01-80-C2-00-00-12	Loadable-Device
+01-80-C2-00-00-13	IEEE-1905.1-Control
+01-80-C2-00-00-14	ISIS-all-level-1-IS's
+01-80-C2-00-00-15	ISIS-all-level-2-IS's
+01-80-C2-00-00-18	IEEE-802.1B-All-Manager-Stations
+01-80-C2-00-00-19	IEEE-802.11aa-groupcast-with-retries
+01-80-C2-00-00-1A	IEEE-802.1B-All-Agent-Stations
+01-80-C2-00-00-1B	ESIS-all-multicast-capable-ES's
+01-80-C2-00-00-1C	ESIS-all-multicast-announcements
+01-80-C2-00-00-1D	ESIS-all-multicast-capable-IS's
+01-80-C2-00-00-1E	Token-Ring-all-DTR-Concentrators
 01-80-C2-00-00-30/45	OAM-Multicast-DA-Class-1
 01-80-C2-00-00-38/45	OAM-Multicast-DA-Class-2
 01-80-C2-00-00-40	All-RBridges
-01-80-C2-00-00-1E	Token-Ring-all-DTR-Concentrators
+01-80-C2-00-00-41	All-IS-IS-RBridges
+01-80-C2-00-00-42	All-Egress-RBridges
+01-80-C2-00-00-45	TRILL-End-Stations
+01-80-C2-00-00-46	All-Edge-RBridges
+01-80-C2-00-01-00	FDDI-RMT-Directed-Beacon
+01-80-C2-00-01-10	FDDI-status-report-frame
+01-DD-00-FF-FF-FF	Ungermann-Bass-boot-me-requests
+01-DD-01-00-00-00	Ungermann-Bass-Spanning-Tree
+01-E0-52-CC-CC-CC	Foundry-DP
+# DOCSIS, defined in ANSI SCTE 22-1 2012
+01-E0-2F-00-00-01	DOCSIS-CM
+01-E0-2F-00-00-02	DOCSIS-CMTS
+01-E0-2F-00-00-03	DOCSIS-STP
+
+# Extremenetworks in their infinite wisdom seems to use 02-04-94 (Vendor MAC XOR 02-00-00)
+# for their base mac address, thus colliding with MS-NLB 02-04/16 which Microsoft in their
+# infinite wisdom decided to use for MS-NLB.
+02-04-96-00-00-00/24	ExtremeNetworks
+
+# Microsoft Network Load Balancing (NLB)
+# Actually, 02-01-virtualip to 02-20-virtualip will be used from server to rest-of-world
+# 02-bf-virtualip will be used from rest-of-world to server
+02-BF-00-00-00-00/16	MS-NLB-VirtServer
+02-01-00-00-00-00/16	MS-NLB-PhysServer-01
+02-02-00-00-00-00/16	MS-NLB-PhysServer-02
+02-03-00-00-00-00/16	MS-NLB-PhysServer-03
+02-04-00-00-00-00/16	MS-NLB-PhysServer-04
+02-05-00-00-00-00/16	MS-NLB-PhysServer-05
+02-06-00-00-00-00/16	MS-NLB-PhysServer-06
+02-07-00-00-00-00/16	MS-NLB-PhysServer-07
+02-08-00-00-00-00/16	MS-NLB-PhysServer-08
+02-09-00-00-00-00/16	MS-NLB-PhysServer-09
+02-0a-00-00-00-00/16	MS-NLB-PhysServer-10
+02-0b-00-00-00-00/16	MS-NLB-PhysServer-11
+02-0c-00-00-00-00/16	MS-NLB-PhysServer-12
+02-0d-00-00-00-00/16	MS-NLB-PhysServer-13
+02-0e-00-00-00-00/16	MS-NLB-PhysServer-14
+02-0f-00-00-00-00/16	MS-NLB-PhysServer-15
+02-10-00-00-00-00/16	MS-NLB-PhysServer-16
+02-11-00-00-00-00/16	MS-NLB-PhysServer-17
+02-12-00-00-00-00/16	MS-NLB-PhysServer-18
+02-13-00-00-00-00/16	MS-NLB-PhysServer-19
+02-14-00-00-00-00/16	MS-NLB-PhysServer-20
+02-15-00-00-00-00/16	MS-NLB-PhysServer-21
+02-16-00-00-00-00/16	MS-NLB-PhysServer-22
+02-17-00-00-00-00/16	MS-NLB-PhysServer-23
+02-18-00-00-00-00/16	MS-NLB-PhysServer-24
+02-19-00-00-00-00/16	MS-NLB-PhysServer-25
+02-1a-00-00-00-00/16	MS-NLB-PhysServer-26
+02-1b-00-00-00-00/16	MS-NLB-PhysServer-27
+02-1c-00-00-00-00/16	MS-NLB-PhysServer-28
+02-1d-00-00-00-00/16	MS-NLB-PhysServer-29
+02-1e-00-00-00-00/16	MS-NLB-PhysServer-30
+02-1f-00-00-00-00/16	MS-NLB-PhysServer-31
+02-20-00-00-00-00/16	MS-NLB-PhysServer-32
+
+#       [ The following block of addresses (03-...) are used by various ]
+#       [ standards.  Some (marked [TR?]) are suspected of only being   ]
+#       [ used on Token Ring for group addresses of Token Ring specific ]
+#       [ functions, reference ISO 8802-5:1995 aka. IEEE 802.5:1995 for ]
+#       [ some info.  These in the Ethernet order for this list.  On    ]
+#       [ Token Ring they appear reversed.  They should never appear on ]
+#       [ Ethernet.  Others, not so marked, are normal reports (may be  ]
+#       [ seen on either).
+03-00-00-00-00-01	NETBIOS-# [TR?]
+03-00-00-00-00-02	Locate-Directory-Server # [TR?]
+03-00-00-00-00-04	Synchronous-Bandwidth-Manager-# [TR?]
+03-00-00-00-00-08	Configuration-Report-Server-# [TR?]
+03-00-00-00-00-10	Ring-Error-Monitor-# [TR?]
+03-00-00-00-00-10	(OS/2-1.3-EE+Communications-Manager)
+03-00-00-00-00-20	Network-Server-Heartbeat-# [TR?]
+03-00-00-00-00-40	(OS/2-1.3-EE+Communications-Manager)
+03-00-00-00-00-80	Active-Monitor # [TR?]
+03-00-00-00-01-00	OSI-All-IS-Token-Ring-Multicast
+03-00-00-00-02-00	OSI-All-ES-Token-Ring-Multicast
+03-00-00-00-04-00	LAN-Manager # [TR?]
+03-00-00-00-08-00	Ring-Wiring-Concentrator # [TR?]
+03-00-00-00-10-00	LAN-Gateway # [TR?]
+03-00-00-00-20-00	Ring-Authorization-Server # [TR?]
+03-00-00-00-40-00	IMPL-Server # [TR?]
+03-00-00-00-80-00	Bridge # [TR?]
+03-00-00-20-00-00	IP-Token-Ring-Multicast (RFC1469)
+03-00-00-80-00-00	Discovery-Client
+03-00-0C-00-00/40	ISL-Frame [TR?]
+03-00-C7-00-00-EE	HP (Compaq) ProLiant NIC teaming
+03-00-FF-FF-FF-FF	All-Stations-Address
+03-BF-00-00-00-00/16	MS-NLB-VirtServer-Multicast
+09-00-07-00-00-00/40	AppleTalk-Zone-multicast-addresses
+			# only goes through 09-00-07-00-00-FC?
+09-00-07-FF-FF-FF	AppleTalk-broadcast-address
+09-00-09-00-00-01	HP-Probe
+09-00-09-00-00-04	HP-DTC
+09-00-0D-00-00-00/24	ICL-Oslan-Multicast
+09-00-0D-02-00-00	ICL-Oslan-Service-discover-only-on-boot
+09-00-0D-02-0A-38	ICL-Oslan-Service-discover-only-on-boot
+09-00-0D-02-0A-39	ICL-Oslan-Service-discover-only-on-boot
+09-00-0D-02-0A-3C	ICL-Oslan-Service-discover-only-on-boot
+09-00-0D-02-FF-FF	ICL-Oslan-Service-discover-only-on-boot
+09-00-0D-09-00-00	ICL-Oslan-Service-discover-as-required
+09-00-1E-00-00-00	Apollo-DOMAIN
+09-00-2B-00-00-00	DEC-MUMPS?
+09-00-2B-00-00-01	DEC-DSM/DDP
+09-00-2B-00-00-02	DEC-VAXELN?
+09-00-2B-00-00-03	DEC-Lanbridge-Traffic-Monitor-(LTM)
+09-00-2B-00-00-04	DEC-MAP-(or-OSI?)-End-System-Hello?
+09-00-2B-00-00-05	DEC-MAP-(or-OSI?)-Intermediate-System-Hello?
+09-00-2B-00-00-06	DEC-CSMA/CD-Encryption?
+09-00-2B-00-00-07	DEC-NetBios-Emulator?
+09-00-2B-00-00-0F	DEC-Local-Area-Transport-(LAT)
+09-00-2B-00-00-10/44	DEC-Experimental
+09-00-2B-01-00-00	DEC-LanBridge-Copy-packets-(All-bridges)
+09-00-2B-01-00-01	DEC-LanBridge-Hello-packets-(All-local-bridges)
+09-00-2B-02-00-00	DEC-DNA-Level-2-Routing-Layer-routers?
+09-00-2B-02-01-00	DEC-DNA-Naming-Service-Advertisement?
+09-00-2B-02-01-01	DEC-DNA-Naming-Service-Solicitation?
+09-00-2B-02-01-09	DEC-Availability-Manager-for-Distributed-Systems-DECamds
+09-00-2B-02-01-02	DEC-Distributed-Time-Service
+09-00-2B-03-00-00/32	DEC-default-filtering-by-bridges?
+09-00-2B-04-00-00	DEC-Local-Area-System-Transport-(LAST)?
+09-00-2B-23-00-00	DEC-Argonaut-Console?
+09-00-4C-00-00-00	BICC-802.1-management
+09-00-4C-00-00-02	BICC-802.1-management
+09-00-4C-00-00-06	BICC-Local-bridge-STA-802.1(D)-Rev6
+09-00-4C-00-00-0C	BICC-Remote-bridge-STA-802.1(D)-Rev8
+09-00-4C-00-00-0F	BICC-Remote-bridge-ADAPTIVE-ROUTING
+09-00-56-FF-00-00/32	Stanford-V-Kernel,-version-6.0
+09-00-6A-00-01-00	TOP-NetBIOS.
+09-00-77-00-00-00	Retix-Bridge-Local-Management-System
+09-00-77-00-00-01	Retix-spanning-tree-bridges
+09-00-77-00-00-02	Retix-Bridge-Adaptive-routing
+09-00-7C-01-00-01	Vitalink-DLS-Multicast
+09-00-7C-01-00-03	Vitalink-DLS-Inlink
+09-00-7C-01-00-04	Vitalink-DLS-and-non-DLS-Multicast
+09-00-7C-02-00-05	Vitalink-diagnostics
+09-00-7C-05-00-01	Vitalink-gateway?
+09-00-7C-05-00-02	Vitalink-Network-Validation-Message
+09-00-87-80-FF-FF	Xyplex-Terminal-Servers
+09-00-87-90-FF-FF	Xyplex-Terminal-Servers
+0C-00-0C-00-00/40	ISL-Frame
+0D-1E-15-BA-DD-06	HP
+20-52-45-43-56-00/40	Receive
+20-53-45-4E-44-00/40	Send
+33-33-00-00-00-00	IPv6-Neighbor-Discovery
+33-33-00-00-00-00/16	IPv6mcast
+AA-00-03-00-00-00/32	DEC-UNA
+AA-00-03-01-00-00/32	DEC-PROM-AA
+AA-00-03-03-00-00/32	DEC-NI20
+AB-00-00-01-00-00	DEC-MOP-Dump/Load-Assistance
+AB-00-00-02-00-00	DEC-MOP-Remote-Console
+AB-00-00-03-00-00	DECNET-Phase-IV-end-node-Hello-packets
+AB-00-00-04-00-00	DECNET-Phase-IV-Router-Hello-packets
+AB-00-03-00-00-00	DEC-Local-Area-Transport-(LAT)-old
+AB-00-04-01-00-00/32	DEC-Local-Area-VAX-Cluster-groups-SCA
+CF-00-00-00-00-00	Ethernet-Configuration-Test-protocol-(Loopback)
+FF-FF-00-60-00-04	Lantastic
+FF-FF-00-40-00-01	Lantastic
+FF-FF-01-E0-00-04	Lantastic
+
+FF-FF-FF-FF-FF-FF	Broadcast

--- a/manuf/manuf.py
+++ b/manuf/manuf.py
@@ -60,7 +60,7 @@ class MacParser(object):
 
     """
     MANUF_URL = "https://code.wireshark.org/review/gitweb?p=wireshark.git;a=blob_plain;f=manuf"
-    WFA_URL = "https://code.wireshark.org/review/gitweb?p=wireshark.git;a=blob_plain;f=wka"                                                                                           
+    WFA_URL = "https://code.wireshark.org/review/gitweb?p=wireshark.git;a=blob_plain;f=wka"
 
     def  __init__(self, manuf_name=None, update=False):
         self._manuf_name = manuf_name or self.get_packaged_manuf_file_path()
@@ -156,7 +156,7 @@ class MacParser(object):
         response.close()
         if not wfa_url:
             wfa_url = self.WFA_URL
-            
+
         # Append WFA to new database
         try:
             response = urlopen(wfa_url)
@@ -173,7 +173,7 @@ class MacParser(object):
             err = "{0} {1}".format(response.code, response.msg)
             raise URLError("Failed downloading database: {0}".format(err))
 
-        response.close()                       
+        response.close()
 
     def search(self, mac, maximum=1):
         """Search for multiple Vendor tuples possibly matching a MAC address.
@@ -295,7 +295,10 @@ class MacParser(object):
         returns the path to manuf file bundled with the package.
         :return:
         """
-        package_init_path = importlib.import_module(__package__).__file__
+        if __package__ is None or __package__ == "":
+            package_init_path = __file__
+        else:
+            package_init_path = importlib.import_module(__package__).__file__
         package_path = os.path.abspath(os.path.join(package_init_path, os.pardir))
         manuf_file_path = os.path.join(package_path, 'manuf')
         return manuf_file_path


### PR DESCRIPTION
Hi,

When the script is run (without importing manuf.py), the builtin __package__ is None or "". Thus the function MacParser.get_packaged_manuf_file_path() fails.
So I have added a test to use __file__ as the path of the script instead.

The PR also includes a database refresh and Python 3.6 (apparently, travis is not ready for 3.7 yet).

Regards,

